### PR TITLE
feat: add pets mod

### DIFF
--- a/packages/pets/MOD.md
+++ b/packages/pets/MOD.md
@@ -1,0 +1,38 @@
+---
+name: "@letta-ai/pets"
+description: "Adds small terminal pets that animate based on Letta Code turn and tool activity"
+---
+
+# Pets mod semantics
+
+## When to use
+
+Use this mod when you want a small ambient terminal pet in Letta Code.
+
+## Behavior
+
+The `/pets` command creates and manages a panel-based pet. Supported pets are:
+
+- cat
+- dog
+- bunny
+- blob
+
+The pet uses Letta Code events to change animation state:
+
+- `turn_start` switches to a thinking animation.
+- `tool_start` switches based on tool type:
+  - shell tools use a terminal animation
+  - read/search tools use a reading animation
+  - edit/write/patch tools use a writing animation
+  - user prompt tools use a waiting animation
+  - other tools use a general working animation
+
+The animation returns to idle after activity stops.
+
+## Safety invariants
+
+- The mod only writes to its own UI panel.
+- The mod does not modify turn input or tool arguments.
+- The mod uses only public command, event, and panel APIs.
+- All timers, event handlers, and panels are cleaned up on unload.

--- a/packages/pets/README.md
+++ b/packages/pets/README.md
@@ -1,0 +1,30 @@
+# Pets
+
+A small terminal pet for Letta Code.
+
+## Usage
+
+```text
+/pets [cat|dog|bunny|blob] [name=<name>]
+/pets status
+/pets stop
+```
+
+Examples:
+
+```text
+/pets cat name=gato
+/pets bunny name=hoppy
+/pets blob name=bloop
+```
+
+The pet animates in the panel area and changes movement based on what Letta Code is doing:
+
+- thinking when a turn starts
+- moving while work is happening
+- terminal animation for shell commands
+- reading animation for read/search tools
+- writing animation for edits/patches
+- waiting animation for user prompts
+
+The pet returns to idle after activity stops.

--- a/packages/pets/mods/index.ts
+++ b/packages/pets/mods/index.ts
@@ -1,0 +1,287 @@
+type PetKind = "cat" | "dog" | "bunny" | "blob";
+type Mood =
+  | "idle"
+  | "working"
+  | "thinking"
+  | "writing"
+  | "shell"
+  | "reading"
+  | "asking";
+
+type PetState = {
+  active: boolean;
+  kind: PetKind;
+  name: string;
+  frame: number;
+  mood: Mood;
+  lastEventAt: number;
+};
+
+type Animation = {
+  frames: string[][];
+};
+
+type Pet = {
+  label: string;
+  animations: Record<Mood, Animation>;
+};
+
+const BASE: Record<PetKind, string[][]> = {
+  cat: [
+    [" /\\_/\\", "( o.o )", " > ^ <"],
+    [" /\\_/\\", "( -.- )", " > ^ <"],
+  ],
+  dog: [
+    ["^..^      /", "/_/\\_____/", "   /\\   /\\", "  /  \\ /  \\"],
+    ["^--^      /", "/_/\\_____/", "   /\\   /\\", "  /  \\ /  \\"],
+    ["^..^      /", "/_/\\_____/", "   /\\   /\\", "  /  \\ /  \\"],
+  ],
+  bunny: [
+    ["  //", " ('>", " /rr", "*\\))_"],
+    ["  //", " ('-", " /rr", "*\\))_"],
+    ["  //", " ('>", " /rr", "*\\))_"],
+  ],
+  blob: [
+    ["  .--.", " ( oo )", "  '--'"],
+    ["  .--.", " ( -- )", "  '--'"],
+  ],
+};
+
+const PETS: Record<PetKind, Pet> = {
+  cat: pet("cat", BASE.cat, ["  /\\_/\\", "=( o.o )=", "  > ^ <"]),
+  dog: pet("dog", BASE.dog, ["^oo^  ___/", "/_/\\_/", "  /\\ /\\"]),
+  bunny: pet("bunny", BASE.bunny, [" //", "('>", "/rr", "\\))_  *"]),
+  blob: pet("blob", BASE.blob, [" .--.", "( oo )", " '--'~"]),
+};
+
+let state: PetState = {
+  active: false,
+  kind: "cat",
+  name: "pixel",
+  frame: 0,
+  mood: "idle",
+  lastEventAt: 0,
+};
+
+function pet(label: string, idle: string[][], walkFrame: string[]): Pet {
+  return {
+    label,
+    animations: {
+      idle: { frames: idle },
+      working: {
+        frames: [
+          shift(walkFrame, 0),
+          shift(walkFrame, 5),
+          shift(walkFrame, 10),
+          shift(walkFrame, 5),
+        ],
+      },
+      thinking: {
+        frames: idle.map((frame, i) => [`${" ".repeat(i)}?`, ...frame]),
+      },
+      shell: {
+        frames: idle.map((frame, i) => [
+          `${i % 2 === 0 ? "$" : ">"} ...`,
+          ...frame,
+        ]),
+      },
+      reading: {
+        frames: idle.map((frame) => ["[==]", ...frame]),
+      },
+      writing: {
+        frames: idle.map((frame, i) => [
+          `${i % 2 === 0 ? "✎" : "✐"} scratch scratch`,
+          ...frame,
+        ]),
+      },
+      asking: {
+        frames: idle.map((frame) => ["??", ...frame]),
+      },
+    },
+  };
+}
+
+function shift(lines: string[], spaces: number): string[] {
+  return lines.map((line) => `${" ".repeat(spaces)}${line}`);
+}
+
+function parseArgs(args: string): {
+  action: string;
+  kind?: PetKind;
+  name?: string;
+} {
+  const parts = args.trim().split(/\s+/).filter(Boolean);
+  const first = parts[0]?.toLowerCase() || "start";
+  const parsed: { action: string; kind?: PetKind; name?: string } = {
+    action: first in PETS ? "start" : first,
+  };
+
+  if (first in PETS) parsed.kind = first as PetKind;
+
+  for (const part of parts.slice(1)) {
+    const [key, value] = part.split("=", 2);
+    if (key === "kind" && value in PETS) parsed.kind = value as PetKind;
+    if (key === "name" && value) parsed.name = value.slice(0, 24);
+  }
+
+  return parsed;
+}
+
+function moodForTool(toolName: string): Mood {
+  const normalized = toolName.toLowerCase();
+  if (["bash", "exec_command", "write_stdin"].includes(normalized))
+    return "shell";
+  if (
+    [
+      "read",
+      "glob",
+      "grep",
+      "ls",
+      "webfetch",
+      "fetch_webpage",
+      "web_search",
+    ].includes(normalized)
+  )
+    return "reading";
+  if (
+    ["edit", "write", "applypatch", "apply_patch", "multiedit"].includes(
+      normalized,
+    )
+  )
+    return "writing";
+  if (["askuserquestion", "ask_user_question"].includes(normalized))
+    return "asking";
+  return "working";
+}
+
+function setMood(mood: Mood) {
+  if (!state.active) return;
+  state = {
+    ...state,
+    mood,
+    frame: mood === state.mood ? state.frame : 0,
+    lastEventAt: Date.now(),
+  };
+  updatePanel();
+}
+
+function renderLines(): string[] {
+  if (!state.active) return [];
+  const pet = PETS[state.kind];
+  const animation = pet.animations[state.mood];
+  const frame = animation.frames[state.frame % animation.frames.length];
+  return [`${state.name} the ${pet.label}`, ...frame];
+}
+
+function rightPad(lines: string[]): string[] {
+  return lines.map((line) => `${" ".repeat(150)}${line}`);
+}
+
+let panel: any = null;
+let updatePanel = () => {};
+
+export default function activate(letta: any) {
+  const disposers: Array<() => void> = [];
+
+  const closePanel = () => {
+    panel?.close();
+    panel = null;
+  };
+
+  updatePanel = () => {
+    if (!letta.capabilities.ui.panels) return;
+    if (!state.active) {
+      closePanel();
+      return;
+    }
+
+    const content = rightPad(renderLines());
+    if (!panel) {
+      panel = letta.ui.openPanel({ id: "pets", order: 10_000, content });
+    } else {
+      panel.update({ content });
+    }
+  };
+
+  const timer = setInterval(() => {
+    if (!state.active) return;
+    const idleAfterMs = state.mood === "asking" ? 30_000 : 4_000;
+    const nextMood =
+      Date.now() - state.lastEventAt > idleAfterMs ? "idle" : state.mood;
+    state = { ...state, mood: nextMood, frame: state.frame + 1 };
+    updatePanel();
+  }, 700);
+  disposers.push(() => clearInterval(timer));
+
+  if (letta.capabilities.events.turns) {
+    disposers.push(letta.events.on("turn_start", () => setMood("thinking")));
+  }
+
+  if (letta.capabilities.events.tools) {
+    disposers.push(
+      letta.events.on("tool_start", (event: { toolName: string }) =>
+        setMood(moodForTool(event.toolName)),
+      ),
+    );
+  }
+
+  if (letta.capabilities.commands) {
+    disposers.push(
+      letta.commands.register({
+        id: "pets",
+        description: "Create or manage a small terminal pet",
+        args: "[cat|dog|bunny|blob|stop|status] [name=<name>]",
+        showInTranscript: false,
+        run(ctx: { args: string }) {
+          const parsed = parseArgs(ctx.args ?? "");
+
+          if (parsed.action === "stop") {
+            state = { ...state, active: false };
+            updatePanel();
+            return { type: "output", output: "Pet dismissed." };
+          }
+
+          if (parsed.action === "status") {
+            return {
+              type: "output",
+              output: state.active
+                ? renderLines().join("\n")
+                : "No active pet. Try /pets cat name=Pixel",
+            };
+          }
+
+          if (!["start", "create"].includes(parsed.action)) {
+            return {
+              type: "output",
+              output:
+                "Usage: /pets [cat|dog|bunny|blob|stop|status] [name=<name>]",
+            };
+          }
+
+          state = {
+            active: true,
+            kind: parsed.kind ?? state.kind,
+            name: parsed.name ?? state.name,
+            frame: 0,
+            mood: "idle",
+            lastEventAt: Date.now(),
+          };
+          updatePanel();
+
+          return {
+            type: "output",
+            output: `Created ${state.name} the ${PETS[state.kind].label}. Use /pets stop to dismiss.`,
+          };
+        },
+      }),
+    );
+  }
+
+  if (letta.capabilities.ui.panels) {
+    disposers.push(closePanel);
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/pets/package.json
+++ b/packages/pets/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@letta-ai/pets",
+  "version": "0.1.0",
+  "description": "Letta Code terminal pets that animate based on turn and tool activity.",
+  "author": "Letta",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "pets",
+    "terminal",
+    "animations"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/pets"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["commands", "events.tools", "events.turns", "ui.panels"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
Adds a `/pets` command for cat, dog, bunny, and blob terminal pets.

Pets render in a panel and animate based on Letta Code turn/tool activity:
- turn start → thinking
- shell tools → terminal animation
- read/search tools → reading
- edit/write/patch tools → writing
- ask-user tools → waiting

Validated with `npm run validate`.