### PR TITLE
Add user timestamps mod package

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ packages/
 ├── memfs-search/         # Agent-callable MemFS memory search
 ├── plan-mode/            # Plan-mode style workflow
 ├── spotify-statusline/   # macOS Spotify now-playing statusline
+├── user-timestamps/      # Adds local timestamp metadata to user messages
 └── web-search/           # Provider-backed web search tools
 
 scripts/
@@ -87,6 +88,7 @@ scripts/
 - **memfs-search** - Agent-callable MemFS memory search with optional QMD semantic/hybrid search
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
 - **spotify-statusline** - macOS Spotify now-playing statusline
+- **user-timestamps** - Adds local timestamp metadata to every user message
 - **web-search** - Provider-backed web search tools using agent-scoped secrets
 
 ## Mod Package Format

--- a/packages/user-timestamps/MOD.md
+++ b/packages/user-timestamps/MOD.md
@@ -1,6 +1,6 @@
 ---
 name: "@letta-ai/user-timestamps"
-description: "Adds local timestamp metadata to every user message before model turns."
+description: "Ensures agents are always aware of the current time by adding timestamp metadata to every user message"
 ---
 
 # User timestamps mod semantics
@@ -35,8 +35,3 @@ The visible block is intentionally included because model providers and downstre
 - The mod uses only public turn event APIs and does not import Letta Code internals.
 - The mod registers a single `turn_start` handler and returns its disposer.
 
-## Adaptation notes for agents
-
-- Keep timestamp text compact. Do not add UTC, ISO, or verbose metadata unless the user explicitly asks.
-- Keep the XML-like tag stable so agents and tests can detect the injected timestamp.
-- If adapting for strict invisibility, remove the visible block only if the harness/provider reliably preserves `metadata.user_timestamp` into model-visible context.

--- a/packages/user-timestamps/MOD.md
+++ b/packages/user-timestamps/MOD.md
@@ -1,0 +1,42 @@
+---
+name: "@letta-ai/user-timestamps"
+description: "Adds local timestamp metadata to every user message before model turns."
+---
+
+# User timestamps mod semantics
+
+## When to use
+
+Use this mod when the agent should always know the exact local time of each user turn without relying on stale prior context or manual user-provided timestamps.
+
+## Behavior
+
+On every `turn_start`, the mod transforms each user message by:
+
+1. Adding structured `metadata.user_timestamp` with:
+   - `local`: the user's local date/time string
+   - `timeZone`: the local IANA timezone when available
+2. Prepending a short visible timestamp block to the user message content:
+
+```text
+<user_timestamp>
+local: Wednesday, June 24, 2026 at 6:00:00 PM PDT
+timezone: America/Los_Angeles
+</user_timestamp>
+```
+
+The visible block is intentionally included because model providers and downstream message schemas may ignore custom metadata. The visible content keeps the behavior robust and easy to inspect.
+
+## Safety invariants
+
+- Only user messages are transformed.
+- Approval messages are left unchanged.
+- Existing `<user_timestamp>` blocks are not duplicated.
+- The mod uses only public turn event APIs and does not import Letta Code internals.
+- The mod registers a single `turn_start` handler and returns its disposer.
+
+## Adaptation notes for agents
+
+- Keep timestamp text compact. Do not add UTC, ISO, or verbose metadata unless the user explicitly asks.
+- Keep the XML-like tag stable so agents and tests can detect the injected timestamp.
+- If adapting for strict invisibility, remove the visible block only if the harness/provider reliably preserves `metadata.user_timestamp` into model-visible context.

--- a/packages/user-timestamps/README.md
+++ b/packages/user-timestamps/README.md
@@ -1,0 +1,55 @@
+# User Timestamps
+
+A Letta Code mod package that adds local timestamp metadata to every user message.
+
+This helps agents answer time-sensitive questions and reason about current time without relying on stale conversation context.
+
+## Install
+
+Once npm mod install support is available:
+
+```bash
+letta install npm:@letta-ai/user-timestamps
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## What it adds
+
+- A `turn_start` transform for user messages
+- Structured `metadata.user_timestamp` containing local time and timezone
+- A compact visible `<user_timestamp>` block prepended to each user message so the model definitely sees the current time
+
+Example injected block:
+
+```text
+<user_timestamp>
+local: Wednesday, June 24, 2026 at 6:00:00 PM PDT
+timezone: America/Los_Angeles
+</user_timestamp>
+```
+
+## Behavior
+
+- User messages get timestamped before they are sent to the model.
+- Approval messages are not changed.
+- Existing timestamp blocks are not duplicated.
+- The timestamp is generated locally using the machine running Letta Code.
+
+## Safety
+
+Mods are trusted local code. Review the source before installing third-party mods.
+
+If a mod breaks startup or command handling, recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/user-timestamps/mods/index.ts
+++ b/packages/user-timestamps/mods/index.ts
@@ -1,0 +1,90 @@
+// Adds current-time metadata to every user message before it is sent to the model.
+// The visible timestamp block is intentionally short so the agent always knows the local time.
+
+function timestampMetadata(date = new Date()) {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "local";
+  return {
+    local: date.toLocaleString(undefined, {
+      dateStyle: "full",
+      timeStyle: "long",
+      timeZoneName: "short",
+    }),
+    timeZone,
+  };
+}
+
+function timestampBlock(meta) {
+  return [
+    "<user_timestamp>",
+    `local: ${meta.local}`,
+    `timezone: ${meta.timeZone}`,
+    "</user_timestamp>",
+    "",
+  ].join("\n");
+}
+
+function hasTimestampText(content) {
+  if (typeof content === "string") return content.includes("<user_timestamp>");
+  if (!Array.isArray(content)) return false;
+  return content.some(
+    (part) =>
+      part?.type === "text" &&
+      typeof part.text === "string" &&
+      part.text.includes("<user_timestamp>"),
+  );
+}
+
+function prependTimestampContent(content, block) {
+  if (typeof content === "string") return block + content;
+
+  if (Array.isArray(content)) {
+    let inserted = false;
+    const next = content.map((part) => {
+      if (!inserted && part?.type === "text" && typeof part.text === "string") {
+        inserted = true;
+        return { ...part, text: block + part.text };
+      }
+      return part;
+    });
+
+    if (!inserted) next.unshift({ type: "text", text: block });
+    return next;
+  }
+
+  return block;
+}
+
+export default function activate(letta) {
+  if (!letta.capabilities.events.turns) {
+    letta.diagnostics?.report?.({
+      severity: "warning",
+      message: "user-timestamps mod requires turn events, but this host does not expose them.",
+    });
+    return;
+  }
+
+  return letta.events.on("turn_start", (event) => {
+    const meta = timestampMetadata();
+    const block = timestampBlock(meta);
+
+    event.input = event.input.map((item) => {
+      if (item.type === "approval" || item.role !== "user") return item;
+
+      const existingMetadata =
+        item.metadata && typeof item.metadata === "object" && !Array.isArray(item.metadata)
+          ? item.metadata
+          : {};
+
+      return {
+        ...item,
+        metadata: {
+          ...existingMetadata,
+          user_timestamp: meta,
+        },
+        content: hasTimestampText(item.content)
+          ? item.content
+          : prependTimestampContent(item.content, block),
+      };
+    });
+  });
+}

--- a/packages/user-timestamps/package.json
+++ b/packages/user-timestamps/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@letta-ai/user-timestamps",
+  "version": "0.1.0",
+  "description": "Letta Code turn-start mod that adds local timestamp metadata to every user message.",
+  "author": "Letta",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "timestamps",
+    "time"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/user-timestamps"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["events.turns"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `@letta-ai/user-timestamps`, a turn-start mod that adds local timestamp metadata to user messages
- Include a compact visible `<user_timestamp>` block so agents reliably see the current local time
- Update the root README package list

## Test
- `npm run validate`