### PR TITLE
feat: add context-thermometer mod

### DIFF
--- a/packages/context-thermometer/MOD.md
+++ b/packages/context-thermometer/MOD.md
@@ -1,0 +1,51 @@
+---
+name: "@letta-ai/context-thermometer"
+description: "Real-time context window usage visualization as a thermometer gauge panel."
+---
+
+# Context thermometer mod semantics
+
+## When to use
+
+Use this mod when you want a visual gauge of context window usage, including a breakdown of memory block sizes and a status indicator.
+
+## Behavioral contract
+
+When active, the mod:
+1. Reads context window token counts on every turn.
+2. Renders a thermometer gauge panel showing usage percentage, token counts, trend sparkline, and memory block breakdown.
+3. Injects a system reminder when context usage exceeds 90%.
+
+## Commands
+
+### `/context`
+
+Toggles the thermometer panel.
+
+### `/context on` / `/context off`
+
+Explicitly enable or disable the panel.
+
+### `/context status`
+
+Show current stats as command output.
+
+### `/context max <tokens>`
+
+Set the max context window size for the gauge.
+
+## Turn reminders
+
+When context usage exceeds 90%, the mod prepends a system reminder warning about context exhaustion and suggesting compaction.
+
+## State
+
+State is in-memory only (not persisted to disk). Max tokens can be configured via `CONTEXT_THERMOMETER_MAX_TOKENS` env var (default: 128,000).
+
+## Adaptation notes for agents
+
+- The mod starts active by default.
+- Memory block sizes are estimated at ~4 chars per token.
+- The max context window defaults to 128K but can be overridden with `/context max` or the env var.
+- The mod is read-only and does not modify turn input except for critical warnings above 90%.
+- If the panel capability is not available, `/context status` still works as a command.

--- a/packages/context-thermometer/README.md
+++ b/packages/context-thermometer/README.md
@@ -1,0 +1,42 @@
+# @letta-ai/context-thermometer
+
+A Letta Code mod that visualizes context window usage as a real-time thermometer gauge panel.
+
+## Features
+
+- **Visual gauge** — a horizontal bar showing context window fill percentage
+- **Token tracking** — input, output, and peak token counts
+- **Trend sparkline** — a Unicode sparkline showing input token history over recent turns
+- **Memory block breakdown** — per-file token estimates for all system memory blocks
+- **Status indicators** — COMFORTABLE (<50%), GETTING FULL (50-75%), WARM (75-90%), CRITICAL (>90%)
+- **Critical warnings** — automatically injects a system reminder when context usage exceeds 90%
+
+## Install
+
+```bash
+letta install npm:@letta-ai/context-thermometer
+```
+
+Then run `/reload` in Letta Code.
+
+## Usage
+
+The thermometer panel appears automatically. Use `/context` to toggle it.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `/context` | Toggle the thermometer panel |
+| `/context on` | Enable the panel |
+| `/context off` | Disable the panel |
+| `/context status` | Show current stats as output |
+| `/context max <tokens>` | Set max context window size |
+
+### Configuration
+
+Set `CONTEXT_THERMOMETER_MAX_TOKENS` in your environment to override the default max of 128,000 tokens.
+
+## How it works
+
+The mod hooks into `turn_start` events to read context window token counts from the conversation context. It reads memory block files from the MemFS filesystem to estimate their token sizes (~4 chars per token). The gauge updates on every turn, and a system reminder is injected when usage exceeds 90%.

--- a/packages/context-thermometer/mods/index.ts
+++ b/packages/context-thermometer/mods/index.ts
@@ -1,0 +1,353 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const DEFAULT_MAX_TOKENS = 128_000;
+const BAR_WIDTH = 40;
+const MAX_HISTORY = 24;
+const MAX_FILE_BYTES = 100_000;
+const SPARKLINE_BLOCKS = "\u2581\u2582\u2583\u2584\u2585\u2586\u2587\u2588";
+const CRITICAL_THRESHOLD = 90;
+
+type ThermometerState = {
+  active: boolean;
+  maxTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  peakInputTokens: number;
+  peakTotalTokens: number;
+  history: number[];
+  lastUpdate: number;
+};
+
+let state: ThermometerState = {
+  active: true,
+  maxTokens: DEFAULT_MAX_TOKENS,
+  inputTokens: 0,
+  outputTokens: 0,
+  peakInputTokens: 0,
+  peakTotalTokens: 0,
+  history: [],
+  lastUpdate: 0,
+};
+
+let panel: { update: (opts: { content: string[] }) => void; close: () => void } | null = null;
+let updatePanel = () => {};
+
+function getMaxTokens(): number {
+  const env = process.env.CONTEXT_THERMOMETER_MAX_TOKENS;
+  if (env) {
+    const n = Number.parseInt(env, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return DEFAULT_MAX_TOKENS;
+}
+
+function candidateMemoryDirs(): string[] {
+  const candidates: string[] = [];
+  if (process.env.MEMORY_DIR) candidates.push(process.env.MEMORY_DIR);
+  const agentId = process.env.AGENT_ID || "";
+  const home = process.env.HOME || "";
+  if (home && agentId) {
+    candidates.push(path.join(home, ".letta", "lc-local-backend", "memfs", agentId, "memory"));
+    candidates.push(path.join(home, ".letta", "agents", agentId, "memory"));
+  }
+  return candidates;
+}
+
+function findMemoryDir(): string | null {
+  for (const candidate of candidateMemoryDirs()) {
+    if (candidate && existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function scanMarkdownDir(
+  dir: string,
+  root: string,
+  out: { name: string; tokens: number }[],
+): void {
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === ".git" || entry.name === "node_modules") continue;
+      scanMarkdownDir(full, root, out);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      try {
+        const stat = statSync(full);
+        if (stat.size > MAX_FILE_BYTES) continue;
+        const content = readFileSync(full, "utf8");
+        const tokens = Math.ceil(content.length / 4);
+        const rel = path.relative(root, full);
+        out.push({ name: rel, tokens });
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+}
+
+function readMemoryBlocks(): { name: string; tokens: number }[] {
+  const dir = findMemoryDir();
+  if (!dir) return [];
+  const blocks: { name: string; tokens: number }[] = [];
+  const systemDir = path.join(dir, "system");
+  if (existsSync(systemDir)) {
+    scanMarkdownDir(systemDir, dir, blocks);
+  }
+  blocks.sort((a, b) => b.tokens - a.tokens);
+  return blocks;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function pct(used: number, max: number): number {
+  if (max <= 0) return 0;
+  return Math.min(100, Math.round((used / max) * 100));
+}
+
+function renderBar(percentage: number): string {
+  const filled = Math.round((percentage / 100) * BAR_WIDTH);
+  const empty = BAR_WIDTH - filled;
+  return `\u2588`.repeat(filled) + `\u2591`.repeat(empty);
+}
+
+function renderSparkline(history: number[]): string {
+  if (history.length < 2) return "";
+  const min = Math.min(...history);
+  const max = Math.max(...history);
+  const range = max - min || 1;
+  return history
+    .map((v) => {
+      const idx = Math.min(7, Math.max(0, Math.floor(((v - min) / range) * 8)));
+      return SPARKLINE_BLOCKS[idx];
+    })
+    .join("");
+}
+
+function statusLevel(percentage: number): { label: string; indicator: string } {
+  if (percentage < 50) return { label: "COMFORTABLE", indicator: "\u25CF" };
+  if (percentage < 75) return { label: "GETTING FULL", indicator: "\u25D0" };
+  if (percentage < 90) return { label: "WARM", indicator: "\u25D1" };
+  return { label: "CRITICAL", indicator: "\u25C9" };
+}
+
+function renderThermometer(
+  s: ThermometerState,
+  memoryBlocks: { name: string; tokens: number }[],
+): string[] {
+  const percentage = pct(s.inputTokens, s.maxTokens);
+  const remaining = Math.max(0, s.maxTokens - s.inputTokens);
+  const status = statusLevel(percentage);
+  const totalMemoryTokens = memoryBlocks.reduce((sum, b) => sum + b.tokens, 0);
+
+  const lines: string[] = [];
+  lines.push(" \u{1F321}\uFE0F  Context Thermometer");
+  lines.push("");
+  lines.push(` ${renderBar(percentage)}  ${percentage}%`);
+  lines.push("");
+
+  if (s.inputTokens > 0) {
+    lines.push(` Input:   ${formatTokens(s.inputTokens)} / ${formatTokens(s.maxTokens)} tokens`);
+    lines.push(` Output:  ${formatTokens(s.outputTokens)} tokens`);
+    if (s.peakInputTokens > s.inputTokens) {
+      lines.push(
+        ` Peak:    ${formatTokens(s.peakInputTokens)} tokens (${pct(s.peakInputTokens, s.maxTokens)}%)`,
+      );
+    }
+  } else {
+    lines.push(" Waiting for first turn...");
+    lines.push(` Max:     ${formatTokens(s.maxTokens)} tokens`);
+  }
+
+  if (s.history.length >= 2) {
+    lines.push("");
+    lines.push(` Trend:   ${renderSparkline(s.history)}`);
+  }
+
+  if (memoryBlocks.length > 0) {
+    lines.push("");
+    lines.push(" Memory Blocks:");
+    const maxBlockTokens = Math.max(...memoryBlocks.map((b) => b.tokens), 1);
+    for (const block of memoryBlocks.slice(0, 8)) {
+      const blockBar = "\u2593".repeat(
+        Math.max(1, Math.round((block.tokens / maxBlockTokens) * 12)),
+      );
+      const name =
+        block.name.length > 28
+          ? `...${block.name.slice(-25)}`
+          : block.name.padEnd(28);
+      lines.push(`   ${name} ~${formatTokens(block.tokens).padStart(5)} ${blockBar}`);
+    }
+    if (memoryBlocks.length > 8) {
+      lines.push(`   ... and ${memoryBlocks.length - 8} more`);
+    }
+    lines.push(`   ${"\u2500".repeat(40)}`);
+    lines.push(
+      `   ${"Total memory".padEnd(28)} ~${formatTokens(totalMemoryTokens).padStart(5)} tokens`,
+    );
+  }
+
+  if (s.inputTokens > 0) {
+    lines.push("");
+    lines.push(
+      ` ${status.indicator} ${status.label} \u2014 ${formatTokens(remaining)} tokens remaining`,
+    );
+  }
+
+  return lines;
+}
+
+export default function activate(letta: any) {
+  const disposers: Array<() => void> = [];
+
+  state.maxTokens = getMaxTokens();
+
+  const closePanel = () => {
+    panel?.close();
+    panel = null;
+  };
+
+  updatePanel = () => {
+    if (!letta.capabilities.ui?.panels) return;
+    if (!state.active) {
+      closePanel();
+      return;
+    }
+    const content = renderThermometer(state, readMemoryBlocks());
+    if (!panel) {
+      panel = letta.ui.openPanel({ id: "context-thermometer", order: 1_000, content });
+    } else {
+      panel.update({ content });
+    }
+  };
+
+  // Show initial panel if capable
+  if (letta.capabilities.ui?.panels) {
+    updatePanel();
+  }
+
+  if (letta.capabilities.events?.turns) {
+    disposers.push(
+      letta.events.on("turn_start", (event: any, ctx: any) => {
+        const inputTokens = Math.max(
+          0,
+          Math.floor(ctx?.contextWindow?.totalInputTokens ?? 0),
+        );
+        const outputTokens = Math.max(
+          0,
+          Math.floor(ctx?.contextWindow?.totalOutputTokens ?? 0),
+        );
+
+        if (inputTokens > 0 || outputTokens > 0) {
+          state.inputTokens = inputTokens;
+          state.outputTokens = outputTokens;
+          state.peakInputTokens = Math.max(state.peakInputTokens, inputTokens);
+          state.peakTotalTokens = Math.max(
+            state.peakTotalTokens,
+            inputTokens + outputTokens,
+          );
+          state.history = [...state.history, inputTokens].slice(-MAX_HISTORY);
+          state.lastUpdate = Date.now();
+        }
+
+        // Auto-detect max tokens from context window info if available
+        const ctxMax =
+          ctx?.contextWindow?.maxTokens ?? ctx?.contextWindow?.contextWindow;
+        if (typeof ctxMax === "number" && ctxMax > 0 && ctxMax !== state.maxTokens) {
+          state.maxTokens = ctxMax;
+        }
+
+        updatePanel();
+
+        // Critical warning injection
+        if (state.active && pct(inputTokens, state.maxTokens) >= CRITICAL_THRESHOLD) {
+          return {
+            input: [
+              {
+                role: "user",
+                content: `<system-reminder>Context window is at ${pct(inputTokens, state.maxTokens)}% capacity (${formatTokens(inputTokens)} / ${formatTokens(state.maxTokens)} tokens). Consider compacting the conversation or summarizing prior context to avoid losing important information.</system-reminder>`,
+              },
+              ...event.input,
+            ],
+          };
+        }
+      }),
+    );
+  }
+
+  if (letta.capabilities.commands) {
+    disposers.push(
+      letta.commands.register({
+        id: "context",
+        description: "Toggle context thermometer panel or show stats",
+        args: "[on|off|status|max <tokens>]",
+        run(ctx: { args: string }) {
+          const args = (ctx.args ?? "").trim().toLowerCase();
+
+          if (args === "on") {
+            state.active = true;
+            updatePanel();
+            return { type: "output" as const, output: "Context thermometer enabled." };
+          }
+
+          if (args === "off") {
+            state.active = false;
+            updatePanel();
+            return { type: "output" as const, output: "Context thermometer disabled." };
+          }
+
+          if (args.startsWith("max ")) {
+            const n = Number.parseInt(args.slice(4), 10);
+            if (Number.isFinite(n) && n > 0) {
+              state.maxTokens = n;
+              updatePanel();
+              return {
+                type: "output" as const,
+                output: `Max tokens set to ${formatTokens(n)}.`,
+              };
+            }
+            return {
+              type: "output" as const,
+              output: "Usage: /context max <tokens>",
+              success: false,
+            };
+          }
+
+          if (args === "status" || (!state.active && args === "")) {
+            const blocks = readMemoryBlocks();
+            const lines = renderThermometer(state, blocks);
+            return { type: "output" as const, output: lines.join("\n") };
+          }
+
+          // Toggle
+          state.active = !state.active;
+          updatePanel();
+          return {
+            type: "output" as const,
+            output: state.active
+              ? "Context thermometer enabled."
+              : "Context thermometer disabled.",
+          };
+        },
+      }),
+    );
+  }
+
+  if (letta.capabilities.ui?.panels) {
+    disposers.push(closePanel);
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/context-thermometer/package.json
+++ b/packages/context-thermometer/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@letta-ai/context-thermometer",
+  "version": "0.1.0",
+  "description": "Letta Code mod that visualizes context window usage as a real-time thermometer gauge panel.",
+  "author": "cameron",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "context",
+    "thermometer",
+    "gauge",
+    "context-window"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/context-thermometer"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["commands", "events.turns", "ui.panels"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A new mod that visualizes context window usage as a real-time thermometer gauge panel — filling a gap in the existing catalog where no mod provides context window observability.

### Features

- **Visual gauge** — horizontal bar showing context window fill percentage
- **Token tracking** — input, output, and peak token counts
- **Trend sparkline** — Unicode sparkline showing input token history over recent turns
- **Memory block breakdown** — per-file token estimates for all system memory blocks, read from the MemFS filesystem
- **Status indicators** — COMFORTABLE (<50%), GETTING FULL (50-75%), WARM (75-90%), CRITICAL (>90%)
- **Critical warnings** — automatically injects a system reminder when context usage exceeds 90%, suggesting compaction

### Capabilities used

- `commands` — `/context` command to toggle panel, show stats, or set max tokens
- `events.turns` — reads context window token counts on every `turn_start`
- `ui.panels` — renders the thermometer gauge as a persistent panel

### Commands

| Command | Description |
|---------|-------------|
| `/context` | Toggle the thermometer panel |
| `/context on` / `/context off` | Explicitly enable/disable |
| `/context status` | Show current stats as output |
| `/context max <tokens>` | Set max context window size |

### Configuration

- `CONTEXT_THERMOMETER_MAX_TOKENS` env var overrides the default max of 128,000 tokens
- Max tokens auto-detected from `ctx.contextWindow` when available

## Test plan

- [x] `npm run validate` passes
- [ ] Install mod and verify panel renders on first turn
- [ ] Verify `/context` toggles panel
- [ ] Verify `/context status` shows stats without panel
- [ ] Verify `/context max <tokens>` updates gauge
- [ ] Verify memory block breakdown reads from MemFS correctly
- [ ] Verify critical warning injects at >90% usage

👾 Generated with [Letta Code](https://letta.com)