### PR TITLE
Migrate git-status from deprecated statusValues to ui.panels

### DIFF
--- a/packages/git-status/MOD.md
+++ b/packages/git-status/MOD.md
@@ -17,10 +17,9 @@ a replacement for existing git UI.
 - Polls `git` outside the render path on a fixed interval (default 4 seconds).
 - Runs a single read-only command per poll: `git status --porcelain=v2 --branch
   --untracked-files=all`, plus a `rev-parse --is-inside-work-tree` guard.
-- Reads the live working directory from the statusline render context (`ModContext.cwd`),
-  captured at render time, so polling follows the session's current directory rather than
-  the launch directory. The host `letta` object does not expose a workspace. Falls back to
-  `process.cwd()` until the first render.
+- Tracks the live working directory via `turn_start` events (`context.cwd`), so polling
+  follows the session's current directory rather than the launch directory. Falls back to
+  `process.cwd()` until the first turn.
 - Branch: from `# branch.head`; shows a short SHA (from `# branch.oid`) when detached.
   Long names are truncated to 22 chars with a trailing `…` to avoid overflowing the row.
 - Ahead/behind: from `# branch.ab +A -B`; rendered as `↑A ↓B`, only when an upstream
@@ -43,8 +42,8 @@ Uses `windowsHide` so no console window flashes on Windows.
 - Renderer stays synchronous; all shelling happens in the poll interval.
 - Only read-only git commands are run; the mod never mutates the repository.
 - Git invocations use a short timeout and swallow errors, degrading to a cleared segment.
-- Timers and status values are cleaned up when the mod is disposed.
-- Optional UI APIs are capability-guarded (`ui.customStatuslineRenderer`, `ui.statusValues`).
+- Timers and panels are cleaned up when the mod is disposed.
+- Optional UI APIs are capability-guarded (`ui.panels`).
 
 ## Adaptation notes for agents
 

--- a/packages/git-status/mods/index.tsx
+++ b/packages/git-status/mods/index.tsx
@@ -165,18 +165,22 @@ function formatSegment(state: GitState): string {
 }
 
 export default function activate(letta: any) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui.panels) return;
 
   let latest: GitState | null = null;
-  // The live working directory is provided by the statusline render context
-  // (ModContext.cwd), which tracks the session's current directory. The host
-  // `letta` object does not expose a workspace, so we capture cwd at render
-  // time and let the poll loop read the latest value.
   let currentCwd = process.cwd();
 
-  const update = async () => {
-    if (!letta.capabilities.ui.statusValues) return;
+  // Track the live working directory from turn_start events so polling
+  // follows the session's current directory rather than the launch directory.
+  if (letta.capabilities.events?.turns) {
+    letta.events.on("turn_start", (_event: any, context: any) => {
+      if (typeof context.cwd === "string" && context.cwd) {
+        currentCwd = context.cwd;
+      }
+    });
+  }
 
+  const update = async () => {
     let state: GitState | null = null;
     try {
       state = await readGitState(currentCwd);
@@ -185,45 +189,22 @@ export default function activate(letta: any) {
     }
 
     latest = state;
-    if (!state) {
-      letta.ui.clearStatus("git");
-      return;
-    }
-
-    letta.ui.setStatus("git", formatSegment(state));
+    panel.update();
   };
 
-  letta.ui.setStatuslineRenderer((context: any) => {
-    const { Box, Text } = context.components;
-    const model = context.model.displayName ?? context.model.id ?? "unknown";
-
-    // Track the live cwd from the render context so polling follows the
-    // session's current directory rather than the launch directory.
-    if (typeof context.cwd === "string" && context.cwd) {
-      currentCwd = context.cwd;
-    }
-
-    const dirty =
-      !!latest &&
-      latest.added + latest.modified + latest.deleted > 0;
-
-    return (
-      <Box justifyContent="space-between" width="100%">
-        <Box>
-          {context.statuses.git ? (
-            <Text color={dirty ? "yellow" : "green"}>
-              {context.statuses.git}
-            </Text>
-          ) : null}
-        </Box>
-        <Box>
-          <Text dimColor>
-            {context.agent.name ?? "Letta"}
-            {` · ${model}`}
-          </Text>
-        </Box>
-      </Box>
-    );
+  const panel = letta.ui.openPanel({
+    id: "git-status",
+    order: 0,
+    render({ width, agent, model, row, chalk }: any) {
+      const left = latest ? formatSegment(latest) : "";
+      const dirty =
+        !!latest && latest.added + latest.modified + latest.deleted > 0;
+      const coloredLeft = left
+        ? (dirty ? chalk.yellow : chalk.green)(left)
+        : "";
+      const right = `${chalk.dim(agent.name ?? "Letta")} · ${chalk.dim(model.displayName ?? model.id ?? "unknown")}`;
+      return row(coloredLeft, right, width);
+    },
   });
 
   void update();
@@ -231,8 +212,6 @@ export default function activate(letta: any) {
 
   return () => {
     clearInterval(timer);
-    if (letta.capabilities.ui.statusValues) {
-      letta.ui.clearStatus("git");
-    }
+    panel.close();
   };
 }

--- a/packages/git-status/package.json
+++ b/packages/git-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/git-status",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Letta Code statusline mod that shows the current git branch, dirty/clean state, file counts, and ahead/behind.",
   "author": "christinatong",
   "license": "Apache-2.0",
@@ -25,9 +25,9 @@
   "letta": {
     "manifestVersion": 1,
     "mods": ["./mods/index.tsx"],
-    "capabilities": ["ui.statusline", "ui.statusValues"],
+    "capabilities": ["ui.panels", "events.turns"],
     "engines": {
-      "lettaCodeCli": ">=0.27.14"
+      "lettaCodeCli": ">=0.27.18"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace setStatuslineRenderer/setStatus/clearStatus with openPanel using order: 0 (statusline slot)
- Track cwd via turn_start events instead of the statusline render context (which panels don't have)
- Bump version to 0.2.0, capabilities to ui.panels + events.turns, engine to >=0.27.18

## Test plan
- [ ] Install the mod and verify git status shows in the statusline
- [ ] Verify branch name, ahead/behind, and file counts render correctly
- [ ] Verify color changes (green clean, yellow dirty)
- [ ] cd into a different git repo and confirm the statusline updates

Co-Authored-By: Letta Code <noreply@letta.com>