### PR TITLE
fix(pets): migrate to panel render API

### DIFF
--- a/packages/pets/MOD.md
+++ b/packages/pets/MOD.md
@@ -34,5 +34,5 @@ The animation returns to idle after activity stops.
 
 - The mod only writes to its own UI panel.
 - The mod does not modify turn input or tool arguments.
-- The mod uses only public command, event, and panel APIs.
+- The mod uses only public command, event, and current render-based panel APIs.
 - All timers, event handlers, and panels are cleaned up on unload.

--- a/packages/pets/mods/index.ts
+++ b/packages/pets/mods/index.ts
@@ -195,11 +195,14 @@ export default function activate(letta: any) {
       return;
     }
 
-    const content = rightPad(renderLines());
     if (!panel) {
-      panel = letta.ui.openPanel({ id: "pets", order: 10_000, content });
+      panel = letta.ui.openPanel({
+        id: "pets",
+        order: 10_000,
+        render: () => rightPad(renderLines()),
+      });
     } else {
-      panel.update({ content });
+      panel.update();
     }
   };
 

--- a/packages/pets/package.json
+++ b/packages/pets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/pets",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Letta Code terminal pets that animate based on turn and tool activity.",
   "author": "ariwebb",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "mods": ["./mods/index.ts"],
     "capabilities": ["commands", "events.tools", "events.turns", "ui.panels"],
     "engines": {
-      "lettaCodeCli": ">=0.27.14"
+      "lettaCodeCli": ">=0.27.20"
     }
   }
 }


### PR DESCRIPTION
## Summary
- migrate pets from legacy panel content updates to render-based panels
- bump @letta-ai/pets to 0.1.2
- require Letta Code >=0.27.20

## Tests
- npm run validate
- bun --check packages/pets/mods/index.ts
- mock activation/render smoke test
- stale API scan for pets

👾 Generated with [Letta Code](https://letta.com)