### PR TITLE
feat(conversation-summary): add statusline mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Mods are organized as npm packages under `packages/`:
 ```txt
 packages/
 ├── analysis-mode/        # Phrase-triggered diagnostic analysis mode
+├── conversation-summary/ # Conversation summary statusline
 ├── goal-mode/            # Goal workflow with commands, tools, and turn reminders
 ├── image-understanding/  # Vision bridge for text-only agents
 ├── memfs-search/         # Agent-callable MemFS memory search
@@ -83,6 +84,7 @@ scripts/
 ## Current Mods
 
 - **analysis-mode** - Phrase-triggered diagnostic mode using turn reminders and local state
+- **conversation-summary** - Current conversation summary/title statusline
 - **goal-mode** - Goal workflow using commands, tools, turn reminders, and local state
 - **image-understanding** - Image-understanding tool, commands, and optional auto-captioning for text-only agents
 - **memfs-search** - Agent-callable MemFS memory search with optional QMD semantic/hybrid search

--- a/packages/conversation-summary/MOD.md
+++ b/packages/conversation-summary/MOD.md
@@ -1,0 +1,35 @@
+---
+name: "@letta-ai/conversation-summary"
+description: "Conversation summary/title statusline for Letta Code."
+---
+
+# Conversation summary statusline mod semantics
+
+## When to use
+
+Use this mod when the user wants Letta Code's idle statusline to show the current conversation summary/title.
+
+## Behavior
+
+- Registers an order-0 panel, replacing the built-in agent/model line while idle.
+- Shows the current conversation summary on the left side of the statusline.
+- Renders the agent name and model on the right so the row stays useful when the conversation has no summary yet.
+- Fetches on `conversation_open`; it does not poll.
+- Uses `letta.client.conversations.retrieve(conversationId)` for API-backed conversations.
+- Supports local agents by reading local backend conversation metadata from `~/.letta/lc-local-backend/conversations/<base64url-key>/conversation.json`.
+- Honors `LETTA_LOCAL_BACKEND_DIR` when resolving local backend storage.
+- Clears the left segment when the current conversation summary is empty or unavailable.
+
+## Safety invariants
+
+- Renderer stays synchronous and side-effect-free.
+- API/file reads happen only during activation and lifecycle events, never during render.
+- Local file access is read-only and limited to local backend conversation metadata.
+- The panel is closed when the mod is disposed.
+- Panel and lifecycle APIs are capability-guarded.
+
+## Adaptation notes for agents
+
+- Keep this mod one-fetch-per-open; do not add polling unless the user explicitly wants live title refresh.
+- If adding a fallback label, preserve the distinction between “no summary yet” and a real conversation title.
+- If composing with other statusline data, remember an order-0 panel owns the full idle row.

--- a/packages/conversation-summary/README.md
+++ b/packages/conversation-summary/README.md
@@ -1,0 +1,53 @@
+# Conversation Summary
+
+A Letta Code statusline mod that shows the current conversation summary in the idle status row.
+
+```text
+Implement provider retry UI                         Amelia · Claude Sonnet 4
+```
+
+## Install
+
+```bash
+letta install npm:@letta-ai/conversation-summary
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## What it adds
+
+- Current conversation summary/title on the left side of the idle statusline
+- Fallback right-side agent/model display
+- Support for both API-backed and local agents
+
+## Behavior
+
+- Fetches the conversation summary when a conversation opens.
+- Does not poll or call the model.
+- Uses the Letta API client for API-backed conversations.
+- Reads local agent conversation metadata from `~/.letta/lc-local-backend/conversations/.../conversation.json`, respecting `LETTA_LOCAL_BACKEND_DIR`.
+- Renders no left segment when the current conversation has no summary yet.
+
+## Requirements
+
+- Letta Code `>=0.27.20` with panel-based statusline support and lifecycle events
+
+## Safety
+
+Mods are trusted local code. Review the source before installing third-party mods.
+
+This mod reads conversation metadata and does not mutate files or conversations.
+
+If a mod breaks startup or command handling, recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/conversation-summary/mods/index.tsx
+++ b/packages/conversation-summary/mods/index.tsx
@@ -1,0 +1,157 @@
+import { Buffer } from "node:buffer";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function cleanSummary(summary: unknown): string | null {
+  return typeof summary === "string" && summary.trim() ? summary.trim() : null;
+}
+
+function localBackendStorageDir(): string {
+  return (
+    process.env.LETTA_LOCAL_BACKEND_DIR ??
+    join(homedir(), ".letta", "lc-local-backend")
+  );
+}
+
+function encodePathSegment(value: string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function summaryKey(
+  conversationId: string | null | undefined,
+  agentId: string | null | undefined,
+): string | null {
+  if (!conversationId) return null;
+  return conversationId === "default"
+    ? `default:${agentId ?? ""}`
+    : conversationId;
+}
+
+function localConversationKey(
+  conversationId: string,
+  agentId: string | null | undefined,
+): string | null {
+  if (conversationId === "default") {
+    return agentId ? `default:${agentId}` : null;
+  }
+  return `conversation:${conversationId}`;
+}
+
+function isLocalConversation(
+  conversationId: string,
+  agentId: string | null | undefined,
+): boolean {
+  return agentId?.startsWith("agent-local-") === true ||
+    conversationId.startsWith("local-conv-") ||
+    conversationId === "default";
+}
+
+function readLocalConversationSummary(
+  conversationId: string,
+  agentId: string | null | undefined,
+): string | null | undefined {
+  const key = localConversationKey(conversationId, agentId);
+  if (!key) return undefined;
+
+  const conversationPath = join(
+    localBackendStorageDir(),
+    "conversations",
+    encodePathSegment(key),
+    "conversation.json",
+  );
+  if (!existsSync(conversationPath)) return undefined;
+
+  try {
+    const conversation = JSON.parse(readFileSync(conversationPath, "utf8"));
+    return cleanSummary(conversation?.summary);
+  } catch {
+    return undefined;
+  }
+}
+
+export default function activate(letta: any) {
+  if (!letta.capabilities.ui?.panels) return;
+
+  let activeConversationId: string | null = process.env.CONVERSATION_ID ?? null;
+  let activeAgentId: string | null =
+    process.env.LETTA_AGENT_ID ?? process.env.AGENT_ID ?? null;
+  const summariesByConversation = new Map<string, string>();
+
+  const setSummary = (
+    conversationId: string,
+    agentId: string | null | undefined,
+    summary: string | null,
+  ) => {
+    const key = summaryKey(conversationId, agentId);
+    if (!key) return;
+    if (summary) summariesByConversation.set(key, summary);
+    else summariesByConversation.delete(key);
+  };
+
+  const panel = letta.ui.openPanel({
+    id: "conversation-summary",
+    order: 0,
+    render({ width, sessionId, agent, model, row, chalk }: any) {
+      const conversationId = sessionId ?? activeConversationId;
+      const agentId = agent.id ?? activeAgentId;
+      const key = summaryKey(conversationId, agentId);
+      const summary = key ? summariesByConversation.get(key) : null;
+      const left = summary ? chalk.hex("#8C8CF9")(summary) : "";
+      const modelLabel = model.displayName ?? model.id ?? "unknown";
+      const right = chalk.dim(`${agent.name ?? "Letta"} · ${modelLabel}`);
+
+      return row(left, right, width);
+    },
+  });
+
+  async function fetchConversationSummary(
+    conversationId: string | null | undefined,
+    agentId: string | null | undefined,
+  ) {
+    if (!conversationId) return;
+
+    if (isLocalConversation(conversationId, agentId)) {
+      const localSummary = readLocalConversationSummary(conversationId, agentId);
+      if (localSummary !== undefined) {
+        setSummary(conversationId, agentId, localSummary);
+        if (conversationId === activeConversationId) panel.update();
+        return;
+      }
+      if (agentId?.startsWith("agent-local-") || conversationId === "default") {
+        setSummary(conversationId, agentId, null);
+        if (conversationId === activeConversationId) panel.update();
+        return;
+      }
+    }
+
+    try {
+      const conversation = await letta.client.conversations.retrieve(
+        conversationId,
+      );
+      setSummary(conversationId, agentId, cleanSummary(conversation?.summary));
+      if (conversationId === activeConversationId) panel.update();
+    } catch {
+      // Keep the previous cached title/fallback if the fetch fails.
+    }
+  }
+
+  const disposers: Array<() => void> = [];
+
+  if (letta.capabilities.events?.lifecycle) {
+    disposers.push(
+      letta.events.on("conversation_open", (event: any) => {
+        activeConversationId = event.conversationId ?? null;
+        activeAgentId = event.agentId ?? null;
+        void fetchConversationSummary(activeConversationId, activeAgentId);
+      }),
+    );
+  }
+
+  void fetchConversationSummary(activeConversationId, activeAgentId);
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+    panel.close();
+  };
+}

--- a/packages/conversation-summary/package.json
+++ b/packages/conversation-summary/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@letta-ai/conversation-summary",
+  "version": "0.1.0",
+  "description": "Letta Code statusline mod that shows the current conversation summary.",
+  "author": "carenthomas",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "statusline",
+    "conversation-summary"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/conversation-summary"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.tsx"],
+    "capabilities": ["ui.panels", "events.lifecycle"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.20"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add @letta-ai/conversation-summary statusline package
- show the current conversation summary on the left with agent/model on the right
- support API-backed conversations plus local-agent conversation metadata via LETTA_LOCAL_BACKEND_DIR

## Tests
- npm run validate
- bun --check packages/conversation-summary/mods/index.tsx
- mock activation/render smoke test for API and local-agent lookup
- npm pack --dry-run --json ./packages/conversation-summary

👾 Generated with [Letta Code](https://letta.com)