### PR TITLE
fix(mods): clean up package naming and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A shared repository for Letta Code mods: trusted local code packages that let agents adapt the harness with tools, slash commands, lifecycle events, permissions, providers, and lightweight UI surfaces.
 
-Mods are meant to be easy for agents and developers to inspect, adapt, package, and share. This repository contains first-party packages, examples, and curation for the mod ecosystem.
+Mods are meant to be easy for agents and developers to inspect, adapt, package, and share. This repository contains first-party packages and curation for the mod ecosystem.
 
 > [!IMPORTANT]
 > The easiest way to use a published mod is with Letta Code:
@@ -26,7 +26,7 @@ This repository contains **mods**: modular packages of trusted local code that e
 - **UI Surfaces:** panels, status values, and statusline integrations
 
 **How it grows:**
-- First-party examples define package conventions
+- First-party packages define package conventions
 - Agents and developers adapt mods to real workflows
 - Useful local experiments graduate into reusable packages
 - Published packages are discoverable through npm metadata and the Letta Code catalog
@@ -57,7 +57,7 @@ cd mods
 npm run validate
 ```
 
-This repository is **source, examples, and curation**. It is not a package registry. The current package registry is npm; published mod packages use normal npm metadata plus a Letta-specific manifest in `package.json` under the `letta` key.
+This repository is **source, packages, and curation**. It is not a package registry. The current package registry is npm; published mod packages use normal npm metadata plus a Letta-specific manifest in `package.json` under the `letta` key.
 
 ## Repository Structure
 
@@ -124,7 +124,7 @@ Packages should use the `letta-package` keyword so they can be discovered by the
 All agents and humans are welcome to contribute useful mods and improvements.
 
 **What to contribute:**
-- **Harness Extensions:** tools, commands, events, providers, permissions, or UI surfaces that solve a real workflow problem
+- **Runtime Capabilities:** tools, commands, events, providers, permissions, or UI surfaces that solve a real workflow problem
 - **Validated Patterns:** mod structures that worked across actual usage
 - **Safety Improvements:** clearer permissions, recovery paths, or safer defaults
 - **Documentation:** better README/MOD guidance for humans and agents
@@ -161,5 +161,5 @@ npm run validate
 
 - [Letta Code](https://github.com/letta-ai/letta-code)
 - [Letta Code docs](https://docs.letta.com/letta-code)
-- [Letta Code mods catalog](https://letta-code-homepage.pages.dev/agents/mods/)
+- [Letta Code mods catalog](https://www.letta.com/agent/mods)
 - [Letta skills repository](https://github.com/letta-ai/skills)

--- a/packages/analysis-mode/README.md
+++ b/packages/analysis-mode/README.md
@@ -6,8 +6,6 @@ Analysis mode is inspired by Westworld-style host diagnostics. It suspends norma
 
 ## Install
 
-Once npm mod install support is available:
-
 ```bash
 letta install npm:@letta-ai/analysis-mode
 ```

--- a/packages/analysis-mode/package.json
+++ b/packages/analysis-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@letta-ai/analysis-mode",
   "version": "0.1.0",
-  "description": "Example Letta Code mod package that adds phrase-triggered diagnostic analysis mode.",
+  "description": "Letta Code mod package that adds phrase-triggered diagnostic analysis mode.",
   "author": "cpacker",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/goal-mode/README.md
+++ b/packages/goal-mode/README.md
@@ -6,8 +6,6 @@ Goal mode keeps a user-provided objective active across turns. The agent receive
 
 ## Install
 
-Once npm mod install support is available:
-
 ```bash
 letta install npm:@letta-ai/goal-mode
 ```
@@ -54,6 +52,6 @@ LETTA_DISABLE_MODS=1 letta
 
 ## Notes
 
-This package is based on the goal-mode bundled-extension reference from Letta Code. It is implemented as a standalone mod package, so it stores state locally instead of importing Letta Code internals.
+This package is implemented as a standalone mod package, so it stores state locally instead of importing Letta Code internals.
 
 See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/goal-mode/package.json
+++ b/packages/goal-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@letta-ai/goal-mode",
   "version": "0.1.0",
-  "description": "Example Letta Code mod package that adds goal mode with goal commands, tools, and turn reminders.",
+  "description": "Letta Code mod package that adds goal mode with goal commands, tools, and turn reminders.",
   "author": "kl2806",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pets/package.json
+++ b/packages/pets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/pets",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Letta Code terminal pets that animate based on turn and tool activity.",
   "author": "ariwebb",
   "license": "Apache-2.0",

--- a/packages/plan-mode/MOD.md
+++ b/packages/plan-mode/MOD.md
@@ -1,47 +1,47 @@
 ---
 name: "@letta-ai/plan-mode"
-description: "Example plan-mode workflow mod for Letta Code."
+description: "Plan-mode workflow mod for Letta Code."
 ---
 
 # Plan mode mod semantics
 
 ## When to use
 
-Use this mod as a reference for workflows that need to pause implementation, gather read-only context, write a plan, ask the user for approval, and only then proceed.
+Use this mod for workflows that need to pause implementation, gather read-only context, write a plan, ask the user for approval, and only then proceed.
 
-This is an example package. It uses sample-prefixed IDs and does not override built-in plan mode.
+This package provides a real plan-mode surface. It overrides `/plan` and exposes `enter_plan_mode` / `exit_plan_mode` as model-callable tools.
 
 ## Behavioral contract
 
-When sample plan mode is active, the agent should:
+When plan mode is active, the agent should:
 
 1. Explore the codebase with read-only tools.
 2. Avoid mutating files, configuration, git state, or external systems.
 3. Write the plan to the generated plan file under `~/.letta/plans/`.
 4. Present the full current plan text to the user for approval.
-5. Call `sample_exit_plan_mode` only after the user approves.
+5. Call `exit_plan_mode` only after the user approves.
 
 ## Commands
 
-### `/sample-plan`
+### `/plan`
 
-Starts sample plan mode for the current conversation.
+Starts plan mode for the current conversation.
 
 The command creates a plan session, chooses a plan file path, and injects a system reminder telling the agent how to proceed.
 
 ## Tools
 
-### `sample_enter_plan_mode`
+### `enter_plan_mode`
 
-Model-callable entrypoint for sample plan mode. Use when a non-trivial task needs explicit planning and approval before implementation.
+Model-callable entrypoint for plan mode. Use when a non-trivial task needs explicit planning and approval before implementation.
 
-### `sample_exit_plan_mode`
+### `exit_plan_mode`
 
 Model-callable exit point. Call only after the plan file has been written, the full current plan has been shown to the user, and the user has approved it.
 
 ## Turn reminders
 
-While sample plan mode is active, the mod prepends a system reminder at turn start. The reminder restates the active plan file path and the rule that only read-only exploration and plan-file writes are allowed.
+While plan mode is active, the mod prepends a system reminder at turn start. The reminder restates the active plan file path and the rule that only read-only exploration and plan-file writes are allowed.
 
 ## Permission invariants
 
@@ -59,18 +59,17 @@ It denies general coding agents, arbitrary shell mutation, package installs, com
 State is stored in:
 
 ```text
-~/.letta/mods/sample-plan-mode.state.json
+~/.letta/mods/plan-mode.state.json
 ```
 
 Plan files are written under:
 
 ```text
-~/.letta/plans/sample-*.md
+~/.letta/plans/plan-*.md
 ```
 
 ## Adaptation notes for agents
 
-- Keep the command/tool IDs sample-prefixed unless the user explicitly wants to replace built-in plan mode.
 - Do not import Letta Code internals. Use the public mod API and Node built-ins.
 - Keep permission checks conservative. If a tool cannot be confidently classified as safe, deny it while plan mode is active.
 - Keep `package.json#letta` as the source of truth for runtime capabilities. Do not duplicate capabilities in this file's frontmatter.

--- a/packages/plan-mode/README.md
+++ b/packages/plan-mode/README.md
@@ -1,47 +1,49 @@
 # Plan Mode
 
-A sample Letta Code mod package that recreates a plan-mode style workflow using public mod APIs.
+A Letta Code mod package that adds a plan-mode workflow using public mod APIs.
 
-This package is an example for developers and agents. It does not replace the built-in `/plan` command. Instead, it uses sample-prefixed IDs so you can install and inspect it safely alongside the built-in flow.
+Plan mode pauses implementation, lets the agent gather read-only context, writes an implementation plan to `~/.letta/plans/`, and asks the user to approve before coding starts.
 
 ## Install
-
-Publishing/install support is still being wired up. Once npm mod install is available, this package is intended to install with:
 
 ```bash
 letta install npm:@letta-ai/plan-mode
 ```
 
-For local development, copy or install the package through the local mod package workflow once available.
+Then reload local mods:
+
+```text
+/reload
+```
 
 ## What it adds
 
-- `/sample-plan` slash command
-- `sample_enter_plan_mode` model-callable tool
-- `sample_exit_plan_mode` model-callable tool
-- a turn reminder while sample plan mode is active
+- `/plan` slash command
+- `enter_plan_mode` model-callable tool
+- `exit_plan_mode` model-callable tool
+- a turn reminder while plan mode is active
 - a permission overlay that blocks mutating tools except plan-file writes
 
 ## Quick start
 
 ```text
-/sample-plan
+/plan
 ```
 
-The command tells the agent to explore read-only, write an implementation plan to a generated file under `~/.letta/plans/`, present the full plan for approval, and then call `sample_exit_plan_mode` after approval.
+The command tells the agent to explore read-only, write an implementation plan to a generated file under `~/.letta/plans/`, present the full plan for approval, and then call `exit_plan_mode` after approval.
 
 ## State files
 
 This mod stores small local state in:
 
 ```text
-~/.letta/mods/sample-plan-mode.state.json
+~/.letta/mods/plan-mode.state.json
 ```
 
 Generated plan files live in:
 
 ```text
-~/.letta/plans/sample-*.md
+~/.letta/plans/plan-*.md
 ```
 
 ## Safety
@@ -56,8 +58,6 @@ letta --no-mods
 LETTA_DISABLE_MODS=1 letta
 ```
 
-## Adapting this example
-
-This example intentionally uses `sample-*` command/tool IDs. If you want to turn it into a real replacement for built-in plan mode, rename the command and tools intentionally and document any overrides.
+Then remove or edit the mod package and run `/reload`.
 
 See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract and semantics.

--- a/packages/plan-mode/mods/index.ts
+++ b/packages/plan-mode/mods/index.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 
 const MODS_DIR = path.join(homedir(), ".letta", "mods");
 const PLANS_DIR = path.join(homedir(), ".letta", "plans");
-const STATE_PATH = path.join(MODS_DIR, "sample-plan-mode.state.json");
+const STATE_PATH = path.join(MODS_DIR, "plan-mode.state.json");
 const GLOBAL_CONVERSATION_ID = "__global__";
 
 const READ_ONLY_TOOL_NAMES = new Set([
@@ -41,8 +41,6 @@ const PLANNING_TOOL_NAMES = new Set([
   "askuserquestion",
   "enterplanmode",
   "exitplanmode",
-  "sampleenterplanmode",
-  "sampleexitplanmode",
   "todowrite",
   "updateplan",
   "writetodos",
@@ -108,7 +106,7 @@ function createPlanFilePath(): string {
   mkdirSync(PLANS_DIR, { recursive: true });
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const suffix = randomUUID().slice(0, 8);
-  return path.join(PLANS_DIR, `sample-${timestamp}-${suffix}.md`);
+  return path.join(PLANS_DIR, `plan-${timestamp}-${suffix}.md`);
 }
 
 function activatePlanMode(conversationId: string | null | undefined, cwd: string) {
@@ -131,14 +129,14 @@ function buildEnterPlanModeMessage(
   cwd: string,
 ): string {
   const relativePatchPath = toRelativePatchPath(cwd, session.planFilePath);
-  return `Entered sample plan mode. Focus on exploring the codebase and designing an implementation approach before making changes.
+  return `Entered plan mode. Focus on exploring the codebase and designing an implementation approach before making changes.
 
-In sample plan mode:
+In plan mode:
 1. Use direct read-only tools for exploration.
 2. Do not edit files, change configuration, install packages, commit, push, or run mutating commands.
 3. Write the implementation plan to the plan file.
 4. Read the plan file and present the full current plan text to the user for approval.
-5. After the user approves, call sample_exit_plan_mode.
+5. After the user approves, call exit_plan_mode.
 
 Plan file path: ${session.planFilePath}
 If using ApplyPatch, use this relative patch path: ${relativePatchPath}`;
@@ -150,12 +148,12 @@ function buildActiveReminder(
 ): string {
   const relativePatchPath = toRelativePatchPath(cwd, session.planFilePath);
   return `<system-reminder>
-Sample plan mode is active. Do not execute the implementation yet. You may use read-only tools for exploration and may write only to the active plan file or another markdown file under ~/.letta/plans/.
+Plan mode is active. Do not execute the implementation yet. You may use read-only tools for exploration and may write only to the active plan file or another markdown file under ~/.letta/plans/.
 
 Active plan file: ${session.planFilePath}
 If using ApplyPatch, use this relative patch path: ${relativePatchPath}
 
-When the plan is complete, read the plan file and present the full current plan text to the user for approval. If the user approves, call sample_exit_plan_mode before making any implementation changes.
+When the plan is complete, read the plan file and present the full current plan text to the user for approval. If the user approves, call exit_plan_mode before making any implementation changes.
 </system-reminder>`;
 }
 
@@ -258,8 +256,9 @@ export default function activate(letta) {
   if (letta.capabilities.commands) {
     disposers.push(
       letta.commands.register({
-        id: "sample-plan",
-        description: "Enter sample plan mode",
+        id: "plan",
+        description: "Enter plan mode",
+        override: true,
         run(ctx) {
           const session = activatePlanMode(ctx.conversation.id, ctx.cwd);
           return {
@@ -275,9 +274,9 @@ export default function activate(letta) {
   if (letta.capabilities.tools) {
     disposers.push(
       letta.tools.register({
-        name: "sample_enter_plan_mode",
+        name: "enter_plan_mode",
         description:
-          "Enter sample plan mode before a non-trivial task that needs read-only exploration and user approval before implementation.",
+          "Enter plan mode before a non-trivial task that needs read-only exploration and user approval before implementation.",
         parameters: { type: "object", properties: {}, additionalProperties: false },
         requiresApproval: true,
         parallelSafe: false,
@@ -290,25 +289,25 @@ export default function activate(letta) {
 
     disposers.push(
       letta.tools.register({
-        name: "sample_exit_plan_mode",
+        name: "exit_plan_mode",
         description:
-          "Exit sample plan mode only after the plan file has been written, the full current plan text has been presented to the user, and the user has approved it.",
+          "Exit plan mode only after the plan file has been written, the full current plan text has been presented to the user, and the user has approved it.",
         parameters: { type: "object", properties: {}, additionalProperties: false },
         approvalPolicy: "alwaysAsk",
         parallelSafe: false,
         run(ctx) {
           const session = getSession(ctx.conversation.id);
           if (!session) {
-            return { status: "error", content: "Sample plan mode is not active for this conversation." };
+            return { status: "error", content: "Plan mode is not active for this conversation." };
           }
           if (!existsSync(session.planFilePath) || statSync(session.planFilePath).size === 0) {
             return {
               status: "error",
-              content: `Write the plan before exiting sample plan mode. Plan file: ${session.planFilePath}`,
+              content: `Write the plan before exiting plan mode. Plan file: ${session.planFilePath}`,
             };
           }
           clearSession(ctx.conversation.id);
-          return "Sample plan mode exited. The user has approved the plan, so implementation can begin.";
+          return "Plan mode exited. The user has approved the plan, so implementation can begin.";
         },
       }),
     );
@@ -332,9 +331,9 @@ export default function activate(letta) {
   if (letta.capabilities.permissions) {
     disposers.push(
       letta.permissions.register({
-        id: "sample-plan-mode",
+        id: "plan-mode",
         description:
-          "Allow read-only tools and writes only to ~/.letta/plans/*.md while sample plan mode is active.",
+          "Allow read-only tools and writes only to ~/.letta/plans/*.md while plan mode is active.",
         check(event) {
           const session = getSession(event.conversationId);
           if (!session) return;
@@ -355,8 +354,8 @@ export default function activate(letta) {
           return {
             decision: "deny",
             reason:
-              `Sample plan mode is active. Use read-only tools, planning tools, or writes only to markdown files under ${PLANS_DIR}. ` +
-              `Active plan file: ${session.planFilePath}. Call sample_exit_plan_mode only after the user approves the full plan.`,
+              `Plan mode is active. Use read-only tools, planning tools, or writes only to markdown files under ${PLANS_DIR}. ` +
+              `Active plan file: ${session.planFilePath}. Call exit_plan_mode only after the user approves the full plan.`,
           };
         },
       }),

--- a/packages/plan-mode/package.json
+++ b/packages/plan-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@letta-ai/plan-mode",
-  "version": "0.1.0",
-  "description": "Example Letta Code mod package that recreates a plan-mode style workflow.",
+  "version": "0.1.1",
+  "description": "Letta Code mod package that adds plan mode.",
   "author": "carenthomas",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/spotify-statusline/README.md
+++ b/packages/spotify-statusline/README.md
@@ -8,8 +8,6 @@ A Letta Code statusline mod that shows the currently playing Spotify track on ma
 
 ## Install
 
-Once npm mod install support is available:
-
 ```bash
 letta install npm:@letta-ai/spotify-statusline
 ```

--- a/packages/user-timestamps/README.md
+++ b/packages/user-timestamps/README.md
@@ -6,8 +6,6 @@ This helps agents answer time-sensitive questions and reason about current time 
 
 ## Install
 
-Once npm mod install support is available:
-
 ```bash
 letta install npm:@letta-ai/user-timestamps
 ```


### PR DESCRIPTION
## Summary
- Promote `@letta-ai/plan-mode` from sample/demo naming to the production `/plan`, `enter_plan_mode`, and `exit_plan_mode` surfaces
- Rename plan-mode local state/plan artifacts from `sample-*` to `plan-*`
- Bump `@letta-ai/plan-mode` and `@letta-ai/pets` to `0.1.1` for republishing
- Clean up repo/package wording that agents may copy: remove stale “example” framing, old install caveats, bundled-extension terminology, and the old mods catalog URL

## Test plan
- [x] `npm run validate`
- [x] `for f in packages/*/mods/*; do case "$f" in *.ts|*.tsx|*.js|*.mjs) bun --check "$f" ;; esac; done`
- [x] `cd packages/plan-mode && npm pack --dry-run`
- [x] `cd packages/pets && npm pack --dry-run`
