### PR TITLE
fix: remove timeZoneName from toLocaleString options

### DIFF
--- a/packages/user-timestamps/mods/index.ts
+++ b/packages/user-timestamps/mods/index.ts
@@ -7,7 +7,6 @@ function timestampMetadata(date = new Date()) {
     local: date.toLocaleString(undefined, {
       dateStyle: "full",
       timeStyle: "long",
-      timeZoneName: "short",
     }),
     timeZone,
   };


### PR DESCRIPTION
## Summary

- Removed `timeZoneName: "short"` from `toLocaleString` options in `user-timestamps` mod
- `dateStyle` and `timeStyle` cannot be combined with other `DateTimeFormat` options per the ECMAScript spec (ECMA-402). This causes a `TypeError: dateStyle and timeStyle may not be used with other DateTimeFormat options` on Node.js 22, crashing the `turn_start` event handler on every user message.
- `timeStyle: "long"` already includes the timezone abbreviation (e.g. "HST"), so `timeZoneName` is redundant.

## Test plan

- [x] Installed mod on Node.js 22 (Letta Code 0.27.18) — confirmed crash before fix
- [x] Applied fix — confirmed `<user_timestamp>` blocks appear correctly with timezone info intact

```js
// Before (crashes on Node 22)
date.toLocaleString(undefined, {
  dateStyle: "full",
  timeStyle: "long",
  timeZoneName: "short",  // ← TypeError
})

// After (works)
date.toLocaleString(undefined, {
  dateStyle: "full",
  timeStyle: "long",
})
// Output: "Friday, June 26, 2026 at 7:11:22 PM HST"
```

👾 Generated with [Letta Code](https://letta.com)