### PR TITLE
feat: add Spotify statusline mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ packages/
 ├── image-understanding/  # Vision bridge for text-only agents
 ├── memfs-search/         # Agent-callable MemFS memory search
 ├── plan-mode/            # Plan-mode style workflow
+├── spotify-statusline/   # macOS Spotify now-playing statusline
 └── web-search/           # Provider-backed web search tools
 
 scripts/
@@ -85,6 +86,7 @@ scripts/
 - **image-understanding** - Image-understanding tool, commands, and optional auto-captioning for text-only agents
 - **memfs-search** - Agent-callable MemFS memory search with optional QMD semantic/hybrid search
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
+- **spotify-statusline** - macOS Spotify now-playing statusline
 - **web-search** - Provider-backed web search tools using agent-scoped secrets
 
 ## Mod Package Format

--- a/packages/spotify-statusline/MOD.md
+++ b/packages/spotify-statusline/MOD.md
@@ -14,6 +14,7 @@ Use this mod when the user wants Letta Code's idle statusline to show the curren
 - Polls Spotify with `osascript` outside the render path.
 - Does not launch Spotify if the app is closed.
 - Shows `🎧 Artist - Track` while music is playing.
+- Wraps the playing track in an OSC 8 hyperlink to the native `spotify:track:<id>` URI so supported terminals can click to jump to the track.
 - Shows `🎧 paused` when Spotify is paused.
 - Clears the Spotify segment when Spotify is stopped, closed, or unavailable.
 - Renders the agent name and model on the right so the statusline remains useful when no track is active.

--- a/packages/spotify-statusline/MOD.md
+++ b/packages/spotify-statusline/MOD.md
@@ -1,0 +1,36 @@
+---
+name: "@letta-ai/spotify-statusline"
+description: "macOS Spotify now-playing statusline for Letta Code."
+---
+
+# Spotify statusline mod semantics
+
+## When to use
+
+Use this mod when the user wants Letta Code's idle statusline to show the current Spotify track on macOS.
+
+## Behavior
+
+- Polls Spotify with `osascript` outside the render path.
+- Does not launch Spotify if the app is closed.
+- Shows `🎧 Artist - Track` while music is playing.
+- Shows `🎧 paused` when Spotify is paused.
+- Clears the Spotify segment when Spotify is stopped, closed, or unavailable.
+- Renders the agent name and model on the right so the statusline remains useful when no track is active.
+
+## Platform assumptions
+
+This mod is macOS-specific because it uses AppleScript via `osascript` to query Spotify.
+
+## Safety invariants
+
+- Renderer stays synchronous.
+- Shelling happens only in the setup interval, never during render.
+- Timers and status values are cleaned up when the mod is disposed.
+- Optional UI APIs are capability-guarded.
+
+## Adaptation notes for agents
+
+- Preserve the `application "Spotify" is running` guard; without it, AppleScript can launch Spotify just to query state.
+- Keep polling lightweight. The default refresh interval is 5 seconds.
+- If composing with other statusline data, remember the custom statusline owns the full idle row.

--- a/packages/spotify-statusline/README.md
+++ b/packages/spotify-statusline/README.md
@@ -29,6 +29,7 @@ Then reload local mods:
 ## Behavior
 
 - Shows `🎧 Artist - Track` while Spotify is playing.
+- Wraps the playing track in a terminal hyperlink (OSC 8) pointing at `spotify:track:<id>`, so supported terminals (iTerm2, Ghostty, WezTerm, Kitty, VS Code) jump to the track on click.
 - Shows `🎧 paused` while Spotify is paused.
 - Shows no Spotify segment when Spotify is stopped, closed, or unavailable.
 - Does not launch Spotify when checking state.

--- a/packages/spotify-statusline/README.md
+++ b/packages/spotify-statusline/README.md
@@ -1,0 +1,54 @@
+# Spotify Statusline
+
+A Letta Code statusline mod that shows the currently playing Spotify track on macOS.
+
+```text
+🎧 Artist - Track                                      Kian-K3-Coder · Claude Sonnet 4
+```
+
+## Install
+
+Once npm mod install support is available:
+
+```bash
+letta install npm:@letta-ai/spotify-statusline
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## What it adds
+
+- macOS Spotify now-playing statusline segment
+- paused-state indicator
+- fallback right-side agent/model display
+
+## Behavior
+
+- Shows `🎧 Artist - Track` while Spotify is playing.
+- Shows `🎧 paused` while Spotify is paused.
+- Shows no Spotify segment when Spotify is stopped, closed, or unavailable.
+- Does not launch Spotify when checking state.
+
+## Requirements
+
+- macOS
+- Spotify desktop app
+- Letta Code with custom statusline mod support
+
+## Safety
+
+Mods are trusted local code. Review the source before installing third-party mods.
+
+If a mod breaks startup or command handling, recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/spotify-statusline/mods/index.tsx
+++ b/packages/spotify-statusline/mods/index.tsx
@@ -3,6 +3,12 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const REFRESH_MS = 5_000;
+const OSC = "\u001B]8;;";
+const ST = "\u001B\\";
+
+function terminalLink(label: string, href: string) {
+  return `${OSC}${href}${ST}${label}${OSC}${ST}`;
+}
 
 async function updateSpotify(letta: any) {
   try {
@@ -13,7 +19,8 @@ if application "Spotify" is running then
     if playerState is "playing" then
       set trackArtist to artist of current track
       set trackName to name of current track
-      return "playing|" & trackArtist & " - " & trackName
+      set trackUrl to spotify url of current track
+      return "playing|" & trackArtist & " - " & trackName & "|" & trackUrl
     else if playerState is "paused" then
       return "paused|"
     else
@@ -25,10 +32,11 @@ else
 end if
 `;
     const { stdout } = await execFileAsync("osascript", ["-e", script], { timeout: 1_500 });
-    const [state, track = ""] = stdout.trim().split("|", 2);
+    const [state, track = "", href = ""] = stdout.trim().split("|", 3);
 
     if (state === "playing" && track.trim()) {
-      letta.ui.setStatus("spotify", `🎧 ${track.trim()}`);
+      const label = `🎧 ${track.trim()}`;
+      letta.ui.setStatus("spotify", href.trim() ? terminalLink(label, href.trim()) : label);
     } else if (state === "paused") {
       letta.ui.setStatus("spotify", "🎧 paused");
     } else {

--- a/packages/spotify-statusline/mods/index.tsx
+++ b/packages/spotify-statusline/mods/index.tsx
@@ -1,0 +1,76 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const REFRESH_MS = 5_000;
+
+async function updateSpotify(letta: any) {
+  try {
+    const script = `
+if application "Spotify" is running then
+  tell application "Spotify"
+    set playerState to player state as string
+    if playerState is "playing" then
+      set trackArtist to artist of current track
+      set trackName to name of current track
+      return "playing|" & trackArtist & " - " & trackName
+    else if playerState is "paused" then
+      return "paused|"
+    else
+      return "stopped|"
+    end if
+  end tell
+else
+  return "stopped|"
+end if
+`;
+    const { stdout } = await execFileAsync("osascript", ["-e", script], { timeout: 1_500 });
+    const [state, track = ""] = stdout.trim().split("|", 2);
+
+    if (state === "playing" && track.trim()) {
+      letta.ui.setStatus("spotify", `🎧 ${track.trim()}`);
+    } else if (state === "paused") {
+      letta.ui.setStatus("spotify", "🎧 paused");
+    } else {
+      letta.ui.clearStatus("spotify");
+    }
+  } catch {
+    letta.ui.clearStatus("spotify");
+  }
+}
+
+export default function activate(letta: any) {
+  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+
+  const update = () => {
+    if (!letta.capabilities.ui.statusValues) return;
+    void updateSpotify(letta);
+  };
+
+  letta.ui.setStatuslineRenderer((context: any) => {
+    const { Box, Text } = context.components;
+    const model = context.model.displayName ?? context.model.id ?? "unknown";
+
+    return (
+      <Box flexDirection="row" marginBottom={1}>
+        <Box flexGrow={1} paddingRight={1}>
+          {context.statuses.spotify ? <Text color="#1DB954">{context.statuses.spotify}</Text> : null}
+        </Box>
+        <Text>
+          <Text color="#8b5cf6">{context.agent.name ?? "Letta"}</Text>
+          <Text dimColor>{` · ${model}`}</Text>
+        </Text>
+      </Box>
+    );
+  });
+
+  update();
+  const timer = setInterval(update, REFRESH_MS);
+
+  return () => {
+    clearInterval(timer);
+    if (letta.capabilities.ui.statusValues) {
+      letta.ui.clearStatus("spotify");
+    }
+  };
+}

--- a/packages/spotify-statusline/package.json
+++ b/packages/spotify-statusline/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@letta-ai/spotify-statusline",
+  "version": "0.1.0",
+  "description": "Letta Code statusline mod that shows the currently playing Spotify track on macOS.",
+  "author": "Kian Jones",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "statusline",
+    "spotify"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/spotify-statusline"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.tsx"],
+    "capabilities": ["ui.statusline", "ui.statusValues"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}

--- a/packages/spotify-statusline/package.json
+++ b/packages/spotify-statusline/package.json
@@ -2,7 +2,7 @@
   "name": "@letta-ai/spotify-statusline",
   "version": "0.1.0",
   "description": "Letta Code statusline mod that shows the currently playing Spotify track on macOS.",
-  "author": "Kian Jones",
+  "author": "kianjones9",
   "license": "Apache-2.0",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- add macOS Spotify now-playing statusline package
- wrap the playing track in an OSC 8 hyperlink that jumps to the Spotify track on click

## Validation
- npm run validate