### PR TITLE
fix(validation): remove stale UI capabilities

### DIFF
--- a/scripts/validate-manifests.mjs
+++ b/scripts/validate-manifests.mjs
@@ -16,8 +16,6 @@ const knownCapabilities = new Set([
   "events.llm",
   "events.compact",
   "ui.panels",
-  "ui.statusValues",
-  "ui.statusline",
 ]);
 const modExtensions = new Set([".js", ".mjs", ".ts", ".tsx"]);
 


### PR DESCRIPTION
## Summary
- remove deprecated ui.statusline and ui.statusValues from the package manifest validator
- keep the allowlist aligned with current Letta Code mod capabilities

## Tests
- npm run validate

👾 Generated with [Letta Code](https://letta.com)