### PR TITLE
fix(spotify-statusline): migrate to panel statusline API

### DIFF
--- a/packages/spotify-statusline/MOD.md
+++ b/packages/spotify-statusline/MOD.md
@@ -17,6 +17,7 @@ Use this mod when the user wants Letta Code's idle statusline to show the curren
 - Wraps the playing track in an OSC 8 hyperlink to the native `spotify:track:<id>` URI so supported terminals can click to jump to the track.
 - Shows `🎧 paused` when Spotify is paused.
 - Clears the Spotify segment when Spotify is stopped, closed, or unavailable.
+- Registers an order-0 panel, replacing the built-in agent/model line while idle.
 - Renders the agent name and model on the right so the statusline remains useful when no track is active.
 
 ## Platform assumptions
@@ -27,11 +28,11 @@ This mod is macOS-specific because it uses AppleScript via `osascript` to query 
 
 - Renderer stays synchronous.
 - Shelling happens only in the setup interval, never during render.
-- Timers and status values are cleaned up when the mod is disposed.
-- Optional UI APIs are capability-guarded.
+- The polling timer and statusline panel are cleaned up when the mod is disposed.
+- Panel UI APIs are capability-guarded.
 
 ## Adaptation notes for agents
 
 - Preserve the `application "Spotify" is running` guard; without it, AppleScript can launch Spotify just to query state.
 - Keep polling lightweight. The default refresh interval is 5 seconds.
-- If composing with other statusline data, remember the custom statusline owns the full idle row.
+- If composing with other statusline data, remember an order-0 panel owns the full idle row.

--- a/packages/spotify-statusline/README.md
+++ b/packages/spotify-statusline/README.md
@@ -22,7 +22,7 @@ Then reload local mods:
 
 - macOS Spotify now-playing statusline segment
 - paused-state indicator
-- fallback right-side agent/model display
+- panel-based primary statusline with fallback right-side agent/model display
 
 ## Behavior
 
@@ -36,7 +36,7 @@ Then reload local mods:
 
 - macOS
 - Spotify desktop app
-- Letta Code with custom statusline mod support
+- Letta Code `>=0.27.18` with panel-based statusline support
 
 ## Safety
 

--- a/packages/spotify-statusline/mods/index.tsx
+++ b/packages/spotify-statusline/mods/index.tsx
@@ -6,13 +6,17 @@ const REFRESH_MS = 5_000;
 const OSC = "\u001B]8;;";
 const ST = "\u001B\\";
 
+type SpotifyStatus =
+  | { state: "playing"; href: string; track: string }
+  | { state: "paused" }
+  | { state: "stopped" };
+
 function terminalLink(label: string, href: string) {
   return `${OSC}${href}${ST}${label}${OSC}${ST}`;
 }
 
-async function updateSpotify(letta: any) {
-  try {
-    const script = `
+async function readSpotifyStatus(): Promise<SpotifyStatus> {
+  const script = `
 if application "Spotify" is running then
   tell application "Spotify"
     set playerState to player state as string
@@ -31,54 +35,61 @@ else
   return "stopped|"
 end if
 `;
-    const { stdout } = await execFileAsync("osascript", ["-e", script], { timeout: 1_500 });
-    const [state, track = "", href = ""] = stdout.trim().split("|", 3);
+  const { stdout } = await execFileAsync("osascript", ["-e", script], {
+    timeout: 1_500,
+  });
+  const [state, track = "", href = ""] = stdout.trim().split("|", 3);
 
-    if (state === "playing" && track.trim()) {
-      const label = `🎧 ${track.trim()}`;
-      letta.ui.setStatus("spotify", href.trim() ? terminalLink(label, href.trim()) : label);
-    } else if (state === "paused") {
-      letta.ui.setStatus("spotify", "🎧 paused");
-    } else {
-      letta.ui.clearStatus("spotify");
-    }
-  } catch {
-    letta.ui.clearStatus("spotify");
+  if (state === "playing" && track.trim()) {
+    return { state: "playing", href: href.trim(), track: track.trim() };
   }
+  if (state === "paused") return { state: "paused" };
+  return { state: "stopped" };
+}
+
+function spotifyLabel(status: SpotifyStatus): string {
+  if (status.state === "playing") {
+    const label = `🎧 ${status.track}`;
+    return status.href ? terminalLink(label, status.href) : label;
+  }
+  if (status.state === "paused") return "🎧 paused";
+  return "";
 }
 
 export default function activate(letta: any) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui?.panels) return;
+
+  let spotifyStatus: SpotifyStatus = { state: "stopped" };
+
+  const panel = letta.ui.openPanel({
+    id: "spotify-statusline",
+    order: 0,
+    render({ width, agent, model, row, chalk }: any) {
+      const left = spotifyLabel(spotifyStatus);
+      const right = `${chalk.hex("#8b5cf6")(agent.name ?? "Letta")}${chalk.dim(
+        ` · ${model.displayName ?? model.id ?? "unknown"}`,
+      )}`;
+      return row(left ? chalk.hex("#1DB954")(left) : "", right, width);
+    },
+  });
 
   const update = () => {
-    if (!letta.capabilities.ui.statusValues) return;
-    void updateSpotify(letta);
+    void readSpotifyStatus()
+      .then((status) => {
+        spotifyStatus = status;
+        panel.update();
+      })
+      .catch(() => {
+        spotifyStatus = { state: "stopped" };
+        panel.update();
+      });
   };
-
-  letta.ui.setStatuslineRenderer((context: any) => {
-    const { Box, Text } = context.components;
-    const model = context.model.displayName ?? context.model.id ?? "unknown";
-
-    return (
-      <Box flexDirection="row" marginBottom={1}>
-        <Box flexGrow={1} paddingRight={1}>
-          {context.statuses.spotify ? <Text color="#1DB954">{context.statuses.spotify}</Text> : null}
-        </Box>
-        <Text>
-          <Text color="#8b5cf6">{context.agent.name ?? "Letta"}</Text>
-          <Text dimColor>{` · ${model}`}</Text>
-        </Text>
-      </Box>
-    );
-  });
 
   update();
   const timer = setInterval(update, REFRESH_MS);
 
   return () => {
     clearInterval(timer);
-    if (letta.capabilities.ui.statusValues) {
-      letta.ui.clearStatus("spotify");
-    }
+    panel.close();
   };
 }

--- a/packages/spotify-statusline/package.json
+++ b/packages/spotify-statusline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/spotify-statusline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Letta Code statusline mod that shows the currently playing Spotify track on macOS.",
   "author": "kianjones9",
   "license": "Apache-2.0",
@@ -25,9 +25,9 @@
   "letta": {
     "manifestVersion": 1,
     "mods": ["./mods/index.tsx"],
-    "capabilities": ["ui.statusline", "ui.statusValues"],
+    "capabilities": ["ui.panels"],
     "engines": {
-      "lettaCodeCli": ">=0.27.14"
+      "lettaCodeCli": ">=0.27.18"
     }
   }
 }


### PR DESCRIPTION
## Summary
- migrate `@letta-ai/spotify-statusline` from removed statusline/status value APIs to `letta.ui.openPanel({ order: 0, render })`
- keep Spotify polling outside the render path and trigger panel refreshes when state changes
- bump package version to `0.1.1`
- require Letta Code `>=0.27.18`, one version past the current released `0.27.17`, because the panel statusline changes are not released yet
- update README/MOD docs for the panel-based statusline behavior

## Test plan
- [x] `bun --check packages/spotify-statusline/mods/index.tsx`
- [x] `npm run validate`
- [x] `cd packages/spotify-statusline && npm pack --dry-run`