### PR TITLE
feat: add tool-guard-inspector mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ packages/
 ├── memfs-search/         # Agent-callable MemFS memory search
 ├── plan-mode/            # Plan-mode style workflow
 ├── spotify-statusline/   # macOS Spotify now-playing statusline
+├── tool-guard-inspector/ # Tool permission audit log and slash command
 ├── user-timestamps/      # Adds local timestamp metadata to user messages
 └── web-search/           # Provider-backed web search tools
 
@@ -88,6 +89,7 @@ scripts/
 - **memfs-search** - Agent-callable MemFS memory search with optional QMD semantic/hybrid search
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
 - **spotify-statusline** - macOS Spotify now-playing statusline
+- **tool-guard-inspector** - Tool permission audit log using a lightweight permission policy and slash command
 - **user-timestamps** - Adds local timestamp metadata to every user message
 - **web-search** - Provider-backed web search tools using agent-scoped secrets
 

--- a/packages/tool-guard-inspector/MOD.md
+++ b/packages/tool-guard-inspector/MOD.md
@@ -1,0 +1,69 @@
+---
+name: "@letta-ai/tool-guard-inspector"
+description: "Tool permission audit mod for Letta Code."
+---
+
+# Tool Guard Inspector mod semantics
+
+## When to use
+
+Use this mod when the user wants lightweight visibility into tool permission decisions made by a local Letta Code mod.
+
+The mod is useful for debugging tool-use behavior, surfacing potentially risky tool calls, and reducing silent failures where a tool action appears to proceed without the user noticing whether it was allowed, asked, or denied.
+
+## Behavioral contract
+
+This package registers a permission policy and a slash command.
+
+The permission policy classifies tool calls into:
+
+- `allow` for common read-only tools and simple read-only shell commands
+- `ask` for ambiguous shell commands, file mutation tools, and delegated agent/task tools
+- `deny` for dangerous shell patterns such as destructive deletion, package installation, git pushes/commits/resets, and `curl | sh`
+
+Unknown tools are allowed and logged as `unclassified tool; observe only` to avoid over-blocking unfamiliar tool surfaces.
+
+## Commands
+
+### `/tool-guard`
+
+Shows recent in-memory audit entries for the current conversation.
+
+### `/tool-guard 25`
+
+Shows up to 25 recent entries.
+
+### `/tool-guard all`
+
+Shows recent entries across conversations in the current process.
+
+### `/tool-guard clear`
+
+Clears audit entries for the current conversation.
+
+### `/tool-guard all clear`
+
+Clears all in-memory audit entries.
+
+## State
+
+The audit log is in memory only.
+
+It stores up to 50 recent entries and is reset when Letta Code exits or reloads the mod. This is intentional for the first version: the mod is an inspector, not a persistent compliance log.
+
+## Permission invariants
+
+The mod should be transparent about its scope:
+
+- It records decisions made by this mod's own permission policy.
+- It does not claim to observe every permission decision from Letta Code or from other mods.
+- It avoids blocking unknown tools by default.
+- It keeps shell classification conservative.
+
+## Adaptation notes for agents
+
+- Do not import Letta Code internals. Use public mod APIs and standard JavaScript.
+- Keep the rule table small and inspectable.
+- Prefer `ask` over `deny` when a command is ambiguous but not clearly dangerous.
+- Keep README language accurate: this is an in-session audit view, not a persistent security log.
+- Keep `package.json#letta` as the source of truth for runtime capabilities.

--- a/packages/tool-guard-inspector/README.md
+++ b/packages/tool-guard-inspector/README.md
@@ -1,0 +1,103 @@
+# Tool Guard Inspector
+
+A Letta Code mod that adds a lightweight permission policy and an in-session audit view for tool calls.
+
+It classifies selected tool calls as `allow`, `ask`, or `deny`, records the decisions made by this mod, and exposes a `/tool-guard` command for inspecting recent decisions.
+
+## Install
+
+```bash
+letta install npm:@letta-ai/tool-guard-inspector
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## What it adds
+
+- a permission policy for common read, shell, mutation, and delegation tools
+- an in-memory audit log of recent decisions made by this mod
+- a `/tool-guard` slash command for viewing recent decisions and stats
+
+## Quick start
+
+After installing the mod, run normal agent tasks that use tools. Then inspect the recent permission decisions:
+
+```text
+/tool-guard
+```
+
+Show more entries:
+
+```text
+/tool-guard 25
+```
+
+Show all in-memory entries across conversations:
+
+```text
+/tool-guard all
+```
+
+Clear the current conversation's entries:
+
+```text
+/tool-guard clear
+```
+
+Clear all in-memory entries:
+
+```text
+/tool-guard all clear
+```
+
+## Example output
+
+```text
+Tool Guard Inspector
+
+Recent permission decisions:
+✓ 14:03:12  read_file  allow  read-only tool | path=README.md
+✓ 14:04:21  bash       allow  read-only shell command | command=git status
+⚠ 14:05:10  edit       ask    file mutation tool | path=src/index.ts
+✗ 14:06:33  bash       deny   dangerous shell command pattern | command=rm -rf dist
+
+Stats: allowed: 8 | asked: 2 | denied: 1
+Scope: current conversation. Use /tool-guard all to include all in-memory entries.
+```
+
+## Policy behavior
+
+The default policy is intentionally conservative:
+
+- common read/search tools are allowed
+- simple read-only shell commands such as `git status`, `git diff`, `ls`, `cat`, and `rg` are allowed
+- chained, piped, redirected, or shell-expanded commands ask for confirmation, even when the visible command looks read-only
+- file mutation tools ask for confirmation
+- dangerous shell patterns such as `rm -rf`, package installs, git pushes/commits/resets, and `curl | sh` are denied
+- unknown tools are allowed and logged as `unclassified tool; observe only`
+
+This mod only records decisions made by its own permission policy. It does not claim to audit every permission decision made by Letta Code or by other mods.
+
+## State
+
+The audit log is in memory only and stores the latest 50 entries. It is cleared when the Letta Code process exits or reloads the mod.
+
+## Safety
+
+Mods are trusted local code. Review the source before installing third-party mods.
+
+If a mod breaks startup or command handling, recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+Then remove or edit the mod package and run `/reload`.
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavior and adaptation notes.

--- a/packages/tool-guard-inspector/mods/index.mjs
+++ b/packages/tool-guard-inspector/mods/index.mjs
@@ -1,0 +1,359 @@
+const MAX_AUDIT_ENTRIES = 50;
+
+const READ_ONLY_TOOL_NAMES = new Set([
+  "glob",
+  "globgemini",
+  "grep",
+  "grepfiles",
+  "list",
+  "listdir",
+  "listdirectory",
+  "ls",
+  "notebookread",
+  "read",
+  "readfile",
+  "readfilegemini",
+  "readlsp",
+  "readmanyfiles",
+  "search",
+  "searchfilecontent",
+  "searchfiles",
+  "viewimage",
+  "webfetch",
+  "fetchwebpage",
+  "websearch",
+]);
+
+const MUTATING_TOOL_NAMES = new Set([
+  "applypatch",
+  "edit",
+  "multiedit",
+  "notebookedit",
+  "patch",
+  "write",
+  "writefile",
+]);
+
+const SHELL_TOOL_NAMES = new Set([
+  "bash",
+  "exec",
+  "execcommand",
+  "runcommand",
+  "shell",
+  "terminal",
+]);
+
+const DELEGATION_TOOL_NAMES = new Set(["agent", "task", "subagent"]);
+
+const READ_ONLY_SHELL_PATTERNS = [
+  /^(pwd|ls|cat|head|tail|wc)(\s|$)/,
+  /^sed\s+-n\s+/,
+  /^git\s+(status|diff|log|show|rev-parse|branch)(\s|$)/,
+  /^rg\s+/,
+  /^find\s+[^;|&<>`]*$/,
+];
+
+const DANGEROUS_SHELL_PATTERNS = [
+  /\brm\s+(-[a-zA-Z]*[rf][a-zA-Z]*|--recursive|--force)\b/,
+  /\b(git\s+(push|commit|reset|clean|rebase|merge)|gh\s+pr\s+merge)\b/,
+  /\b(npm|pnpm|yarn|bun)\s+(install|add|remove|update|upgrade)\b/,
+  /\b(curl|wget)\b.*\|\s*(sh|bash)\b/,
+  /\bchmod\s+(\+x|[0-7]{3,4})\b/,
+];
+
+const MUTATING_SHELL_PATTERNS = [
+  /\b(mv|cp|mkdir|touch|tee)\b/,
+  /\b(git\s+(add|checkout|switch|restore|tag))\b/,
+  /\b(pip|uv|poetry)\s+(install|add|remove|update)\b/,
+];
+
+const auditLog = [];
+
+function normalizeName(value) {
+  return String(value ?? "").replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function nowIsoTime() {
+  return new Date().toISOString();
+}
+
+function truncate(value, maxLength = 120) {
+  const text = String(value ?? "");
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function extractCommand(args) {
+  if (!args || typeof args !== "object") return "";
+  return String(args.command ?? args.cmd ?? args.input ?? args.script ?? "");
+}
+
+function summarizeArgs(args) {
+  if (!args || typeof args !== "object") return "";
+  const command = extractCommand(args);
+  if (command.trim()) return `command=${truncate(command.trim(), 100)}`;
+
+  const pathValue =
+    args.file_path ??
+    args.path ??
+    args.notebook_path ??
+    args.cwd ??
+    args.workingDirectory;
+  if (typeof pathValue === "string" && pathValue.trim()) {
+    return `path=${truncate(pathValue.trim(), 100)}`;
+  }
+
+  const keys = Object.keys(args).slice(0, 6);
+  return keys.length ? `args=${keys.join(",")}` : "";
+}
+
+function classifyShellCommand(command) {
+  const trimmed = String(command ?? "").trim();
+
+  if (!trimmed) {
+    return {
+      decision: "ask",
+      category: "shell",
+      reason: "empty shell command",
+    };
+  }
+
+  if (DANGEROUS_SHELL_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+    return {
+      decision: "deny",
+      category: "shell",
+      reason: "dangerous shell command pattern",
+    };
+  }
+
+  if (/[|;&<>`\n]/.test(trimmed) || trimmed.includes("$(") || trimmed.includes("${")) {
+    return {
+      decision: "ask",
+      category: "shell",
+      reason: "chained, piped, redirected, or expanded shell command",
+    };
+  }
+
+  if (READ_ONLY_SHELL_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+    return {
+      decision: "allow",
+      category: "shell",
+      reason: "read-only shell command",
+    };
+  }
+
+  if (MUTATING_SHELL_PATTERNS.some((pattern) => pattern.test(trimmed))) {
+    return {
+      decision: "ask",
+      category: "shell",
+      reason: "potentially mutating shell command",
+    };
+  }
+
+  return {
+    decision: "ask",
+    category: "shell",
+    reason: "unclassified shell command",
+  };
+}
+
+function classifyToolCall(event) {
+  const toolName = String(event?.toolName ?? "unknown");
+  const normalized = normalizeName(toolName);
+  const args = event?.args ?? {};
+
+  if (READ_ONLY_TOOL_NAMES.has(normalized)) {
+    return {
+      toolName,
+      decision: "allow",
+      category: "read-only",
+      reason: "read-only tool",
+    };
+  }
+
+  if (SHELL_TOOL_NAMES.has(normalized)) {
+    return {
+      toolName,
+      ...classifyShellCommand(extractCommand(args)),
+    };
+  }
+
+  if (MUTATING_TOOL_NAMES.has(normalized)) {
+    return {
+      toolName,
+      decision: "ask",
+      category: "mutation",
+      reason: "file mutation tool",
+    };
+  }
+
+  if (DELEGATION_TOOL_NAMES.has(normalized)) {
+    return {
+      toolName,
+      decision: "ask",
+      category: "delegation",
+      reason: "delegated agent or task",
+    };
+  }
+
+  return {
+    toolName,
+    decision: "allow",
+    category: "unknown",
+    reason: "unclassified tool; observe only",
+  };
+}
+
+function pushAudit(event, result) {
+  auditLog.push({
+    at: nowIsoTime(),
+    conversationId: String(event?.conversationId ?? "__global__"),
+    toolName: result.toolName,
+    decision: result.decision,
+    category: result.category,
+    reason: result.reason,
+    summary: summarizeArgs(event?.args),
+  });
+
+  while (auditLog.length > MAX_AUDIT_ENTRIES) auditLog.shift();
+}
+
+function iconForDecision(decision) {
+  if (decision === "allow") return "✓";
+  if (decision === "ask") return "⚠";
+  if (decision === "deny") return "✗";
+  return "·";
+}
+
+function formatTime(iso) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleTimeString(undefined, { hour12: false });
+}
+
+function entriesForConversation(conversationId, includeAll) {
+  if (includeAll || !conversationId) return auditLog;
+  return auditLog.filter((entry) => entry.conversationId === conversationId);
+}
+
+function renderStats(entries) {
+  const stats = entries.reduce(
+    (acc, entry) => {
+      acc[entry.decision] = (acc[entry.decision] ?? 0) + 1;
+      return acc;
+    },
+    { allow: 0, ask: 0, deny: 0 },
+  );
+
+  return `allowed: ${stats.allow ?? 0} | asked: ${stats.ask ?? 0} | denied: ${stats.deny ?? 0}`;
+}
+
+function renderAuditLog({ conversationId, includeAll = false, limit = 12 } = {}) {
+  const entries = entriesForConversation(conversationId, includeAll).slice(-limit).reverse();
+
+  if (entries.length === 0) {
+    return [
+      "Tool Guard Inspector",
+      "",
+      "No tool permission checks have been recorded yet.",
+      "Run a tool call, then use /tool-guard again.",
+    ].join("\n");
+  }
+
+  const lines = [
+    "Tool Guard Inspector",
+    "",
+    "Recent permission decisions:",
+    ...entries.map((entry) => {
+      const detail = entry.summary ? ` | ${entry.summary}` : "";
+      return `${iconForDecision(entry.decision)} ${formatTime(entry.at)}  ${entry.toolName}  ${entry.decision}  ${entry.reason}${detail}`;
+    }),
+    "",
+    `Stats: ${renderStats(entriesForConversation(conversationId, includeAll))}`,
+  ];
+
+  if (!includeAll) {
+    lines.push("Scope: current conversation. Use /tool-guard all to include all in-memory entries.");
+  }
+
+  return lines.join("\n");
+}
+
+function parseCommandArgs(args) {
+  const parts = String(args ?? "").trim().split(/\s+/).filter(Boolean);
+  const includeAll = parts.includes("all");
+  const clear = parts.includes("clear");
+  const numericLimit = parts.map((part) => Number.parseInt(part, 10)).find((value) => Number.isFinite(value));
+  const limit = numericLimit && numericLimit > 0 ? Math.min(numericLimit, MAX_AUDIT_ENTRIES) : 12;
+  return { includeAll, clear, limit };
+}
+
+function clearEntries(conversationId, includeAll) {
+  if (includeAll || !conversationId) {
+    const count = auditLog.length;
+    auditLog.length = 0;
+    return count;
+  }
+
+  let removed = 0;
+  for (let i = auditLog.length - 1; i >= 0; i -= 1) {
+    if (auditLog[i].conversationId === conversationId) {
+      auditLog.splice(i, 1);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+export default function activate(letta) {
+  const disposers = [];
+
+  if (letta.capabilities?.permissions) {
+    disposers.push(
+      letta.permissions.register({
+        id: "tool-guard-inspector",
+        description:
+          "Classify selected tool calls as allow/ask/deny and keep an in-session audit log.",
+        check(event) {
+          const result = classifyToolCall(event);
+          pushAudit(event, result);
+          return {
+            decision: result.decision,
+            reason: result.reason,
+          };
+        },
+      }),
+    );
+  }
+
+  if (letta.capabilities?.commands) {
+    disposers.push(
+      letta.commands.register({
+        id: "tool-guard",
+        description: "Show recent tool permission decisions recorded by Tool Guard Inspector",
+        args: "[all] [clear] [limit]",
+        showInTranscript: false,
+        run(ctx) {
+          const { includeAll, clear, limit } = parseCommandArgs(ctx.args);
+          const conversationId = String(ctx.conversation?.id ?? "__global__");
+
+          if (clear) {
+            const removed = clearEntries(conversationId, includeAll);
+            return {
+              type: "output",
+              output: `Tool Guard Inspector cleared ${removed} audit entr${removed === 1 ? "y" : "ies"}.`,
+            };
+          }
+
+          return {
+            type: "output",
+            output: renderAuditLog({ conversationId, includeAll, limit }),
+          };
+        },
+      }),
+    );
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/tool-guard-inspector/package.json
+++ b/packages/tool-guard-inspector/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@letta-ai/tool-guard-inspector",
+  "version": "0.1.0",
+  "description": "Letta Code mod that records a lightweight audit view of tool permission decisions.",
+  "author": "Yingzuo Liu",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "tool-guard",
+    "permissions",
+    "audit"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/tool-guard-inspector"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": [
+      "./mods/index.mjs"
+    ],
+    "capabilities": [
+      "commands",
+      "permissions"
+    ],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `@letta-ai/tool-guard-inspector`, a small Letta Code mod that registers a lightweight permission policy and exposes `/tool-guard` for inspecting recent allow/ask/deny decisions made by the mod.

The first version keeps an in-memory audit log of recent tool checks, classifies common read-only tools, shell commands, mutation tools, and delegation tools, and avoids over-blocking unfamiliar tool surfaces by allowing unknown tools while labeling them as unclassified.

This is intended as a lightweight runtime observability mod for tool-use behavior, not a persistent compliance log or a global audit of all Letta Code permission decisions.

## What it adds

* `packages/tool-guard-inspector`
* a permission policy for common read/search, shell, mutation, and delegation tools
* `/tool-guard` command to inspect recent decisions
* README and MOD docs describing behavior, scope, safety assumptions, and limitations

## Test plan

* [x] `node --check packages/tool-guard-inspector/mods/index.mjs`
* [x] `npm run validate`
* [x] `npm pack ./packages/tool-guard-inspector --dry-run`
