### PR TITLE
fix(git-status): migrate to panel statusline API

### DIFF
--- a/packages/git-status/MOD.md
+++ b/packages/git-status/MOD.md
@@ -44,14 +44,14 @@ Uses `windowsHide` so no console window flashes on Windows.
 - Only read-only git commands are run; the mod never mutates the repository.
 - Git invocations use a short timeout and swallow errors, degrading to a cleared segment.
 - Timers and status values are cleaned up when the mod is disposed.
-- Optional UI APIs are capability-guarded (`ui.customStatuslineRenderer`, `ui.statusValues`).
+- Panel UI is capability-guarded (`ui.panels`).
 
 ## Adaptation notes for agents
 
 - Keep polling lightweight; raise `REFRESH_MS` if a large repo makes `git status` slow.
 - To add line-level churn, layer in `git diff --numstat` / `--cached --numstat` and a
   sparkline; this mod intentionally stays at the file + branch level.
-- The custom statusline owns the full idle row — if composing with other statusline data,
-  merge it into this renderer rather than registering a second renderer.
+- The order-0 panel owns the full idle row — if composing with other statusline data,
+  merge it into this panel rather than registering a second order-0 panel.
 - Porcelain v2 is required for the branch/ahead-behind headers; do not downgrade to v1
   without re-deriving branch and upstream separately.

--- a/packages/git-status/mods/index.tsx
+++ b/packages/git-status/mods/index.tsx
@@ -165,74 +165,51 @@ function formatSegment(state: GitState): string {
 }
 
 export default function activate(letta: any) {
-  if (!letta.capabilities.ui.customStatuslineRenderer) return;
+  if (!letta.capabilities.ui?.panels) return;
 
   let latest: GitState | null = null;
-  // The live working directory is provided by the statusline render context
+  // The live working directory is provided by the panel render context
   // (ModContext.cwd), which tracks the session's current directory. The host
   // `letta` object does not expose a workspace, so we capture cwd at render
   // time and let the poll loop read the latest value.
   let currentCwd = process.cwd();
 
-  const update = async () => {
-    if (!letta.capabilities.ui.statusValues) return;
+  const panel = letta.ui.openPanel({
+    id: "git-status",
+    order: 0,
+    render({ width, cwd, agent, model, row, chalk }: any) {
+      // Track the live cwd from the render context so polling follows the
+      // session's current directory rather than the launch directory.
+      if (typeof cwd === "string" && cwd) {
+        currentCwd = cwd;
+      }
 
-    let state: GitState | null = null;
-    try {
-      state = await readGitState(currentCwd);
-    } catch {
-      state = null;
-    }
+      const dirty =
+        !!latest &&
+        latest.added + latest.modified + latest.deleted > 0;
+      const segment = latest ? formatSegment(latest) : "";
+      const left = segment ? chalk[dirty ? "yellow" : "green"](segment) : "";
+      const modelLabel = model.displayName ?? model.id ?? "unknown";
+      const right = chalk.dim(`${agent.name ?? "Letta"} · ${modelLabel}`);
 
-    latest = state;
-    if (!state) {
-      letta.ui.clearStatus("git");
-      return;
-    }
-
-    letta.ui.setStatus("git", formatSegment(state));
-  };
-
-  letta.ui.setStatuslineRenderer((context: any) => {
-    const { Box, Text } = context.components;
-    const model = context.model.displayName ?? context.model.id ?? "unknown";
-
-    // Track the live cwd from the render context so polling follows the
-    // session's current directory rather than the launch directory.
-    if (typeof context.cwd === "string" && context.cwd) {
-      currentCwd = context.cwd;
-    }
-
-    const dirty =
-      !!latest &&
-      latest.added + latest.modified + latest.deleted > 0;
-
-    return (
-      <Box justifyContent="space-between" width="100%">
-        <Box>
-          {context.statuses.git ? (
-            <Text color={dirty ? "yellow" : "green"}>
-              {context.statuses.git}
-            </Text>
-          ) : null}
-        </Box>
-        <Box>
-          <Text dimColor>
-            {context.agent.name ?? "Letta"}
-            {` · ${model}`}
-          </Text>
-        </Box>
-      </Box>
-    );
+      return row(left, right, width);
+    },
   });
+
+  const update = async () => {
+    try {
+      latest = await readGitState(currentCwd);
+    } catch {
+      latest = null;
+    }
+    panel.update();
+  };
 
   void update();
   const timer = setInterval(() => void update(), REFRESH_MS);
 
   return () => {
     clearInterval(timer);
-    if (letta.capabilities.ui.statusValues) {
-      letta.ui.clearStatus("git");
-    }
+    panel.close();
   };
 }

--- a/packages/git-status/package.json
+++ b/packages/git-status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/git-status",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Letta Code statusline mod that shows the current git branch, dirty/clean state, file counts, and ahead/behind.",
   "author": "christinatong",
   "license": "Apache-2.0",
@@ -24,10 +24,14 @@
   ],
   "letta": {
     "manifestVersion": 1,
-    "mods": ["./mods/index.tsx"],
-    "capabilities": ["ui.statusline", "ui.statusValues"],
+    "mods": [
+      "./mods/index.tsx"
+    ],
+    "capabilities": [
+      "ui.panels"
+    ],
     "engines": {
-      "lettaCodeCli": ">=0.27.14"
+      "lettaCodeCli": ">=0.27.20"
     }
   }
 }


### PR DESCRIPTION
## Summary
- migrate git-status from removed statusline/statusValues APIs to an order-0 panel renderer
- update git-status package capabilities to ui.panels
- bump @letta-ai/git-status to 0.1.1 and require Letta Code >=0.27.20

## Tests
- npm run validate
- bun --check packages/git-status/mods/index.tsx
- mock activation/render smoke test

👾 Generated with [Letta Code](https://letta.com)