### PR TITLE
feat: add web search mod package

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ mods/         # mod implementation files declared by package.json#letta
 - [`packages/plan-mode`](./packages/plan-mode) - sample plan-mode workflow using commands, tools, turn reminders, permissions, and local state
 - [`packages/goal-mode`](./packages/goal-mode) - goal workflow using commands, tools, turn reminders, and local state
 - [`packages/analysis-mode`](./packages/analysis-mode) - phrase-triggered diagnostic mode using turn reminders and local state
+- [`packages/web-search`](./packages/web-search) - Tavily-backed web search tool using agent-scoped secrets
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mods/         # mod implementation files declared by package.json#letta
 - [`packages/plan-mode`](./packages/plan-mode) - sample plan-mode workflow using commands, tools, turn reminders, permissions, and local state
 - [`packages/goal-mode`](./packages/goal-mode) - goal workflow using commands, tools, turn reminders, and local state
 - [`packages/analysis-mode`](./packages/analysis-mode) - phrase-triggered diagnostic mode using turn reminders and local state
-- [`packages/web-search`](./packages/web-search) - Tavily-backed web search tool using agent-scoped secrets
+- [`packages/web-search`](./packages/web-search) - provider-backed web search tools using agent-scoped secrets
 
 ## Safety
 

--- a/packages/web-search/MOD.md
+++ b/packages/web-search/MOD.md
@@ -1,6 +1,6 @@
 ---
 name: "@letta-ai/web-search"
-description: "Tavily-backed web search tool using Letta Code agent-scoped secrets."
+description: "Provider-backed web_search tool using Letta Code agent-scoped secrets."
 ---
 
 # Web search mod semantics
@@ -13,38 +13,48 @@ Use this package when an agent needs live web search, current facts, source disc
 
 This package registers one tool:
 
-- `web_search` - searches the live web with Tavily and returns a concise answer plus ranked source results.
+- `web_search` - searches the live web using the first configured provider key, or an explicitly selected provider.
 
 ## Secret behavior
 
-The tool reads `TAVILY_API_KEY` at invocation time with:
+The tool reads provider keys at invocation time with:
 
 ```ts
-await ctx.secret("TAVILY_API_KEY", { envFallback: true })
+await ctx.secret("PROVIDER_API_KEY", { envFallback: true })
 ```
 
-Resolution order:
+Supported keys:
+
+- `EXA_API_KEY`
+- `TAVILY_API_KEY`
+- `PARALLEL_API_KEY`
+- `PERPLEXITY_API_KEY`
+
+Resolution order for each key:
 
 1. agent-scoped `/secret` store
-2. `process.env.TAVILY_API_KEY`
+2. matching `process.env` variable
 
-If neither source is configured, the tool returns a normal error result with instructions to run:
-
-```text
-/secret set TAVILY_API_KEY <value>
-```
+Auto provider selection checks keys in this order: Exa, Tavily, Parallel, Perplexity. If no provider key is configured, the tool returns a normal error result with instructions to run `/secret set ... <value>`.
 
 Do not hardcode API keys or import private Letta Code secret internals.
+
+## Provider guidance
+
+- Use `provider: "exa"` for ranked source discovery, research, companies, news, pages, and results with text/highlights.
+- Use `provider: "tavily"` for concise web answers plus ranked source results.
+- Use `provider: "perplexity"` for concise web-grounded answers with citations.
+- Use `provider: "parallel"` for LLM-optimized excerpts from targeted queries.
+- Use `provider: "auto"` when any configured provider is acceptable.
 
 ## Behavior
 
 - The tool is a read-only network call and is marked `parallelSafe: true`.
-- Queries are sent to Tavily.
+- Queries are sent to the selected third-party provider.
 - The package uses `fetch`; it has no provider SDK dependencies.
 - The tool should return setup/API errors as tool error results, not throw for expected missing configuration.
 
 ## Adaptation notes for agents
 
-- Keep the public tool name generic (`web_search`) unless adding additional provider-specific tools.
 - Keep secret access inside tool invocation context only.
 - If the user wants approval before network calls, set `requiresApproval: true` in the tool registration.

--- a/packages/web-search/MOD.md
+++ b/packages/web-search/MOD.md
@@ -1,0 +1,50 @@
+---
+name: "@letta-ai/web-search"
+description: "Tavily-backed web search tool using Letta Code agent-scoped secrets."
+---
+
+# Web search mod semantics
+
+## When to use
+
+Use this package when an agent needs live web search, current facts, source discovery, news, research papers, company pages, or web-grounded answers.
+
+## Tool
+
+This package registers one tool:
+
+- `web_search` - searches the live web with Tavily and returns a concise answer plus ranked source results.
+
+## Secret behavior
+
+The tool reads `TAVILY_API_KEY` at invocation time with:
+
+```ts
+await ctx.secret("TAVILY_API_KEY", { envFallback: true })
+```
+
+Resolution order:
+
+1. agent-scoped `/secret` store
+2. `process.env.TAVILY_API_KEY`
+
+If neither source is configured, the tool returns a normal error result with instructions to run:
+
+```text
+/secret set TAVILY_API_KEY <value>
+```
+
+Do not hardcode API keys or import private Letta Code secret internals.
+
+## Behavior
+
+- The tool is a read-only network call and is marked `parallelSafe: true`.
+- Queries are sent to Tavily.
+- The package uses `fetch`; it has no provider SDK dependencies.
+- The tool should return setup/API errors as tool error results, not throw for expected missing configuration.
+
+## Adaptation notes for agents
+
+- Keep the public tool name generic (`web_search`) unless adding additional provider-specific tools.
+- Keep secret access inside tool invocation context only.
+- If the user wants approval before network calls, set `requiresApproval: true` in the tool registration.

--- a/packages/web-search/README.md
+++ b/packages/web-search/README.md
@@ -1,13 +1,13 @@
 # Web Search
 
-A Letta Code mod package that adds a Tavily-backed `web_search` tool.
+A Letta Code mod package that adds a provider-backed `web_search` tool.
 
-The tool reads `TAVILY_API_KEY` through Letta Code's agent-scoped secret API, with process environment fallback for local development. This means it works with `/secret set TAVILY_API_KEY <value>` and does not require hardcoding API keys in the mod.
+The tool reads API keys through Letta Code's agent-scoped secret API, with process environment fallback for local development. This means it works with `/secret set ... <value>` and does not require hardcoding API keys in the mod.
 
 ## Requirements
 
 - Letta Code `>=0.27.16`
-- A Tavily API key
+- At least one provider API key
 
 ## Install
 
@@ -22,27 +22,40 @@ Run `/reload` in active sessions after installing.
 Recommended, agent-scoped:
 
 ```text
+/secret set EXA_API_KEY <value>
 /secret set TAVILY_API_KEY <value>
+/secret set PARALLEL_API_KEY <value>
+/secret set PERPLEXITY_API_KEY <value>
 ```
 
-Environment fallback is also supported if the key is present when Letta Code starts:
+Environment fallback is also supported if keys are present when Letta Code starts:
 
 ```bash
+export EXA_API_KEY=...
 export TAVILY_API_KEY=...
+export PARALLEL_API_KEY=...
+export PERPLEXITY_API_KEY=...
 letta
 ```
 
-If neither source is configured, the tool returns a setup error telling the agent/user how to add the key.
+You only need to configure the providers you want to use. If no provider is configured, the tool returns a setup error telling the agent/user how to add a key.
 
 ## Tool
 
-- `web_search` searches the live web with Tavily and returns a concise answer plus ranked source results.
+- `web_search` searches the live web using the first configured provider key, or an explicitly selected provider.
 
-Supported options include search depth, topic, max result count, domain include/exclude filters, and whether to include Tavily's generated answer or raw source content.
+Provider selection defaults to `auto`, which checks keys in this order:
+
+1. `EXA_API_KEY`
+2. `TAVILY_API_KEY`
+3. `PARALLEL_API_KEY`
+4. `PERPLEXITY_API_KEY`
+
+Pass `provider: "exa" | "tavily" | "parallel" | "perplexity"` to force a provider.
 
 ## Privacy
 
-Search queries are sent to Tavily. Review Tavily's terms and avoid sending sensitive data unless appropriate.
+Search queries are sent to the selected third-party provider. Review provider terms and avoid sending sensitive data unless appropriate.
 
 ## Safety
 

--- a/packages/web-search/README.md
+++ b/packages/web-search/README.md
@@ -1,0 +1,59 @@
+# Web Search
+
+A Letta Code mod package that adds a Tavily-backed `web_search` tool.
+
+The tool reads `TAVILY_API_KEY` through Letta Code's agent-scoped secret API, with process environment fallback for local development. This means it works with `/secret set TAVILY_API_KEY <value>` and does not require hardcoding API keys in the mod.
+
+## Requirements
+
+- Letta Code `>=0.27.16`
+- A Tavily API key
+
+## Install
+
+```bash
+letta install npm:@letta-ai/web-search
+```
+
+Run `/reload` in active sessions after installing.
+
+## Configure
+
+Recommended, agent-scoped:
+
+```text
+/secret set TAVILY_API_KEY <value>
+```
+
+Environment fallback is also supported if the key is present when Letta Code starts:
+
+```bash
+export TAVILY_API_KEY=...
+letta
+```
+
+If neither source is configured, the tool returns a setup error telling the agent/user how to add the key.
+
+## Tool
+
+- `web_search` searches the live web with Tavily and returns a concise answer plus ranked source results.
+
+Supported options include search depth, topic, max result count, domain include/exclude filters, and whether to include Tavily's generated answer or raw source content.
+
+## Privacy
+
+Search queries are sent to Tavily. Review Tavily's terms and avoid sending sensitive data unless appropriate.
+
+## Safety
+
+Mods are trusted local code. Review the source before installing third-party mods.
+
+If a mod breaks startup or command handling, recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/web-search/mods/index.ts
+++ b/packages/web-search/mods/index.ts
@@ -1,0 +1,192 @@
+const TAVILY_API_URL = "https://api.tavily.com/search";
+const TAVILY_API_KEY = "TAVILY_API_KEY";
+
+function stringArg(value, fallback = "") {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+function booleanArg(value, fallback) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function stringArrayArg(value) {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => stringArg(item)).filter(Boolean);
+}
+
+function clampInteger(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+}
+
+function pickEnum(value, allowed, fallback) {
+  return allowed.includes(value) ? value : fallback;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  if (!text) return "";
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function missingTavilyKey() {
+  return {
+    status: "error",
+    content:
+      "Web search is not configured. Use /secret set TAVILY_API_KEY <value> to configure Tavily securely, or start Letta Code with TAVILY_API_KEY set in the process environment.",
+  };
+}
+
+function formatResult(result, index, includeRawContent) {
+  const title = stringArg(result?.title, "Untitled");
+  const url = stringArg(result?.url);
+  const publishedDate = stringArg(result?.published_date);
+  const score = typeof result?.score === "number" ? result.score.toFixed(3) : "";
+  const content = stringArg(result?.content);
+  const rawContent = includeRawContent ? stringArg(result?.raw_content) : "";
+
+  return [
+    `### ${index + 1}. ${title}`,
+    url,
+    publishedDate ? `Published: ${publishedDate}` : "",
+    score ? `Score: ${score}` : "",
+    content ? `Snippet:\n${content.slice(0, 1600)}` : "",
+    rawContent ? `Raw content:\n${rawContent.slice(0, 2400)}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatTavilyResponse(data, includeRawContent) {
+  const answer = stringArg(data?.answer);
+  const results = Array.isArray(data?.results) ? data.results : [];
+  const sections = [];
+
+  if (answer) {
+    sections.push(["## Tavily answer", answer].join("\n"));
+  }
+
+  if (results.length > 0) {
+    sections.push(
+      [
+        "## Sources",
+        ...results.map((result, index) =>
+          formatResult(result, index, includeRawContent),
+        ),
+      ].join("\n\n"),
+    );
+  }
+
+  return sections.length > 0 ? sections.join("\n\n") : "No Tavily results.";
+}
+
+function buildSearchBody(args) {
+  const body = {
+    query: stringArg(args.query),
+    search_depth: pickEnum(args.search_depth, ["basic", "advanced"], "basic"),
+    topic: pickEnum(args.topic, ["general", "news", "finance"], "general"),
+    max_results: clampInteger(args.max_results, 5, 1, 10),
+    include_answer: booleanArg(args.include_answer, true),
+    include_raw_content: booleanArg(args.include_raw_content, false),
+    include_images: false,
+    include_image_descriptions: false,
+  };
+
+  const includeDomains = stringArrayArg(args.include_domains);
+  if (includeDomains.length > 0) body.include_domains = includeDomains;
+
+  const excludeDomains = stringArrayArg(args.exclude_domains);
+  if (excludeDomains.length > 0) body.exclude_domains = excludeDomains;
+
+  return body;
+}
+
+export default function activate(letta) {
+  if (!letta.capabilities.tools) return;
+
+  return letta.tools.register({
+    name: "web_search",
+    description:
+      "Search the live web with Tavily and return a concise answer plus ranked source results. Use for current facts, source discovery, news, research papers, companies, or web pages.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The web-search query or research question.",
+        },
+        search_depth: {
+          type: "string",
+          enum: ["basic", "advanced"],
+          description:
+            "Search depth. basic is lower latency; advanced is deeper. Defaults to basic.",
+        },
+        topic: {
+          type: "string",
+          enum: ["general", "news", "finance"],
+          description: "Search topic. Defaults to general.",
+        },
+        max_results: {
+          type: "number",
+          description: "Number of source results to return, 1-10. Defaults to 5.",
+        },
+        include_answer: {
+          type: "boolean",
+          description: "Whether Tavily should include a generated answer. Defaults to true.",
+        },
+        include_raw_content: {
+          type: "boolean",
+          description:
+            "Whether to include raw source content snippets when available. Defaults to false.",
+        },
+        include_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to restrict results to.",
+        },
+        exclude_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to exclude from results.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx) {
+      const apiKey = await ctx.secret(TAVILY_API_KEY, { envFallback: true });
+      if (!apiKey) return missingTavilyKey();
+
+      const body = buildSearchBody(ctx.args);
+      if (!body.query) return { status: "error", content: "query is required" };
+
+      const response = await fetch(TAVILY_API_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: ctx.signal,
+      });
+
+      if (!response.ok) {
+        const detail = await readResponseBody(response);
+        return {
+          status: "error",
+          content: `Tavily API error ${response.status}: ${detail.slice(0, 2000)}`,
+        };
+      }
+
+      const data = await response.json();
+      return formatTavilyResponse(data, body.include_raw_content);
+    },
+  });
+}

--- a/packages/web-search/mods/index.ts
+++ b/packages/web-search/mods/index.ts
@@ -1,5 +1,14 @@
+const EXA_API_URL = "https://api.exa.ai/search";
 const TAVILY_API_URL = "https://api.tavily.com/search";
-const TAVILY_API_KEY = "TAVILY_API_KEY";
+const PERPLEXITY_API_URL = "https://api.perplexity.ai/v1/sonar";
+const PARALLEL_SEARCH_API_URL = "https://api.parallel.ai/v1/search";
+
+const PROVIDERS = [
+  { id: "exa", key: "EXA_API_KEY", label: "Exa" },
+  { id: "tavily", key: "TAVILY_API_KEY", label: "Tavily" },
+  { id: "parallel", key: "PARALLEL_API_KEY", label: "Parallel" },
+  { id: "perplexity", key: "PERPLEXITY_API_KEY", label: "Perplexity" },
+];
 
 function stringArg(value, fallback = "") {
   return typeof value === "string" ? value.trim() : fallback;
@@ -34,15 +43,72 @@ async function readResponseBody(response) {
   }
 }
 
-function missingTavilyKey() {
+function missingProviderKey(provider) {
   return {
     status: "error",
-    content:
-      "Web search is not configured. Use /secret set TAVILY_API_KEY <value> to configure Tavily securely, or start Letta Code with TAVILY_API_KEY set in the process environment.",
+    content: `${provider.label} web search is not configured. Use /secret set ${provider.key} <value> to configure it securely, or start Letta Code with ${provider.key} set in the process environment.`,
   };
 }
 
-function formatResult(result, index, includeRawContent) {
+function missingAllProviderKeys() {
+  return {
+    status: "error",
+    content: [
+      "Web search is not configured. Set at least one provider key:",
+      ...PROVIDERS.map((provider) => `- /secret set ${provider.key} <value>`),
+      "Environment fallback is also supported for the same key names.",
+    ].join("\n"),
+  };
+}
+
+async function selectProvider(ctx) {
+  const requested = pickEnum(
+    ctx.args.provider,
+    ["auto", ...PROVIDERS.map((provider) => provider.id)],
+    "auto",
+  );
+
+  if (requested !== "auto") {
+    const provider = PROVIDERS.find((candidate) => candidate.id === requested);
+    const apiKey = await ctx.secret(provider.key, { envFallback: true });
+    return apiKey ? { apiKey, provider } : { error: missingProviderKey(provider) };
+  }
+
+  for (const provider of PROVIDERS) {
+    const apiKey = await ctx.secret(provider.key, { envFallback: true });
+    if (apiKey) return { apiKey, provider };
+  }
+
+  return { error: missingAllProviderKeys() };
+}
+
+function formatExaResult(result, index) {
+  const title = stringArg(result?.title, "Untitled");
+  const url = stringArg(result?.url);
+  const date = stringArg(result?.publishedDate);
+  const author = stringArg(result?.author);
+  const text = stringArg(result?.text);
+  const highlights = Array.isArray(result?.highlights)
+    ? result.highlights.map((item) => stringArg(item)).filter(Boolean)
+    : [];
+  const summary = stringArg(result?.summary);
+
+  return [
+    `### ${index + 1}. ${title}`,
+    url,
+    date ? `Published: ${date}` : "",
+    author ? `Author: ${author}` : "",
+    summary ? `Summary: ${summary}` : "",
+    highlights.length
+      ? `Highlights:\n${highlights.map((item) => `- ${item}`).join("\n")}`
+      : "",
+    text ? `Text:\n${text.slice(0, 1600)}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatTavilyResult(result, index, includeRawContent) {
   const title = stringArg(result?.title, "Untitled");
   const url = stringArg(result?.url);
   const publishedDate = stringArg(result?.published_date);
@@ -62,21 +128,152 @@ function formatResult(result, index, includeRawContent) {
     .join("\n");
 }
 
-function formatTavilyResponse(data, includeRawContent) {
+function formatPerplexitySearchResults(results) {
+  if (!Array.isArray(results) || results.length === 0) return "";
+
+  return [
+    "## Search results",
+    ...results.map((result, index) => {
+      const title = stringArg(result?.title, "Untitled");
+      const url = stringArg(result?.url);
+      const date = stringArg(result?.date) || stringArg(result?.last_updated);
+      const snippet = stringArg(result?.snippet);
+      return [
+        `### ${index + 1}. ${title}`,
+        url,
+        date ? `Date: ${date}` : "",
+        snippet,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }),
+  ].join("\n\n");
+}
+
+function formatParallelResult(result, index) {
+  const title = stringArg(result?.title, "Untitled");
+  const url = stringArg(result?.url);
+  const publishDate = stringArg(result?.publish_date);
+  const excerpts = Array.isArray(result?.excerpts)
+    ? result.excerpts.map((item) => stringArg(item)).filter(Boolean)
+    : [];
+
+  return [
+    `### ${index + 1}. ${title}`,
+    url,
+    publishDate ? `Published: ${publishDate}` : "",
+    excerpts.length ? excerpts.map((excerpt) => `- ${excerpt}`).join("\n") : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+async function runExaSearch(ctx, apiKey, query) {
+  const body = {
+    query,
+    type: pickEnum(
+      ctx.args.exa_type ?? ctx.args.search_type,
+      ["auto", "instant", "fast", "deep-lite", "deep"],
+      "auto",
+    ),
+    numResults: clampInteger(ctx.args.max_results ?? ctx.args.num_results, 5, 1, 10),
+    contents: {
+      text: { maxCharacters: 1600 },
+      highlights: true,
+      summary: { query: "Main relevant facts for the user's question" },
+    },
+    moderation: true,
+  };
+
+  const category = pickEnum(
+    ctx.args.category,
+    ["company", "research paper", "news", "personal site", "financial report", "people"],
+    "",
+  );
+  if (category) body.category = category;
+
+  const includeDomains = stringArrayArg(ctx.args.include_domains);
+  if (includeDomains.length > 0) body.includeDomains = includeDomains;
+
+  const excludeDomains = stringArrayArg(ctx.args.exclude_domains);
+  if (excludeDomains.length > 0) body.excludeDomains = excludeDomains;
+
+  const startPublishedDate = stringArg(ctx.args.start_published_date);
+  if (startPublishedDate) body.startPublishedDate = startPublishedDate;
+
+  const endPublishedDate = stringArg(ctx.args.end_published_date);
+  if (endPublishedDate) body.endPublishedDate = endPublishedDate;
+
+  const response = await fetch(EXA_API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body: JSON.stringify(body),
+    signal: ctx.signal,
+  });
+
+  if (!response.ok) {
+    const detail = await readResponseBody(response);
+    return {
+      status: "error",
+      content: `Exa API error ${response.status}: ${detail.slice(0, 2000)}`,
+    };
+  }
+
+  const data = await response.json();
+  const results = Array.isArray(data?.results) ? data.results : [];
+  if (results.length === 0) return "No Exa results.";
+
+  return ["## Exa results", ...results.map(formatExaResult)].join("\n\n");
+}
+
+async function runTavilySearch(ctx, apiKey, query) {
+  const body = {
+    query,
+    search_depth: pickEnum(ctx.args.search_depth, ["basic", "advanced"], "basic"),
+    topic: pickEnum(ctx.args.topic, ["general", "news", "finance"], "general"),
+    max_results: clampInteger(ctx.args.max_results, 5, 1, 10),
+    include_answer: booleanArg(ctx.args.include_answer, true),
+    include_raw_content: booleanArg(ctx.args.include_raw_content, false),
+    include_images: false,
+    include_image_descriptions: false,
+  };
+
+  const includeDomains = stringArrayArg(ctx.args.include_domains);
+  if (includeDomains.length > 0) body.include_domains = includeDomains;
+
+  const excludeDomains = stringArrayArg(ctx.args.exclude_domains);
+  if (excludeDomains.length > 0) body.exclude_domains = excludeDomains;
+
+  const response = await fetch(TAVILY_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: ctx.signal,
+  });
+
+  if (!response.ok) {
+    const detail = await readResponseBody(response);
+    return {
+      status: "error",
+      content: `Tavily API error ${response.status}: ${detail.slice(0, 2000)}`,
+    };
+  }
+
+  const data = await response.json();
   const answer = stringArg(data?.answer);
   const results = Array.isArray(data?.results) ? data.results : [];
   const sections = [];
 
-  if (answer) {
-    sections.push(["## Tavily answer", answer].join("\n"));
-  }
-
+  if (answer) sections.push(["## Tavily answer", answer].join("\n"));
   if (results.length > 0) {
     sections.push(
       [
         "## Sources",
         ...results.map((result, index) =>
-          formatResult(result, index, includeRawContent),
+          formatTavilyResult(result, index, body.include_raw_content),
         ),
       ].join("\n\n"),
     );
@@ -85,25 +282,133 @@ function formatTavilyResponse(data, includeRawContent) {
   return sections.length > 0 ? sections.join("\n\n") : "No Tavily results.";
 }
 
-function buildSearchBody(args) {
+async function runPerplexitySearch(ctx, apiKey, query) {
   const body = {
-    query: stringArg(args.query),
-    search_depth: pickEnum(args.search_depth, ["basic", "advanced"], "basic"),
-    topic: pickEnum(args.topic, ["general", "news", "finance"], "general"),
-    max_results: clampInteger(args.max_results, 5, 1, 10),
-    include_answer: booleanArg(args.include_answer, true),
-    include_raw_content: booleanArg(args.include_raw_content, false),
-    include_images: false,
-    include_image_descriptions: false,
+    model: "sonar",
+    messages: [
+      {
+        role: "system",
+        content:
+          "Answer with concise, factual web-grounded information. Include citations when available.",
+      },
+      { role: "user", content: query },
+    ],
+    max_tokens: clampInteger(ctx.args.max_tokens, 1200, 100, 4000),
+    search_mode: pickEnum(ctx.args.search_mode, ["web", "academic", "sec"], "web"),
+    stream: false,
   };
 
-  const includeDomains = stringArrayArg(args.include_domains);
-  if (includeDomains.length > 0) body.include_domains = includeDomains;
+  const recency = pickEnum(
+    ctx.args.recency,
+    ["hour", "day", "week", "month", "year"],
+    "",
+  );
+  if (recency) body.search_recency_filter = recency;
 
-  const excludeDomains = stringArrayArg(args.exclude_domains);
-  if (excludeDomains.length > 0) body.exclude_domains = excludeDomains;
+  const response = await fetch(PERPLEXITY_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: ctx.signal,
+  });
 
-  return body;
+  if (!response.ok) {
+    const detail = await readResponseBody(response);
+    return {
+      status: "error",
+      content: `Perplexity API error ${response.status}: ${detail.slice(0, 2000)}`,
+    };
+  }
+
+  const data = await response.json();
+  const answer = stringArg(data?.choices?.[0]?.message?.content);
+  const citations = Array.isArray(data?.citations) ? data.citations : [];
+  const citationText = citations.length
+    ? ["## Citations", ...citations.map((url, index) => `${index + 1}. ${url}`)].join("\n")
+    : "";
+  const searchResults = formatPerplexitySearchResults(data?.search_results);
+
+  return ["## Perplexity answer", answer, citationText, searchResults]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+async function runParallelSearch(ctx, apiKey, query) {
+  const objective = stringArg(ctx.args.objective, query);
+  const searchQueries = stringArrayArg(ctx.args.search_queries).slice(0, 3);
+  if (searchQueries.length === 0) searchQueries.push(query);
+
+  const sourcePolicy = {};
+  const includeDomains = stringArrayArg(ctx.args.include_domains);
+  if (includeDomains.length > 0) sourcePolicy.include_domains = includeDomains;
+  const excludeDomains = stringArrayArg(ctx.args.exclude_domains);
+  if (excludeDomains.length > 0) sourcePolicy.exclude_domains = excludeDomains;
+  const afterDate = stringArg(ctx.args.after_date);
+  if (afterDate) sourcePolicy.after_date = afterDate;
+
+  const advancedSettings = {
+    max_results: clampInteger(ctx.args.max_results, 6, 1, 10),
+    excerpt_settings: { max_chars_per_result: 1200 },
+  };
+  if (Object.keys(sourcePolicy).length > 0) {
+    advancedSettings.source_policy = sourcePolicy;
+  }
+
+  const body = {
+    objective,
+    search_queries: searchQueries,
+    mode: pickEnum(ctx.args.mode, ["basic", "advanced"], "advanced"),
+    max_chars_total: clampInteger(ctx.args.max_chars_total, 6000, 1000, 12000),
+    advanced_settings: advancedSettings,
+  };
+
+  const response = await fetch(PARALLEL_SEARCH_API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body: JSON.stringify(body),
+    signal: ctx.signal,
+  });
+
+  if (!response.ok) {
+    const detail = await readResponseBody(response);
+    return {
+      status: "error",
+      content: `Parallel API error ${response.status}: ${detail.slice(0, 2000)}`,
+    };
+  }
+
+  const data = await response.json();
+  const results = Array.isArray(data?.results) ? data.results : [];
+  if (results.length === 0) return "No Parallel results.";
+
+  const warnings = Array.isArray(data?.warnings)
+    ? data.warnings.map((warning) => stringArg(warning?.message)).filter(Boolean)
+    : [];
+  const warningText = warnings.length
+    ? ["## Warnings", ...warnings.map((warning) => `- ${warning}`)].join("\n")
+    : "";
+
+  return ["## Parallel results", ...results.map(formatParallelResult), warningText]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+async function runSelectedProvider(ctx, provider, apiKey, query) {
+  switch (provider.id) {
+    case "exa":
+      return runExaSearch(ctx, apiKey, query);
+    case "tavily":
+      return runTavilySearch(ctx, apiKey, query);
+    case "parallel":
+      return runParallelSearch(ctx, apiKey, query);
+    case "perplexity":
+      return runPerplexitySearch(ctx, apiKey, query);
+    default:
+      return { status: "error", content: `Unsupported web search provider: ${provider.id}` };
+  }
 }
 
 export default function activate(letta) {
@@ -112,7 +417,7 @@ export default function activate(letta) {
   return letta.tools.register({
     name: "web_search",
     description:
-      "Search the live web with Tavily and return a concise answer plus ranked source results. Use for current facts, source discovery, news, research papers, companies, or web pages.",
+      "Search the live web using the first configured provider key (Exa, Tavily, Parallel, or Perplexity), or a provider selected explicitly. Use for current facts, source discovery, news, research papers, companies, or web pages.",
     parameters: {
       type: "object",
       properties: {
@@ -120,20 +425,35 @@ export default function activate(letta) {
           type: "string",
           description: "The web-search query or research question.",
         },
-        search_depth: {
+        provider: {
           type: "string",
-          enum: ["basic", "advanced"],
+          enum: ["auto", "exa", "tavily", "parallel", "perplexity"],
           description:
-            "Search depth. basic is lower latency; advanced is deeper. Defaults to basic.",
-        },
-        topic: {
-          type: "string",
-          enum: ["general", "news", "finance"],
-          description: "Search topic. Defaults to general.",
+            "Provider to use. auto picks the first configured key in this order: Exa, Tavily, Parallel, Perplexity. Defaults to auto.",
         },
         max_results: {
           type: "number",
           description: "Number of source results to return, 1-10. Defaults to 5.",
+        },
+        include_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to restrict results to, supported by Exa/Tavily/Parallel.",
+        },
+        exclude_domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional domains to exclude from results, supported by Exa/Tavily/Parallel.",
+        },
+        search_depth: {
+          type: "string",
+          enum: ["basic", "advanced"],
+          description: "Tavily search depth. Defaults to basic.",
+        },
+        topic: {
+          type: "string",
+          enum: ["general", "news", "finance"],
+          description: "Tavily topic. Defaults to general.",
         },
         include_answer: {
           type: "boolean",
@@ -142,17 +462,64 @@ export default function activate(letta) {
         include_raw_content: {
           type: "boolean",
           description:
-            "Whether to include raw source content snippets when available. Defaults to false.",
+            "Whether Tavily should include raw source content snippets when available. Defaults to false.",
         },
-        include_domains: {
-          type: "array",
-          items: { type: "string" },
-          description: "Optional domains to restrict results to.",
+        category: {
+          type: "string",
+          enum: ["company", "research paper", "news", "personal site", "financial report", "people"],
+          description: "Exa result category to focus the search.",
         },
-        exclude_domains: {
+        exa_type: {
+          type: "string",
+          enum: ["auto", "instant", "fast", "deep-lite", "deep"],
+          description: "Exa search type. Defaults to auto.",
+        },
+        start_published_date: {
+          type: "string",
+          description: "Exa ISO date/time. Only results published after this date.",
+        },
+        end_published_date: {
+          type: "string",
+          description: "Exa ISO date/time. Only results published before this date.",
+        },
+        search_mode: {
+          type: "string",
+          enum: ["web", "academic", "sec"],
+          description: "Perplexity search corpus. Defaults to web.",
+        },
+        recency: {
+          type: "string",
+          enum: ["hour", "day", "week", "month", "year"],
+          description: "Perplexity publication recency filter.",
+        },
+        max_tokens: {
+          type: "number",
+          description: "Perplexity maximum answer tokens. Defaults to 1200.",
+        },
+        objective: {
+          type: "string",
+          description:
+            "Parallel natural-language research goal. Defaults to query when omitted.",
+        },
+        search_queries: {
           type: "array",
+          description:
+            "Parallel keyword queries. Defaults to [query] when omitted.",
           items: { type: "string" },
-          description: "Optional domains to exclude from results.",
+          maxItems: 3,
+        },
+        mode: {
+          type: "string",
+          enum: ["basic", "advanced"],
+          description: "Parallel search mode. Defaults to advanced.",
+        },
+        max_chars_total: {
+          type: "number",
+          description: "Parallel maximum characters across all excerpts. Defaults to 6000.",
+        },
+        after_date: {
+          type: "string",
+          description: "Parallel YYYY-MM-DD start date for filtering results.",
         },
       },
       required: ["query"],
@@ -161,32 +528,13 @@ export default function activate(letta) {
     requiresApproval: false,
     parallelSafe: true,
     async run(ctx) {
-      const apiKey = await ctx.secret(TAVILY_API_KEY, { envFallback: true });
-      if (!apiKey) return missingTavilyKey();
+      const query = stringArg(ctx.args.query);
+      if (!query) return { status: "error", content: "query is required" };
 
-      const body = buildSearchBody(ctx.args);
-      if (!body.query) return { status: "error", content: "query is required" };
+      const selection = await selectProvider(ctx);
+      if (selection.error) return selection.error;
 
-      const response = await fetch(TAVILY_API_URL, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-        signal: ctx.signal,
-      });
-
-      if (!response.ok) {
-        const detail = await readResponseBody(response);
-        return {
-          status: "error",
-          content: `Tavily API error ${response.status}: ${detail.slice(0, 2000)}`,
-        };
-      }
-
-      const data = await response.json();
-      return formatTavilyResponse(data, body.include_raw_content);
+      return runSelectedProvider(ctx, selection.provider, selection.apiKey, query);
     },
   });
 }

--- a/packages/web-search/package.json
+++ b/packages/web-search/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@letta-ai/web-search",
+  "version": "0.1.0",
+  "description": "Letta Code mod package that adds Tavily-backed web search using agent-scoped secrets.",
+  "author": "carenthomas",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "web-search",
+    "tavily"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/web-search"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["tools"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.16"
+    }
+  }
+}

--- a/packages/web-search/package.json
+++ b/packages/web-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@letta-ai/web-search",
   "version": "0.1.0",
-  "description": "Letta Code mod package that adds Tavily-backed web search using agent-scoped secrets.",
+  "description": "Letta Code mod package that adds provider-backed web search tools using agent-scoped secrets.",
   "author": "carenthomas",
   "license": "Apache-2.0",
   "type": "module",
@@ -10,7 +10,10 @@
     "letta-mod",
     "letta-code",
     "web-search",
-    "tavily"
+    "exa",
+    "tavily",
+    "perplexity",
+    "parallel"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add `@letta-ai/web-search` mod package exposing a single `web_search` tool
- supports four providers out of the box: **Exa, Tavily, Parallel, and Perplexity**, each reading its own key (`EXA_API_KEY`, `TAVILY_API_KEY`, `PARALLEL_API_KEY`, `PERPLEXITY_API_KEY`) via `ctx.secret(..., { envFallback: true })`
- `provider: "auto"` (default) picks the first configured key in order Exa -> Tavily -> Parallel -> Perplexity; pass an explicit `provider` to force one
- provider-specific options with input clamping and per-provider result formatting (Exa category/type/date filters + highlights/summary; Tavily depth/topic/answer/raw content; Perplexity search mode/recency/citations; Parallel objective/multi-query/excerpts)
- returns a normal setup-error result (not a throw) when no provider key is configured
- document `/secret set <KEY> <value>` setup with env fallback; require Letta Code `>=0.27.16`

> Note: summary edited post-merge to reflect the full multi-provider implementation (the original only mentioned Tavily).

## Tests
- `npm run validate`
- `bun --check packages/web-search/mods/index.ts`
- smoke-tested install/load/tool missing-secret path against Letta Code PR 3058 runtime
- smoke-tested env fallback with mocked Tavily response against Letta Code PR 3058 runtime