### PR TITLE
ci: notify home-site to refresh mod catalog after publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,25 +109,28 @@ jobs:
             npm publish "./$package_dir" --access public
           done < changed-packages.txt
 
-  # Tell the marketing site to regenerate its mod catalog (/agent/mods) now that
-  # new packages are on npm. No-ops if the token secret is absent — the site also
-  # refreshes on an hourly schedule, so this just makes it near-real-time.
+  # Tell the marketing site to regenerate its mod catalog now that new packages
+  # are on npm. The target repo is kept in a secret (not hardcoded) so this public
+  # workflow / its logs don't reference the private site repo. No-ops if the
+  # secrets are absent — the site also refreshes on a schedule, so this just makes
+  # the update near-real-time.
   notify-site:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger letta-home-site mod catalog refresh
+      - name: Trigger site mod catalog refresh
         env:
           DISPATCH_TOKEN: ${{ secrets.HOMESITE_DISPATCH_TOKEN }}
+          DISPATCH_URL: ${{ secrets.HOMESITE_DISPATCH_URL }}
         run: |
-          if [ -z "${DISPATCH_TOKEN:-}" ]; then
-            echo "HOMESITE_DISPATCH_TOKEN not set; skipping (home-site hourly schedule will catch up)."
+          if [ -z "${DISPATCH_TOKEN:-}" ] || [ -z "${DISPATCH_URL:-}" ]; then
+            echo "Dispatch secrets not set; skipping (site schedule will catch up)."
             exit 0
           fi
           curl -fsS -X POST \
             -H "Authorization: Bearer $DISPATCH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/letta-ai/letta-home-site/dispatches \
+            "$DISPATCH_URL" \
             -d '{"event_type":"mods-updated"}'
-          echo "Dispatched mods-updated to letta-home-site."
+          echo "Dispatched mods-updated to the site."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,3 +108,26 @@ jobs:
             echo "Publishing $name@$version from $package_dir"
             npm publish "./$package_dir" --access public
           done < changed-packages.txt
+
+  # Tell the marketing site to regenerate its mod catalog (/agent/mods) now that
+  # new packages are on npm. No-ops if the token secret is absent — the site also
+  # refreshes on an hourly schedule, so this just makes it near-real-time.
+  notify-site:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger letta-home-site mod catalog refresh
+        env:
+          DISPATCH_TOKEN: ${{ secrets.HOMESITE_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "${DISPATCH_TOKEN:-}" ]; then
+            echo "HOMESITE_DISPATCH_TOKEN not set; skipping (home-site hourly schedule will catch up)."
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $DISPATCH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/letta-ai/letta-home-site/dispatches \
+            -d '{"event_type":"mods-updated"}'
+          echo "Dispatched mods-updated to letta-home-site."


### PR DESCRIPTION
## Summary
After `publish.yml` publishes changed mod packages to npm, ping the marketing site so it regenerates and redeploys its mod catalog near-real-time.

- New `notify-site` job (`needs: publish`) POSTs a `repository_dispatch` (`mods-updated`) to the site repo, which runs its catalog-refresh workflow (regenerate → commit → deploy).
- **Privacy:** the target repo is **not hardcoded** — both the dispatch URL and token live in secrets, so this public workflow and its (world-readable) Actions logs never reference the private site repo. GitHub masks secret values in logs.
- **No-ops gracefully** if the secrets are unset, so it never blocks publishing. The site also refreshes on a schedule, so the dispatch only makes updates near-instant.

## Setup required before this is active
Add two repo secrets to `letta-ai/mods` (Settings → Secrets and variables → Actions):
- **`HOMESITE_DISPATCH_TOKEN`** — fine-grained PAT scoped to the site repo with **Contents: read and write** (the permission `repository_dispatch` requires), or a classic PAT with `repo` scope.
- **`HOMESITE_DISPATCH_URL`** — `https://api.github.com/repos/<owner>/<site-repo>/dispatches`

## Pairs with
The receiving catalog-refresh workflow on the site repo.

👾 Generated with [Letta Code](https://letta.com)