### PR TITLE
Add Hypa context compression mod

### DIFF
--- a/packages/hypa/MOD.md
+++ b/packages/hypa/MOD.md
@@ -1,0 +1,89 @@
+---
+name: "@letta-ai/hypa"
+description: "Integrates Hypa local context compression — rewrites shell commands, provides tools for compressed file reading, semantic search, and text compression"
+---
+
+# Hypa mod semantics
+
+## When to use
+
+Use this mod when the user wants to reduce context window pressure from noisy tool output. Hypa is a local context runtime that intercepts shell commands and rewrites them through deterministic reducers, compressing output before the model sees it.
+
+Upstream Hypa: <https://github.com/Hypabolic/Hypa>
+
+## Behavior
+
+The mod performs three roles:
+
+### 1. Shell command rewriting (tool_start interception)
+
+On every `tool_start` event for `Bash` or `exec_command` tools, the mod:
+
+1. Extracts the core command by stripping the `cd <workdir> &&` prefix and `2>&1` suffix that the harness prepends/appends.
+2. Sends the core command to `hypa rewrite --json`.
+3. If Hypa returns `Rewritten` or `GenericWrapper`, replaces the command with the Hypa-wrapped version, re-attaching the prefix and suffix.
+4. If Hypa returns `Passthrough` or an error, leaves the command unchanged (fail-open).
+
+Different model harnesses expose shell tools under different names and arg keys:
+- `Bash` with `{ command: string }` (Claude-style harness)
+- `exec_command` with `{ cmd: string }` (Letta Auto / GLM harness)
+
+Both are supported.
+
+Multi-line shell scripts and here-documents are intentionally not rewritten because generic shell wrapping can change their semantics.
+
+### 2. `/hypa` diagnostics command
+
+Shows:
+- Hypa binary path and MCP proxy status
+- Last rewrite (input, outcome, command, error)
+- Mod-level stats (rewrites, passthroughs, errors this session)
+- Hypa session stats (tokens saved, tool calls). These prefer Hypa's recorded command metrics for the active session when available, falling back to `hypa session status` counters otherwise.
+- Observed `tool_start` tool names
+
+### 3. CLI-backed tools
+
+- `hypa_diagnostics` — Same output as `/hypa`, available as a tool for environments where slash commands are unavailable.
+- `hypa_read` — Context-aware file reading with modes: smart, full, outline, signatures, pruned.
+- `hypa_search` — Semantic code search with scopes: project, session, code, docs and kinds: text, regex, symbol.
+- `hypa_compress` — Compress explicit text with kinds: shell-output, log, code, generic.
+- `hypa_mcp_proxy` (optional, env-gated) — Proxy to upstream MCP servers configured in Hypa.
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HYPA_BIN` | `hypa` | Path to the Hypa binary |
+| `HYPA_LETTA_REWRITE_TIMEOUT_MS` | `5000` | Timeout for `hypa rewrite` calls |
+| `HYPA_LETTA_ENABLE_MCP_PROXY` | (unset) | Set to `1` to enable the MCP proxy tool |
+| `HYPA_LETTA_MCP_PROXY_TIMEOUT_MS` | `10000` | Timeout for MCP proxy calls |
+
+## Requirements
+
+- Hypa CLI installed and on `PATH` (or via `HYPA_BIN`)
+- Letta Code `>=0.27.20`
+
+The mod checks for the configured Hypa binary during activation and in diagnostics. If Hypa is missing, it reports an actionable warning when diagnostics are available and otherwise fails open.
+
+## Safety invariants
+
+- All Hypa calls are local — no data leaves the machine.
+- Errors from `hypa rewrite` fail open: the original command runs unchanged.
+- Commands already starting with `hypa` are never double-wrapped.
+- Multi-line commands and here-documents are never wrapped.
+- The mod only intercepts `Bash` and `exec_command` tool calls; all other tools are untouched.
+- `hypa rewrite` may exit non-zero for `Passthrough` outcomes while still emitting valid JSON on stdout; the mod recovers these correctly.
+
+## Recovery
+
+If the mod breaks startup or command handling, run:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+Then remove or edit the package and run `/reload`.

--- a/packages/hypa/README.md
+++ b/packages/hypa/README.md
@@ -1,0 +1,167 @@
+# @letta-ai/hypa
+
+A [Letta Code](https://docs.letta.com/letta-code) mod that integrates [Hypa](https://github.com/Hypabolic/Hypa) — a local context runtime for coding agents. Hypa reduces noisy tool output via deterministic, local compression.
+
+Upstream Hypa resources:
+
+- GitHub: <https://github.com/Hypabolic/Hypa>
+- Pi package: <https://pi.dev/packages/@hypabolic/pi-hypa>
+
+## What it does
+
+### Shell command rewriting
+
+The mod intercepts `Bash` and `exec_command` tool calls and rewrites the command through `hypa rewrite --json`. When Hypa recognizes a command (e.g. `git status`, `npm install`, `npm run ci`), it wraps it so the output is compressed before the model sees it.
+
+The mod strips the `cd <workdir> &&` prefix and `2>&1` suffix that the Letta Code harness prepends/appends to commands, so Hypa's reducers can match the core command. After rewriting, the prefix and suffix are re-attached.
+
+Multi-line shell scripts and here-documents are intentionally not rewritten because generic shell wrapping can change their semantics.
+
+**Supported outcomes:**
+
+| Outcome | Behavior |
+|---|---|
+| `Rewritten` | Command replaced with `hypa <command>` (specific reducer) |
+| `GenericWrapper` | Command replaced with `hypa -c "<command>"` (generic reducer) |
+| `Passthrough` | Command runs unchanged |
+| Error | Command runs unchanged (fail-open) |
+
+### `/hypa` diagnostics
+
+Run `/hypa` to see:
+
+- Hypa binary path and MCP proxy status
+- Last rewrite (input, outcome, command)
+- Mod-level stats (rewrites, passthroughs, errors this session)
+- Hypa session stats (tokens saved, tool calls). These prefer Hypa's recorded
+  command metrics for the active session when available, falling back to
+  `hypa session status` counters otherwise.
+- Observed `tool_start` tool names
+
+### Tools
+
+| Tool | Description |
+|---|---|
+| `hypa_diagnostics` | Same output as `/hypa`, for environments without slash commands |
+| `hypa_read` | Context-aware file reading (modes: smart, full, outline, signatures, pruned) |
+| `hypa_search` | Semantic code search (scopes: project, session, code, docs; kinds: text, regex, symbol) |
+| `hypa_compress` | Compress explicit text (kinds: shell-output, log, code, generic) |
+| `hypa_mcp_proxy` | Proxy to upstream MCP servers (optional, env-gated) |
+
+## Installation
+
+### Prerequisites
+
+1. Install the [Hypa CLI](https://pi.dev/packages/@hypabolic/pi-hypa) and ensure `hypa` is on your `PATH`.
+2. Letta Code `>=0.27.20`.
+
+The mod checks whether the configured Hypa binary is available during activation and in `/hypa` diagnostics. Missing Hypa is non-fatal: shell commands run unchanged and diagnostics explain how to install or configure the binary.
+
+### Install the mod
+
+```bash
+letta mod install @letta-ai/hypa
+```
+
+Or manually clone this repo and copy the package into your mods directory.
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HYPA_BIN` | `hypa` | Path to the Hypa binary |
+| `HYPA_LETTA_REWRITE_TIMEOUT_MS` | `5000` | Timeout for `hypa rewrite` calls (ms) |
+| `HYPA_LETTA_ENABLE_MCP_PROXY` | (unset) | Set to `1` to enable the MCP proxy tool |
+| `HYPA_LETTA_MCP_PROXY_TIMEOUT_MS` | `10000` | Timeout for MCP proxy calls (ms) |
+
+## How it works
+
+```
+Agent calls Bash: "cd /repo && npm run ci 2>&1"
+  ↓
+Mod strips prefix/suffix: core = "npm run ci"
+  ↓
+hypa rewrite "npm run ci" --json
+  ↓
+Hypa returns: {"outcome":"GenericWrapper","command":"hypa -c \"npm run ci\""}
+  ↓
+Mod re-attaches prefix/suffix: "cd /repo && hypa -c \"npm run ci\" 2>&1"
+  ↓
+Agent runs the rewritten command — output is compressed by Hypa
+```
+
+## Token savings
+
+Each rewritten command appends a Hypa footer to the compressed output:
+
+```text
+[hypa: 1200→340 tok, -72%, reducer=git-diff]
+```
+
+Individual savings vary by reducer — some commands compress by 90%+ while others pass through unchanged. Over a typical session of 50–100+ shell calls, these savings compound:
+
+```text
+$ /hypa
+
+Hypa session:
+  Tool calls:   104
+  Tokens saved: 1792
+  Source:       command metrics
+```
+
+This directly reduces the agent's context window consumption, leaving more room for reasoning and code.
+
+## Cross-harness support
+
+Different model harnesses expose shell tools under different names:
+
+| Harness | Tool name | Arg key |
+|---|---|---|
+| Claude-style | `Bash` | `command` |
+| Letta Auto / GLM | `exec_command` | `cmd` |
+
+The mod supports both automatically.
+
+## License
+
+Apache-2.0
+
+## Testing and linting
+
+This package includes the original example-based and property-based test suite from the standalone `letta-hypa` source repo.
+
+```bash
+cd packages/hypa
+npm install
+npm run ci
+```
+
+The package-local quality gate is:
+
+```bash
+vitest run && tsc --noEmit && biome check .
+```
+
+This intentionally keeps linting local to `packages/hypa` rather than imposing a root-wide formatter on all mods in this heterogeneous repository.
+
+Available scripts:
+
+| Script | Purpose |
+|---|---|
+| `npm test` | Run the Vitest example-based and property-based tests |
+| `npm run typecheck` | Typecheck the shipped mod with TypeScript |
+| `npm run lint` | Run Biome lint rules |
+| `npm run check` | Run Biome lint/format/import checks |
+| `npm run format` | Format package files with Biome |
+| `npm run ci` | Run tests, typecheck, and Biome checks |
+
+The suite covers shell rewrite recovery, tool routing across `Bash` and `exec_command`, command prefix/suffix reconstruction, argument preservation, CLI-backed tools, diagnostics rendering, and fast-check properties across generated command/input spaces.
+
+The mods repo root should still pass manifest validation:
+
+```bash
+cd ../..
+npm run validate
+```

--- a/packages/hypa/biome.json
+++ b/packages/hypa/biome.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "files": {
+    "includes": ["mods/**/*.ts", "tests/**/*.ts", "*.json"]
+  }
+}

--- a/packages/hypa/mods/index.ts
+++ b/packages/hypa/mods/index.ts
@@ -1,0 +1,855 @@
+// letta-hypa mod for Letta Code
+// Integrates Hypa — a local context runtime for coding agents.
+// Hypa reduces noisy tool output via deterministic, local compression.
+// See https://pi.dev/packages/@hypabolic/pi-hypa for the Pi extension this is adapted from.
+
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Letta Code mod API types (minimal subset used by this mod)
+// ---------------------------------------------------------------------------
+
+export interface ToolStartEvent {
+  agentId?: string | null;
+  conversationId?: string | null;
+  toolCallId?: string | null;
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+export interface ToolStartResult {
+  args: Record<string, unknown>;
+}
+
+export interface ModEventContext {
+  cwd?: string;
+  workingDirectory?: string;
+  signal?: AbortSignal;
+  context?: {
+    cwd?: string;
+    workspace?: {
+      cwd?: string;
+      currentDir?: string;
+    };
+  };
+}
+
+export type ToolStartHandler = (
+  event: ToolStartEvent,
+  ctx: ModEventContext,
+) => Promise<ToolStartResult | undefined> | ToolStartResult | undefined;
+
+export interface ToolRunContext {
+  cwd: string;
+  args: Record<string, unknown>;
+  signal?: AbortSignal;
+  conversation?: {
+    getHistory(opts?: unknown): Promise<unknown[]>;
+  };
+}
+
+export interface ToolRegistration {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  requiresApproval?: boolean;
+  approvalPolicy?: string;
+  parallelSafe?: boolean;
+  run(ctx: ToolRunContext): Promise<string | { status: string; content: string }>;
+}
+
+export interface CommandRunContext {
+  cwd: string;
+  args: string;
+  agent?: { name?: string | null; id?: string | null };
+}
+
+export interface CommandResult {
+  type: "output" | "prompt" | "handled";
+  output?: string;
+  content?: string;
+  systemReminder?: boolean;
+}
+
+export interface CommandRegistration {
+  id: string;
+  description: string;
+  args?: string;
+  showInTranscript?: boolean;
+  runWhenBusy?: boolean;
+  run(ctx: CommandRunContext): CommandResult | Promise<CommandResult>;
+}
+
+export interface LettaModApi {
+  capabilities?: {
+    tools?: boolean;
+    commands?: boolean;
+    events?: {
+      lifecycle?: boolean;
+      tools?: boolean;
+      turns?: boolean;
+    };
+    permissions?: boolean;
+    providers?: boolean;
+    ui?: {
+      panels?: boolean;
+      statusValues?: boolean;
+    };
+  };
+  tools?: {
+    register(tool: ToolRegistration): () => void;
+  };
+  commands?: {
+    register(cmd: CommandRegistration): () => void;
+  };
+  events?: {
+    on(name: "tool_start", handler: ToolStartHandler): () => void;
+    on(name: string, handler: (...args: unknown[]) => unknown): () => void;
+  };
+  diagnostics?: {
+    report(opts: { message: string; severity?: "error" | "warning" }): void;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+function getHypaBin(): string {
+  return process.env.HYPA_BIN || "hypa";
+}
+
+function getRewriteTimeoutMs(): number {
+  return Number.parseInt(process.env.HYPA_LETTA_REWRITE_TIMEOUT_MS || "5000", 10);
+}
+
+function getMcpProxyEnabled(): boolean {
+  return process.env.HYPA_LETTA_ENABLE_MCP_PROXY === "1";
+}
+
+function getMcpProxyTimeoutMs(): number {
+  return Number.parseInt(process.env.HYPA_LETTA_MCP_PROXY_TIMEOUT_MS || "10000", 10);
+}
+
+async function isHypaInstalled(execFn: typeof execFileAsync = execFileAsync): Promise<boolean> {
+  const bin = getHypaBin();
+  try {
+    await execFn("sh", ["-lc", 'command -v "$1" >/dev/null 2>&1', "sh", bin], {
+      timeout: 3000,
+      maxBuffer: 16 * 1024,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reportHypaMissing(letta: LettaModApi): void {
+  letta.diagnostics?.report({
+    severity: "warning",
+    message:
+      `@letta-ai/hypa: Hypa binary '${getHypaBin()}' was not found. ` +
+      "Install Hypa from https://github.com/Hypabolic/Hypa or set HYPA_BIN. " +
+      "Shell commands will run unchanged until Hypa is available.",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Rewrite state (module-level for diagnostics)
+// ---------------------------------------------------------------------------
+
+export interface RewriteRecord {
+  input: string;
+  outcome: string;
+  command: string | null;
+  error: string | null;
+}
+
+export interface ModStats {
+  rewrites: number;
+  passthroughs: number;
+  errors: number;
+  tokensSaved: number;
+}
+
+let lastRewrite: RewriteRecord | null = null;
+const observedToolStartNames = new Set<string>();
+const modStats: ModStats = { rewrites: 0, passthroughs: 0, errors: 0, tokensSaved: 0 };
+
+export function getLastRewrite(): RewriteRecord | null {
+  return lastRewrite;
+}
+
+export function getModStats(): ModStats {
+  return { ...modStats };
+}
+
+export function resetRewriteState(): void {
+  lastRewrite = null;
+  observedToolStartNames.clear();
+  modStats.rewrites = 0;
+  modStats.passthroughs = 0;
+  modStats.errors = 0;
+  modStats.tokensSaved = 0;
+}
+
+function trackRewrite(result: RewriteResult): void {
+  if (result.outcome === "Rewritten" || result.outcome === "GenericWrapper") {
+    modStats.rewrites++;
+  } else if (result.outcome === "Passthrough") {
+    modStats.passthroughs++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hypa CLI helpers
+// ---------------------------------------------------------------------------
+
+export interface RewriteResult {
+  input: string;
+  outcome: string;
+  command: string;
+}
+
+export async function hypaRewrite(
+  command: string,
+  cwd: string,
+  execFn: typeof execFileAsync = execFileAsync,
+): Promise<RewriteResult | null> {
+  const bin = getHypaBin();
+  const timeoutMs = getRewriteTimeoutMs();
+  try {
+    const { stdout } = await execFn(bin, ["rewrite", command, "--json"], {
+      cwd,
+      timeout: timeoutMs,
+      maxBuffer: 1024 * 1024,
+    });
+    const result = JSON.parse(stdout) as RewriteResult;
+    lastRewrite = { ...result, error: null };
+    trackRewrite(result);
+    return result;
+  } catch (error) {
+    // Hypa may exit non-zero for Passthrough outcomes while still emitting
+    // valid JSON on stdout.  Attempt to recover the result before treating
+    // this as a real error.
+    const maybeStdout =
+      error && typeof error === "object" && "stdout" in error
+        ? String((error as { stdout?: unknown }).stdout ?? "")
+        : "";
+    if (maybeStdout) {
+      try {
+        const result = JSON.parse(maybeStdout) as RewriteResult;
+        if (
+          result.outcome === "Passthrough" ||
+          result.outcome === "Rewritten" ||
+          result.outcome === "GenericWrapper"
+        ) {
+          lastRewrite = { ...result, error: null };
+          trackRewrite(result);
+          return result;
+        }
+      } catch {
+        // stdout wasn't valid JSON — fall through to real error handling
+      }
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    lastRewrite = { input: command, outcome: "Error", command: null, error: message };
+    modStats.errors++;
+    return null;
+  }
+}
+
+export async function hypaExec(
+  args: string[],
+  cwd: string,
+  options?: { timeoutMs?: number; input?: string },
+  execFn: typeof execFileAsync = execFileAsync,
+): Promise<string> {
+  const bin = getHypaBin();
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  try {
+    const execOptions: Parameters<typeof execFn>[2] = {
+      cwd,
+      timeout: timeoutMs,
+      maxBuffer: 1024 * 1024,
+      encoding: "utf8",
+    };
+    if (options?.input !== undefined) {
+      (execOptions as { input?: string }).input = options.input;
+    }
+    const { stdout } = await execFn(bin, args, execOptions);
+    return typeof stdout === "string" ? stdout : stdout.toString("utf8");
+  } catch (error) {
+    if (error && typeof error === "object" && "stderr" in error) {
+      const stderr = String((error as { stderr?: string }).stderr ?? "").trim();
+      if (stderr) throw new Error(stderr);
+    }
+    throw error;
+  }
+}
+
+interface SessionStats {
+  sessionId: string | null;
+  tokensSaved: number | null;
+  toolCalls: number | null;
+  commandTokensSaved: number | null;
+  commandToolCalls: number | null;
+}
+
+function parseSessionStat(output: string, key: string): number | null {
+  const match = output.match(new RegExp(`^${key}:\\s*(\\d+)`, "m"));
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function parseSessionId(output: string): string | null {
+  const match = output.match(/^id:\s*([^\s]+)/m);
+  if (!match) return null;
+
+  // Session IDs are currently UUIDs. Keep this slightly broader for forward
+  // compatibility, but reject anything that could affect the SQLite query.
+  return /^[A-Za-z0-9_-]+$/.test(match[1]) ? match[1] : null;
+}
+
+async function fetchHypaCommandMetrics(
+  sessionId: string,
+): Promise<{ toolCalls: number; tokensSaved: number } | null> {
+  const dbPath = process.env.HYPA_DB || `${homedir()}/.hypa/hypa.db`;
+  const sql =
+    "SELECT COUNT(*), COALESCE(SUM(original_tokens - compressed_tokens), 0) " +
+    `FROM command_metrics WHERE session_id = '${sessionId}';`;
+
+  try {
+    const { stdout } = await execFileAsync("sqlite3", [dbPath, sql], {
+      timeout: 3000,
+      maxBuffer: 64 * 1024,
+      encoding: "utf8",
+    });
+    const [toolCalls, tokensSaved] = String(stdout).trim().split("|").map(Number);
+    if (!Number.isFinite(toolCalls) || !Number.isFinite(tokensSaved)) return null;
+
+    return { toolCalls, tokensSaved };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchHypaSessionStats(): Promise<SessionStats | null> {
+  try {
+    const output = await hypaExec(["session", "status"], process.cwd(), {
+      timeoutMs: 3000,
+    });
+    const sessionId = parseSessionId(output);
+    const commandMetrics = sessionId ? await fetchHypaCommandMetrics(sessionId) : null;
+
+    return {
+      sessionId,
+      tokensSaved: parseSessionStat(output, "tokens_saved"),
+      toolCalls: parseSessionStat(output, "tool_calls"),
+      commandTokensSaved: commandMetrics?.tokensSaved ?? null,
+      commandToolCalls: commandMetrics?.toolCalls ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function renderHypaDiagnostics(): Promise<string> {
+  const bin = getHypaBin();
+  const mcpProxy = getMcpProxyEnabled();
+  const installed = await isHypaInstalled();
+  const lines = [
+    "Hypa integration for Letta Code",
+    "",
+    `Binary:      ${bin}`,
+    `Available:   ${installed ? "yes" : "no"}`,
+    `MCP proxy:   ${mcpProxy ? "enabled" : "disabled"}`,
+  ];
+  if (!installed) {
+    lines.push("Install:     https://github.com/Hypabolic/Hypa");
+  }
+  lines.push("");
+  lines.push("Last rewrite:");
+  if (lastRewrite) {
+    lines.push(`  Input:    ${lastRewrite.input}`);
+    lines.push(`  Outcome:  ${lastRewrite.outcome}`);
+    if (lastRewrite.command) {
+      lines.push(`  Command:  ${lastRewrite.command}`);
+    }
+    if (lastRewrite.error) {
+      lines.push(`  Error:    ${lastRewrite.error}`);
+    }
+  } else {
+    lines.push("  (no rewrites yet)");
+  }
+
+  // Mod-level stats (this session)
+  lines.push("");
+  lines.push("Mod stats (this session):");
+  lines.push(`  Rewrites:     ${modStats.rewrites}`);
+  lines.push(`  Passthroughs: ${modStats.passthroughs}`);
+  lines.push(`  Errors:       ${modStats.errors}`);
+
+  // Hypa session stats (global, from hypa session status)
+  const session = installed ? await fetchHypaSessionStats() : null;
+  if (session) {
+    lines.push("");
+    lines.push("Hypa session:");
+    const toolCalls = session.commandToolCalls ?? session.toolCalls;
+    const tokensSaved = session.commandTokensSaved ?? session.tokensSaved;
+    if (toolCalls !== null) {
+      lines.push(`  Tool calls:   ${toolCalls}`);
+    }
+    if (tokensSaved !== null) {
+      lines.push(`  Tokens saved: ${tokensSaved}`);
+    }
+    if (session.commandToolCalls !== null || session.commandTokensSaved !== null) {
+      lines.push("  Source:       command metrics");
+    }
+  }
+
+  lines.push("");
+  lines.push("Observed tool_start names:");
+  if (observedToolStartNames.size > 0) {
+    for (const name of [...observedToolStartNames].sort()) {
+      lines.push(`  - ${name}`);
+    }
+  } else {
+    lines.push("  (none yet)");
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isHypaCommand(command: string): boolean {
+  return command.trimStart().startsWith("hypa");
+}
+
+function isComplexShellCommand(command: string): boolean {
+  // `hypa -c "..."` is not safe for multi-line scripts or here-documents: the
+  // shell redirection belongs to the outer command, not the quoted inner one.
+  // Leave these untouched rather than risking semantic changes.
+  return command.includes("\n") || command.includes("<<");
+}
+
+export interface CommandParts {
+  /** The leading "cd <dir> && " prefix, or "" if none. */
+  prefix: string;
+  /** The core command to send to hypa rewrite. */
+  core: string;
+  /** The trailing " 2>&1" redirect (or similar), or "" if none. */
+  suffix: string;
+}
+
+/**
+ * Extract the cd-prefix and redirect-suffix from a command so the core can be
+ * sent to `hypa rewrite` without the wrapper noise that prevents reducers from
+ * matching.
+ *
+ * The Bash tool generates commands like:
+ *   cd /path/to/repo && npm run ci 2>&1
+ *
+ * The `cd <dir> &&` prefix and `2>&1` suffix break Hypa's reducer pattern
+ * matching.  We strip them, send the core to Hypa, and re-attach them after
+ * the rewrite.
+ */
+export function extractCommandParts(command: string): CommandParts {
+  let prefix = "";
+  let suffix = "";
+  let core = command;
+
+  // Extract leading "cd <dir> && " prefix.
+  // Handles unquoted, double-quoted, and single-quoted paths.
+  const cdMatch = core.match(/^cd\s+("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)\s*&&\s*/);
+  if (cdMatch) {
+    prefix = cdMatch[0];
+    core = core.slice(prefix.length);
+  }
+
+  // Extract trailing "2>&1" redirect.
+  const redirectMatch = core.match(/\s*2>&1\s*$/);
+  if (redirectMatch) {
+    suffix = redirectMatch[0];
+    core = core.slice(0, core.length - suffix.length);
+  }
+
+  return { prefix, core, suffix };
+}
+
+function resolveCwd(ctx: ModEventContext): string {
+  return (
+    ctx.cwd ??
+    ctx.workingDirectory ??
+    ctx.context?.cwd ??
+    ctx.context?.workspace?.currentDir ??
+    ctx.context?.workspace?.cwd ??
+    process.cwd()
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mod activation
+// ---------------------------------------------------------------------------
+
+export default function activate(letta: LettaModApi): () => void {
+  const disposers: (() => void)[] = [];
+
+  const canRegisterToolStart = Boolean(letta.capabilities?.events?.tools && letta.events);
+  const canRegisterCommands = Boolean(letta.capabilities?.commands && letta.commands);
+  const canRegisterTools = Boolean(letta.capabilities?.tools && letta.tools);
+
+  // Pre-flight dependency check. Missing Hypa is non-fatal: shell commands
+  // continue unchanged, but the user gets an actionable diagnostics warning.
+  if (letta.diagnostics?.report) {
+    void isHypaInstalled().then((installed) => {
+      if (!installed) reportHypaMissing(letta);
+    });
+  }
+
+  // 1. Shell rewrite interception via tool_start event.
+  //    Intercepts Bash and exec_command tool calls and rewrites the command
+  //    through `hypa rewrite --json`. When Hypa returns Rewritten or
+  //    GenericWrapper, the command is replaced with the hypa-wrapped version
+  //    so output is compressed in place. Passthrough and errors fail open.
+  //
+  //    Different model harnesses expose shell tools under different names and
+  //    arg keys:
+  //      - Bash:        { command: string }   (e.g. Claude-style harness)
+  //      - exec_command: { cmd: string }       (e.g. Letta Auto / GLM harness)
+  if (canRegisterToolStart && letta.events) {
+    disposers.push(
+      letta.events.on("tool_start", async (event, ctx) => {
+        if (!observedToolStartNames.has(event.toolName)) {
+          observedToolStartNames.add(event.toolName);
+          letta.diagnostics?.report({
+            severity: "warning",
+            message: `letta-hypa observed tool_start toolName=${event.toolName}`,
+          });
+        }
+
+        // Determine which arg key holds the command for this tool.
+        const isBash = event.toolName === "Bash";
+        const isExecCommand = event.toolName === "exec_command";
+        if (!isBash && !isExecCommand) return;
+
+        const commandKey = isExecCommand ? "cmd" : "command";
+        const command = String(event.args?.[commandKey] ?? "");
+        if (!command) return;
+
+        // Skip multi-line scripts and here-documents; generic wrapping can
+        // change their shell semantics.
+        if (isComplexShellCommand(command)) return;
+
+        const cwd = resolveCwd(ctx);
+
+        // Strip cd-prefix and 2>&1-suffix so Hypa's reducers can match the
+        // core command.  The harness prepends "cd <workdir> &&" and appends
+        // "2>&1" to most commands, which prevents reducers from matching.
+        const { prefix, core, suffix } = extractCommandParts(command);
+        if (!core.trim()) return; // nothing to rewrite after stripping
+
+        // Skip commands already starting with hypa after removing harness
+        // wrappers, otherwise `cd <workdir> && hypa ... 2>&1` can be wrapped
+        // again as `hypa -c "hypa ..."`.
+        if (isHypaCommand(core)) return;
+
+        const result = await hypaRewrite(core, cwd);
+        if (!result) return; // Error — fail open, pass through original.
+
+        if (result.outcome === "Rewritten" || result.outcome === "GenericWrapper") {
+          const rewritten = prefix + result.command + suffix;
+          return { args: { ...event.args, [commandKey]: rewritten } };
+        }
+        // Passthrough or unknown — leave command as-is.
+      }),
+    );
+  }
+
+  // 2. /hypa diagnostics command.
+  if (canRegisterCommands && letta.commands) {
+    disposers.push(
+      letta.commands.register({
+        id: "hypa",
+        description:
+          "Show Hypa integration diagnostics (binary, rewrite status, MCP proxy, stats).",
+        async run() {
+          return { type: "output" as const, output: await renderHypaDiagnostics() };
+        },
+      }),
+    );
+  }
+
+  // 3. CLI-backed tools.
+  if (canRegisterTools && letta.tools) {
+    disposers.push(
+      letta.tools.register({
+        name: "hypa_diagnostics",
+        description:
+          "Show Hypa integration diagnostics. Use this in environments where the /hypa slash command is not available.",
+        parameters: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        requiresApproval: false,
+        parallelSafe: true,
+        async run() {
+          return await renderHypaDiagnostics();
+        },
+      }),
+    );
+
+    // hypa_read — context-aware file reading.
+    disposers.push(
+      letta.tools.register({
+        name: "hypa_read",
+        description:
+          "Read a file with context-aware compression via Hypa. " +
+          "Use when reading large files and you want compressed or structured output. " +
+          "Modes: smart (default), full, outline, signatures, pruned.",
+        parameters: {
+          type: "object",
+          properties: {
+            path: { type: "string", description: "File path to read" },
+            mode: {
+              type: "string",
+              description: "Read mode: smart, full, outline, signatures, pruned",
+              enum: ["smart", "full", "outline", "signatures", "pruned"],
+            },
+            max_tokens: { type: "number", description: "Maximum tokens to return" },
+          },
+          required: ["path"],
+          additionalProperties: false,
+        },
+        requiresApproval: false,
+        parallelSafe: true,
+        async run(ctx) {
+          const path = String(ctx.args.path ?? "").trim();
+          if (!path) return { status: "error", content: "path is required" };
+          const mode = String(ctx.args.mode ?? "smart");
+          const args = ["read", path, "--mode", mode];
+          if (ctx.args.max_tokens) {
+            args.push("--max-tokens", String(ctx.args.max_tokens));
+          }
+          try {
+            const output = await hypaExec(args, ctx.cwd);
+            return output || "(empty)";
+          } catch (error) {
+            return {
+              status: "error",
+              content: error instanceof Error ? error.message : String(error),
+            };
+          }
+        },
+      }),
+    );
+
+    // hypa_search — search files, symbols, and indexed context.
+    disposers.push(
+      letta.tools.register({
+        name: "hypa_search",
+        description:
+          "Search files, symbols, and indexed context using Hypa. " +
+          "Use for semantic code search across the project.",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Search query" },
+            scope: {
+              type: "string",
+              description: "Search scope: project, session, code, docs",
+              enum: ["project", "session", "code", "docs"],
+            },
+            kind: {
+              type: "string",
+              description: "Search kind: text, regex, symbol",
+              enum: ["text", "regex", "symbol"],
+            },
+            max: { type: "number", description: "Maximum number of results" },
+          },
+          required: ["query"],
+          additionalProperties: false,
+        },
+        requiresApproval: false,
+        parallelSafe: true,
+        async run(ctx) {
+          const query = String(ctx.args.query ?? "").trim();
+          if (!query) return { status: "error", content: "query is required" };
+          const args = ["search", query];
+          if (ctx.args.scope) args.push("--scope", String(ctx.args.scope));
+          if (ctx.args.kind) args.push("--kind", String(ctx.args.kind));
+          if (ctx.args.max) args.push("--max", String(ctx.args.max));
+          try {
+            const output = await hypaExec(args, ctx.cwd);
+            return output || "No matches.";
+          } catch (error) {
+            return {
+              status: "error",
+              content: error instanceof Error ? error.message : String(error),
+            };
+          }
+        },
+      }),
+    );
+
+    // hypa_compress — compress explicit text.
+    disposers.push(
+      letta.tools.register({
+        name: "hypa_compress",
+        description:
+          "Compress text using Hypa's deterministic reducers. " +
+          "Use when you have large text output (logs, shell output, code) " +
+          "that needs compression before adding to context.",
+        parameters: {
+          type: "object",
+          properties: {
+            text: { type: "string", description: "Text to compress" },
+            kind: {
+              type: "string",
+              description: "Output kind: shell-output, log, code, generic",
+              enum: ["shell-output", "log", "code", "generic"],
+            },
+            max_tokens: { type: "number", description: "Maximum output tokens" },
+          },
+          required: ["text"],
+          additionalProperties: false,
+        },
+        requiresApproval: false,
+        parallelSafe: true,
+        async run(ctx) {
+          const text = String(ctx.args.text ?? "");
+          if (!text) return { status: "error", content: "text is required" };
+          const kind = String(ctx.args.kind ?? "generic");
+          const args = ["compress", "--kind", kind];
+          if (ctx.args.max_tokens) {
+            args.push("--max-tokens", String(ctx.args.max_tokens));
+          }
+          try {
+            const output = await hypaExec(args, ctx.cwd, { input: text });
+            return output || "(empty)";
+          } catch (error) {
+            return {
+              status: "error",
+              content: error instanceof Error ? error.message : String(error),
+            };
+          }
+        },
+      }),
+    );
+
+    // 4. Optional MCP proxy tool.
+    if (getMcpProxyEnabled()) {
+      disposers.push(
+        letta.tools.register({
+          name: "hypa_mcp_proxy",
+          description:
+            "Interact with upstream MCP servers configured in Hypa. " +
+            "Actions: list, search, schema, invoke, auth_check. " +
+            "Use this instead of adding individual MCP server tools to context.",
+          parameters: {
+            type: "object",
+            properties: {
+              action: {
+                type: "string",
+                description: "Action: list, search, schema, invoke, auth_check",
+                enum: ["list", "search", "schema", "invoke", "auth_check"],
+              },
+              query: { type: "string", description: "Search query (for 'search' action)" },
+              server: {
+                type: "string",
+                description: "Server name (for 'schema', 'invoke', 'auth_check')",
+              },
+              tool: { type: "string", description: "Tool name (for 'invoke')" },
+              arguments: {
+                type: "object",
+                description: "Tool arguments (for 'invoke')",
+                additionalProperties: true,
+              },
+            },
+            required: ["action"],
+            additionalProperties: false,
+          },
+          requiresApproval: true,
+          parallelSafe: false,
+          async run(ctx) {
+            const action = String(ctx.args.action ?? "");
+            const timeoutMs = getMcpProxyTimeoutMs();
+            try {
+              switch (action) {
+                case "list": {
+                  const output = await hypaExec(["mcp", "list"], ctx.cwd, { timeoutMs });
+                  return output || "No servers configured.";
+                }
+                case "search": {
+                  const query = String(ctx.args.query ?? "");
+                  if (!query) return { status: "error", content: "query is required for 'search'" };
+                  const output = await hypaExec(["mcp", "search", "--query", query], ctx.cwd, {
+                    timeoutMs,
+                  });
+                  return output || "No matches.";
+                }
+                case "schema": {
+                  const server = String(ctx.args.server ?? "");
+                  if (!server)
+                    return { status: "error", content: "server is required for 'schema'" };
+                  const args = ["mcp", "schema"];
+                  if (server) args.push("--server", server);
+                  const output = await hypaExec(args, ctx.cwd, { timeoutMs });
+                  return output || "(empty)";
+                }
+                case "invoke": {
+                  const server = String(ctx.args.server ?? "");
+                  const tool = String(ctx.args.tool ?? "");
+                  if (!server || !tool) {
+                    return {
+                      status: "error",
+                      content: "server and tool are required for 'invoke'",
+                    };
+                  }
+                  const invokeArgs = ["mcp", "invoke", "--server", server, "--tool", tool];
+                  if (ctx.args.arguments) {
+                    invokeArgs.push("--arguments", JSON.stringify(ctx.args.arguments));
+                  }
+                  const output = await hypaExec(invokeArgs, ctx.cwd, { timeoutMs });
+                  return output || "(empty)";
+                }
+                case "auth_check": {
+                  const server = String(ctx.args.server ?? "");
+                  if (!server)
+                    return { status: "error", content: "server is required for 'auth_check'" };
+                  const output = await hypaExec(
+                    ["mcp", "auth", "check", "--server", server],
+                    ctx.cwd,
+                    {
+                      timeoutMs,
+                    },
+                  );
+                  return output || "(empty)";
+                }
+                default:
+                  return { status: "error", content: `Unknown action: ${action}` };
+              }
+            } catch (error) {
+              return {
+                status: "error",
+                content: error instanceof Error ? error.message : String(error),
+              };
+            }
+          },
+        }),
+      );
+    }
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+    lastRewrite = null;
+  };
+}

--- a/packages/hypa/package.json
+++ b/packages/hypa/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@letta-ai/hypa",
+  "version": "0.1.0",
+  "description": "Letta Code mod integrating Hypa — a local context runtime that compresses noisy tool output via deterministic, local rewriting.",
+  "author": "robert@enosi.energy",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "hypa",
+    "compression",
+    "context",
+    "tokens",
+    "tool-output",
+    "shell-rewrite"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/hypa"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods",
+    "tests",
+    "tsconfig.json",
+    "biome.json"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint .",
+    "format": "biome format --write .",
+    "check": "biome check .",
+    "ci": "vitest run && tsc --noEmit && biome check ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.0",
+    "@types/node": "^26.0.1",
+    "fast-check": "^4.8.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  },
+  "letta": {
+    "manifestVersion": 1,
+    "mods": [
+      "./mods/index.ts"
+    ],
+    "capabilities": [
+      "commands",
+      "tools",
+      "events.tools"
+    ],
+    "engines": {
+      "lettaCodeCli": ">=0.27.20"
+    }
+  }
+}

--- a/packages/hypa/tests/mod.test.ts
+++ b/packages/hypa/tests/mod.test.ts
@@ -1,0 +1,1247 @@
+// Tests for letta-hypa mod.
+// Mocks execFile/execFileSync to test behaviour without calling the real hypa binary.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mock execFile and execFileSync ---
+// The mod imports both from node:child_process. We mock the module so we can
+// control the output of hypa CLI calls. vi.hoisted ensures the mock is
+// available when vi.mock's factory runs.
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn() as unknown as (
+    ...args: unknown[]
+  ) => Promise<{ stdout: string; stderr: string }>,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+}));
+vi.mock("node:util", () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+// Import after mocks are set up.
+import activate, {
+  extractCommandParts,
+  getLastRewrite,
+  hypaExec,
+  hypaRewrite,
+  type LettaModApi,
+  resetRewriteState,
+} from "../mods/index";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function execResult(stdout: string, stderr = ""): { stdout: string; stderr: string } {
+  return { stdout, stderr };
+}
+
+function execError(stderr: string, code?: number, stdout?: string): Error {
+  const err = new Error(stderr);
+  if (code !== undefined) (err as unknown as { code: number }).code = code;
+  (err as unknown as { stderr: string }).stderr = stderr;
+  if (stdout !== undefined) (err as unknown as { stdout: string }).stdout = stdout;
+  return err;
+}
+
+/** Simulate hypa exiting non-zero but with valid JSON on stdout (the Passthrough bug). */
+function mockRejectWithStdout(stdout: string, code = 1) {
+  mockExecFile.mockRejectedValue(execError("Command failed", code, stdout));
+}
+
+function makeLettaApi(overrides: Partial<LettaModApi> = {}): LettaModApi {
+  return {
+    capabilities: {
+      tools: true,
+      commands: true,
+      events: { tools: true, lifecycle: false, turns: false },
+      permissions: false,
+      providers: false,
+      ui: { panels: false, statusValues: false },
+    },
+    tools: { register: vi.fn(() => () => {}) },
+    commands: { register: vi.fn(() => () => {}) },
+    events: { on: vi.fn(() => () => {}) },
+    ...overrides,
+  };
+}
+
+function mockResolve(stdout: string, stderr = "") {
+  mockExecFile.mockResolvedValue(execResult(stdout, stderr));
+}
+
+function mockReject(stderr: string, code?: number) {
+  mockExecFile.mockRejectedValue(execError(stderr, code));
+}
+
+function mockImplementation(
+  fn: (
+    ...args: unknown[]
+  ) => Promise<{ stdout: string; stderr: string }> | { stdout: string; stderr: string },
+) {
+  mockExecFile.mockImplementation(fn as unknown as typeof mockExecFile);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: hypaRewrite (async)
+// ---------------------------------------------------------------------------
+
+describe("hypaRewrite", () => {
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+  });
+
+  it("returns Rewritten result with wrapped command", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "git status",
+        outcome: "Rewritten",
+        command: "hypa git status",
+      }),
+    );
+
+    const result = await hypaRewrite("git status", "/tmp");
+    expect(result).toEqual({
+      input: "git status",
+      outcome: "Rewritten",
+      command: "hypa git status",
+    });
+  });
+
+  it("returns GenericWrapper result", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "ls -la",
+        outcome: "GenericWrapper",
+        command: 'hypa -c "ls -la"',
+      }),
+    );
+
+    const result = await hypaRewrite("ls -la", "/tmp");
+    expect(result).toEqual({
+      input: "ls -la",
+      outcome: "GenericWrapper",
+      command: 'hypa -c "ls -la"',
+    });
+  });
+
+  it("returns Passthrough result (command unchanged)", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "docker build .",
+        outcome: "Passthrough",
+        command: "docker build .",
+      }),
+    );
+
+    const result = await hypaRewrite("docker build .", "/tmp");
+    expect(result).toEqual({
+      input: "docker build .",
+      outcome: "Passthrough",
+      command: "docker build .",
+    });
+  });
+
+  it("returns null on exec error and records error in lastRewrite", async () => {
+    mockReject("command not found");
+
+    const result = await hypaRewrite("go test ./...", "/tmp");
+    expect(result).toBeNull();
+    const record = getLastRewrite();
+    expect(record).not.toBeNull();
+    expect(record?.outcome).toBe("Error");
+    expect(record?.error).toBeTruthy();
+  });
+
+  // --- Recovery from non-zero exit with valid JSON on stdout ---
+  // Hypa exits non-zero for Passthrough outcomes but still emits valid JSON
+  // on stdout.  The mod must recover the result instead of treating it as an
+  // error.
+
+  it("recovers Passthrough from err.stdout on non-zero exit", async () => {
+    mockRejectWithStdout(
+      JSON.stringify({
+        input: "cd /tmp && npm run ci 2>&1",
+        outcome: "Passthrough",
+        command: "cd /tmp && npm run ci 2>&1",
+      }),
+    );
+
+    const result = await hypaRewrite("cd /tmp && npm run ci 2>&1", "/tmp");
+    expect(result).toEqual({
+      input: "cd /tmp && npm run ci 2>&1",
+      outcome: "Passthrough",
+      command: "cd /tmp && npm run ci 2>&1",
+    });
+    // Should NOT be recorded as an error
+    const record = getLastRewrite();
+    expect(record?.outcome).toBe("Passthrough");
+    expect(record?.error).toBeNull();
+  });
+
+  it("recovers Rewritten from err.stdout on non-zero exit", async () => {
+    mockRejectWithStdout(
+      JSON.stringify({
+        input: "git status",
+        outcome: "Rewritten",
+        command: "hypa git status",
+      }),
+    );
+
+    const result = await hypaRewrite("git status", "/tmp");
+    expect(result).toEqual({
+      input: "git status",
+      outcome: "Rewritten",
+      command: "hypa git status",
+    });
+    expect(getLastRewrite()?.error).toBeNull();
+  });
+
+  it("recovers GenericWrapper from err.stdout on non-zero exit", async () => {
+    mockRejectWithStdout(
+      JSON.stringify({
+        input: "ls -la",
+        outcome: "GenericWrapper",
+        command: 'hypa -c "ls -la"',
+      }),
+    );
+
+    const result = await hypaRewrite("ls -la", "/tmp");
+    expect(result).toEqual({
+      input: "ls -la",
+      outcome: "GenericWrapper",
+      command: 'hypa -c "ls -la"',
+    });
+    expect(getLastRewrite()?.error).toBeNull();
+  });
+
+  it("returns null when err.stdout has invalid JSON", async () => {
+    mockRejectWithStdout("not valid json");
+
+    const result = await hypaRewrite("echo hello", "/tmp");
+    expect(result).toBeNull();
+    expect(getLastRewrite()?.outcome).toBe("Error");
+  });
+
+  it("returns null when err.stdout has unrecognized outcome", async () => {
+    mockRejectWithStdout(JSON.stringify({ input: "test", outcome: "Unknown", command: "test" }));
+
+    const result = await hypaRewrite("test", "/tmp");
+    expect(result).toBeNull();
+    expect(getLastRewrite()?.outcome).toBe("Error");
+  });
+
+  it("returns null when error has no stdout property", async () => {
+    mockReject("command not found");
+
+    const result = await hypaRewrite("go test", "/tmp");
+    expect(result).toBeNull();
+    expect(getLastRewrite()?.outcome).toBe("Error");
+  });
+
+  it("returns null on JSON parse error", async () => {
+    mockResolve("not valid json");
+
+    const result = await hypaRewrite("echo hello", "/tmp");
+    expect(result).toBeNull();
+    expect(getLastRewrite()?.outcome).toBe("Error");
+  });
+
+  it("stores last rewrite record for diagnostics", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "npm install",
+        outcome: "GenericWrapper",
+        command: 'hypa -c "npm install"',
+      }),
+    );
+
+    await hypaRewrite("npm install", "/tmp");
+    const record = getLastRewrite();
+    expect(record).toEqual({
+      input: "npm install",
+      outcome: "GenericWrapper",
+      command: 'hypa -c "npm install"',
+      error: null,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypaExec
+// ---------------------------------------------------------------------------
+
+describe("hypaExec", () => {
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+  });
+
+  it("returns stdout on success", async () => {
+    mockResolve("file contents here");
+
+    const output = await hypaExec(["read", "/tmp/test.txt", "--mode", "smart"], "/tmp");
+    expect(output).toBe("file contents here");
+  });
+
+  it("passes input option for stdin", async () => {
+    let capturedOptions: Record<string, unknown> = {};
+    mockImplementation((_bin, _args, opts) => {
+      capturedOptions = opts as Record<string, unknown>;
+      return execResult("compressed output");
+    });
+
+    const output = await hypaExec(["compress", "--kind", "generic"], "/tmp", {
+      input: "some text",
+    });
+    expect(output).toBe("compressed output");
+    expect(capturedOptions.input).toBe("some text");
+  });
+
+  it("throws with stderr message on error", async () => {
+    mockReject("file not found");
+
+    await expect(hypaExec(["read", "/nonexistent"], "/tmp")).rejects.toThrow("file not found");
+  });
+
+  it("uses custom timeout when provided", async () => {
+    let capturedOptions: Record<string, unknown> = {};
+    mockImplementation((_bin, _args, opts) => {
+      capturedOptions = opts as Record<string, unknown>;
+      return execResult("ok");
+    });
+
+    await hypaExec(["mcp", "list"], "/tmp", { timeoutMs: 15000 });
+    expect(capturedOptions.timeout).toBe(15000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: extractCommandParts
+// ---------------------------------------------------------------------------
+
+describe("extractCommandParts", () => {
+  it("extracts cd prefix and 2>&1 suffix", () => {
+    const parts = extractCommandParts("cd /tmp && npm run ci 2>&1");
+    expect(parts).toEqual({
+      prefix: "cd /tmp && ",
+      core: "npm run ci",
+      suffix: " 2>&1",
+    });
+  });
+
+  it("extracts only cd prefix when no redirect", () => {
+    const parts = extractCommandParts("cd /tmp && npm run ci");
+    expect(parts).toEqual({
+      prefix: "cd /tmp && ",
+      core: "npm run ci",
+      suffix: "",
+    });
+  });
+
+  it("extracts only 2>&1 suffix when no cd prefix", () => {
+    const parts = extractCommandParts("npm run ci 2>&1");
+    expect(parts).toEqual({
+      prefix: "",
+      core: "npm run ci",
+      suffix: " 2>&1",
+    });
+  });
+
+  it("returns command as core when no cd or redirect", () => {
+    const parts = extractCommandParts("npm run ci");
+    expect(parts).toEqual({
+      prefix: "",
+      core: "npm run ci",
+      suffix: "",
+    });
+  });
+
+  it("handles double-quoted paths with spaces", () => {
+    const parts = extractCommandParts('cd "/path with spaces" && git status');
+    expect(parts.prefix).toBe('cd "/path with spaces" && ');
+    expect(parts.core).toBe("git status");
+  });
+
+  it("handles single-quoted paths with spaces", () => {
+    const parts = extractCommandParts("cd '/path with spaces' && git status");
+    expect(parts.prefix).toBe("cd '/path with spaces' && ");
+    expect(parts.core).toBe("git status");
+  });
+
+  it("does not match cd without &&", () => {
+    const parts = extractCommandParts("cd /tmp");
+    expect(parts.prefix).toBe("");
+    expect(parts.core).toBe("cd /tmp");
+  });
+
+  it("handles compound commands after cd prefix", () => {
+    const parts = extractCommandParts("cd /tmp && cmd1 && cmd2 2>&1");
+    expect(parts.prefix).toBe("cd /tmp && ");
+    expect(parts.core).toBe("cmd1 && cmd2");
+    expect(parts.suffix).toBe(" 2>&1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: activate
+// ---------------------------------------------------------------------------
+
+describe("activate", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+    letta = makeLettaApi();
+    dispose = undefined;
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("registers tool_start event handler, /hypa command, and tools", () => {
+    dispose = activate(letta);
+    expect(letta.events?.on).toHaveBeenCalledWith("tool_start", expect.any(Function));
+    expect(letta.commands?.register).toHaveBeenCalledWith(expect.objectContaining({ id: "hypa" }));
+    expect(letta.tools?.register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "hypa_read" }),
+    );
+    expect(letta.tools?.register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "hypa_search" }),
+    );
+    expect(letta.tools?.register).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "hypa_compress" }),
+    );
+  });
+
+  it("does not register MCP proxy tool when disabled", () => {
+    dispose = activate(letta);
+    const registerCalls = (letta.tools?.register as ReturnType<typeof vi.fn>).mock.calls;
+    const mcpProxy = registerCalls.find(
+      (call: unknown[]) => (call[0] as { name: string }).name === "hypa_mcp_proxy",
+    );
+    expect(mcpProxy).toBeUndefined();
+  });
+
+  it("registers MCP proxy tool when HYPA_LETTA_ENABLE_MCP_PROXY=1", () => {
+    process.env.HYPA_LETTA_ENABLE_MCP_PROXY = "1";
+    dispose = activate(letta);
+    const registerCalls = (letta.tools?.register as ReturnType<typeof vi.fn>).mock.calls;
+    const mcpProxy = registerCalls.find(
+      (call: unknown[]) => (call[0] as { name: string }).name === "hypa_mcp_proxy",
+    );
+    expect(mcpProxy).toBeDefined();
+    delete process.env.HYPA_LETTA_ENABLE_MCP_PROXY;
+  });
+
+  it("returns a disposer that cleans up", () => {
+    const disposer = activate(letta);
+    expect(typeof disposer).toBe("function");
+    disposer();
+    expect(getLastRewrite()).toBeNull();
+  });
+
+  it("skips registration when capabilities are missing", () => {
+    const minimal: LettaModApi = { capabilities: {} };
+    dispose = activate(minimal);
+    expect(typeof dispose).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tool_start handler (synchronous)
+// ---------------------------------------------------------------------------
+
+describe("tool_start handler", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolStartHandler: (
+    event: { toolName: string; args: Record<string, unknown> },
+    ctx: { cwd?: string },
+  ) => Promise<{ args: Record<string, unknown> } | undefined>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+    letta = makeLettaApi();
+    (letta.events?.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (_name: string, handler: typeof toolStartHandler) => {
+        toolStartHandler = handler;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("rewrites Bash command when outcome is Rewritten", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "git status",
+        outcome: "Rewritten",
+        command: "hypa git status",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "git status" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({ args: { command: "hypa git status" } });
+  });
+
+  it("rewrites Bash command when outcome is GenericWrapper", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "ls -la",
+        outcome: "GenericWrapper",
+        command: 'hypa -c "ls -la"',
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "ls -la" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({ args: { command: 'hypa -c "ls -la"' } });
+  });
+
+  it("does not rewrite when outcome is Passthrough", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "docker build .",
+        outcome: "Passthrough",
+        command: "docker build .",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "docker build ." } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("fails open (returns void) on exec error", async () => {
+    mockReject("not found");
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "go test ./..." } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("skips commands already starting with hypa", async () => {
+    vi.mocked(mockExecFile).mockImplementation(() => {
+      throw new Error("should not be called");
+    });
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "hypa doctor" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("skips hypa commands after stripping cd prefix and redirect suffix", async () => {
+    vi.mocked(mockExecFile).mockImplementation(() => {
+      throw new Error("should not be called");
+    });
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "cd /tmp && hypa git status 2>&1" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("skips heredoc commands because generic wrapping changes shell semantics", async () => {
+    vi.mocked(mockExecFile).mockImplementation(() => {
+      throw new Error("should not be called");
+    });
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "node <<'NODE'\nconsole.log('hi')\nNODE" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("skips multi-line shell scripts because generic wrapping can change semantics", async () => {
+    vi.mocked(mockExecFile).mockImplementation(() => {
+      throw new Error("should not be called");
+    });
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "echo one\necho two" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-Bash tool calls", async () => {
+    const result = await toolStartHandler(
+      { toolName: "Read", args: { file_path: "/tmp/test.txt" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("ignores empty command", async () => {
+    const result = await toolStartHandler({ toolName: "Bash", args: {} }, { cwd: "/tmp" });
+    expect(result).toBeUndefined();
+  });
+
+  // --- exec_command tool support ---
+  // Some model harnesses (Letta Auto, GLM) expose the shell tool as
+  // exec_command with a `cmd` arg key instead of Bash with `command`.
+
+  it("rewrites exec_command using cmd arg key", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "git status",
+        outcome: "Rewritten",
+        command: "hypa git status",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "exec_command", args: { cmd: "git status" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({ args: { cmd: "hypa git status" } });
+  });
+
+  it("does not rewrite exec_command on Passthrough", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "docker build .",
+        outcome: "Passthrough",
+        command: "docker build .",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "exec_command", args: { cmd: "docker build ." } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("fails open on exec_command error", async () => {
+    mockReject("not found");
+
+    const result = await toolStartHandler(
+      { toolName: "exec_command", args: { cmd: "go test ./..." } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("recovers Passthrough from non-zero exit for exec_command", async () => {
+    mockRejectWithStdout(
+      JSON.stringify({
+        input: "cd /tmp && npm run ci 2>&1",
+        outcome: "Passthrough",
+        command: "cd /tmp && npm run ci 2>&1",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "exec_command", args: { cmd: "cd /tmp && npm run ci 2>&1" } },
+      { cwd: "/tmp" },
+    );
+    // Passthrough → no rewrite, command runs as-is
+    expect(result).toBeUndefined();
+  });
+
+  it("recovers Rewritten from non-zero exit for Bash", async () => {
+    mockRejectWithStdout(
+      JSON.stringify({
+        input: "git status",
+        outcome: "Rewritten",
+        command: "hypa git status",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "git status" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({ args: { command: "hypa git status" } });
+  });
+
+  // --- cd prefix and 2>&1 suffix stripping ---
+  // The harness prepends "cd <workdir> &&" and appends "2>&1" to commands,
+  // which prevents Hypa's reducers from matching. The handler strips these,
+  // sends the core to hypa rewrite, and re-attaches them after.
+
+  it("strips cd prefix and 2>&1 suffix, rewrites core, re-attaches both", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "npm run ci",
+        outcome: "GenericWrapper",
+        command: 'hypa -c "npm run ci"',
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "cd /tmp && npm run ci 2>&1" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({
+      args: { command: 'cd /tmp && hypa -c "npm run ci" 2>&1' },
+    });
+  });
+
+  it("strips only cd prefix when no redirect", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "git status",
+        outcome: "Rewritten",
+        command: "hypa git status",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "cd /tmp && git status" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({ args: { command: "cd /tmp && hypa git status" } });
+  });
+
+  it("strips only 2>&1 suffix when no cd prefix", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "npm run ci",
+        outcome: "GenericWrapper",
+        command: 'hypa -c "npm run ci"',
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "npm run ci 2>&1" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({
+      args: { command: 'hypa -c "npm run ci" 2>&1' },
+    });
+  });
+
+  it("passes through original when core is Passthrough", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "docker build .",
+        outcome: "Passthrough",
+        command: "docker build .",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      { toolName: "Bash", args: { command: "cd /tmp && docker build . 2>&1" } },
+      { cwd: "/tmp" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("preserves other args when stripping cd/redirect", async () => {
+    mockResolve(
+      JSON.stringify({
+        input: "git status",
+        outcome: "Rewritten",
+        command: "hypa git status",
+      }),
+    );
+
+    const result = await toolStartHandler(
+      {
+        toolName: "Bash",
+        args: { command: "cd /tmp && git status 2>&1", timeout: 5000 },
+      },
+      { cwd: "/tmp" },
+    );
+    expect(result).toEqual({
+      args: { command: "cd /tmp && hypa git status 2>&1", timeout: 5000 },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: /hypa command
+// ---------------------------------------------------------------------------
+
+describe("/hypa command", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let commandRun: (ctx: {
+    cwd: string;
+    args: string;
+  }) => Promise<{ type: string; output: string }> | { type: string; output: string };
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+    letta = makeLettaApi();
+    (letta.commands?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (cmd: { id: string; run: typeof commandRun }) => {
+        if (cmd.id === "hypa") commandRun = cmd.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("shows diagnostics with no rewrites yet", async () => {
+    // fetchHypaSessionStats calls hypaExec which calls mockExecFile.
+    // Mock it to return empty session status so it doesn't interfere.
+    mockImplementation((_bin, args) => {
+      if (args?.includes?.("session")) return execResult("tokens_saved: 0\ntool_calls: 0\n");
+      return execResult("");
+    });
+
+    const result = await commandRun({ cwd: "/tmp", args: "" });
+    expect(result.type).toBe("output");
+    expect(result.output).toContain("Hypa integration for Letta Code");
+    expect(result.output).toContain("no rewrites yet");
+  });
+
+  it("shows install guidance when the hypa binary is missing", async () => {
+    mockImplementation((_bin, args) => {
+      if (args?.includes?.("-lc")) return Promise.reject(execError("not found"));
+      return execResult("");
+    });
+
+    const result = await commandRun({ cwd: "/tmp", args: "" });
+    expect(result.type).toBe("output");
+    expect(result.output).toContain("Available:   no");
+    expect(result.output).toContain("https://github.com/Hypabolic/Hypa");
+    expect(result.output).not.toContain("Hypa session:");
+  });
+
+  it("shows last rewrite after a rewrite occurs", async () => {
+    mockImplementation((_bin, args) => {
+      if (args?.includes?.("rewrite")) {
+        return execResult(
+          JSON.stringify({
+            input: "git status",
+            outcome: "Rewritten",
+            command: "hypa git status",
+          }),
+        );
+      }
+      if (args?.includes?.("session")) return execResult("tokens_saved: 0\ntool_calls: 0\n");
+      return execResult("");
+    });
+
+    await hypaRewrite("git status", "/tmp");
+
+    const result = await commandRun({ cwd: "/tmp", args: "" });
+    expect(result.output).toContain("git status");
+    expect(result.output).toContain("Rewritten");
+    expect(result.output).toContain("hypa git status");
+  });
+
+  it("shows error in diagnostics after a failed rewrite", async () => {
+    mockImplementation((_bin, args) => {
+      if (args?.includes?.("rewrite")) {
+        return Promise.reject(execError("binary not found"));
+      }
+      if (args?.includes?.("session")) return execResult("tokens_saved: 0\ntool_calls: 0\n");
+      return execResult("");
+    });
+
+    await hypaRewrite("go test ./...", "/tmp");
+
+    const result = await commandRun({ cwd: "/tmp", args: "" });
+    expect(result.output).toContain("Error");
+    expect(result.output).toContain("binary not found");
+  });
+
+  it("shows mod stats and hypa session stats", async () => {
+    mockImplementation((_bin, args) => {
+      if (args?.includes?.("rewrite")) {
+        return execResult(
+          JSON.stringify({
+            input: "git status",
+            outcome: "Rewritten",
+            command: "hypa git status",
+          }),
+        );
+      }
+      if (args?.includes?.("session")) {
+        return execResult("tokens_saved: 1337\ntool_calls: 42\n");
+      }
+      return execResult("");
+    });
+
+    await hypaRewrite("git status", "/tmp");
+
+    const result = await commandRun({ cwd: "/tmp", args: "" });
+    // Mod stats
+    expect(result.output).toContain("Mod stats (this session):");
+    expect(result.output).toContain("Rewrites:     1");
+    expect(result.output).toContain("Passthroughs: 0");
+    // Hypa session stats
+    expect(result.output).toContain("Hypa session:");
+    expect(result.output).toContain("Tokens saved: 1337");
+    expect(result.output).toContain("Tool calls:   42");
+  });
+
+  it("prefers command metrics over stale session counters", async () => {
+    mockImplementation((bin, args) => {
+      if (bin === "sqlite3") {
+        return execResult("91|1724\n");
+      }
+      if (args?.includes?.("session")) {
+        return execResult(
+          "id:           session-1\nproject_root: /tmp\ntool_calls:   0\ntokens_saved: 0\n",
+        );
+      }
+      return execResult("");
+    });
+
+    const result = await commandRun({ cwd: "/tmp", args: "" });
+
+    expect(result.output).toContain("Hypa session:");
+    expect(result.output).toContain("Tool calls:   91");
+    expect(result.output).toContain("Tokens saved: 1724");
+    expect(result.output).toContain("Source:       command metrics");
+  });
+
+  it("handles fetchHypaSessionStats failure gracefully", async () => {
+    mockImplementation((_bin, args) => {
+      if (args?.includes?.("session")) {
+        return Promise.reject(execError("connection refused"));
+      }
+      return execResult("");
+    });
+
+    const result = await commandRun({ cwd: "/tmp", args: "" });
+    // Should still show mod stats even if session stats fail
+    expect(result.output).toContain("Mod stats (this session):");
+    // Should NOT show Hypa session section
+    expect(result.output).not.toContain("Hypa session:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypa_read tool
+// ---------------------------------------------------------------------------
+
+describe("hypa_read tool", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolRun: (ctx: { cwd: string; args: Record<string, unknown> }) => Promise<unknown>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    letta = makeLettaApi();
+    (letta.tools?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (tool: { name: string; run: typeof toolRun }) => {
+        if (tool.name === "hypa_read") toolRun = tool.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("reads a file with default smart mode", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("compressed file contents");
+    });
+
+    const result = await toolRun({ cwd: "/tmp", args: { path: "/tmp/test.txt" } });
+    expect(result).toBe("compressed file contents");
+    expect(capturedArgs).toContain("read");
+    expect(capturedArgs).toContain("/tmp/test.txt");
+    expect(capturedArgs).toContain("--mode");
+    expect(capturedArgs).toContain("smart");
+  });
+
+  it("uses custom mode when provided", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("outline output");
+    });
+
+    const result = await toolRun({ cwd: "/tmp", args: { path: "/tmp/test.txt", mode: "outline" } });
+    expect(result).toBe("outline output");
+    expect(capturedArgs).toContain("outline");
+  });
+
+  it("returns error when path is missing", async () => {
+    const result = await toolRun({ cwd: "/tmp", args: {} });
+    expect(result).toEqual({ status: "error", content: "path is required" });
+  });
+
+  it("returns error on exec failure", async () => {
+    mockReject("file not found");
+
+    const result = await toolRun({ cwd: "/tmp", args: { path: "/nonexistent" } });
+    expect(result).toEqual({ status: "error", content: "file not found" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypa_search tool
+// ---------------------------------------------------------------------------
+
+describe("hypa_search tool", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolRun: (ctx: { cwd: string; args: Record<string, unknown> }) => Promise<unknown>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    letta = makeLettaApi();
+    (letta.tools?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (tool: { name: string; run: typeof toolRun }) => {
+        if (tool.name === "hypa_search") toolRun = tool.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("searches with query", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("search results");
+    });
+
+    const result = await toolRun({ cwd: "/tmp", args: { query: "auth handler" } });
+    expect(result).toBe("search results");
+    expect(capturedArgs).toContain("search");
+    expect(capturedArgs).toContain("auth handler");
+  });
+
+  it("passes scope and kind options", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("results");
+    });
+
+    const result = await toolRun({
+      cwd: "/tmp",
+      args: { query: "test", scope: "code", kind: "symbol" },
+    });
+    expect(result).toBe("results");
+    expect(capturedArgs).toContain("--scope");
+    expect(capturedArgs).toContain("code");
+    expect(capturedArgs).toContain("--kind");
+    expect(capturedArgs).toContain("symbol");
+  });
+
+  it("returns error when query is missing", async () => {
+    const result = await toolRun({ cwd: "/tmp", args: {} });
+    expect(result).toEqual({ status: "error", content: "query is required" });
+  });
+
+  it("returns No matches on empty output", async () => {
+    mockResolve("");
+
+    const result = await toolRun({ cwd: "/tmp", args: { query: "nonexistent" } });
+    expect(result).toBe("No matches.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypa_compress tool
+// ---------------------------------------------------------------------------
+
+describe("hypa_compress tool", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolRun: (ctx: { cwd: string; args: Record<string, unknown> }) => Promise<unknown>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    letta = makeLettaApi();
+    (letta.tools?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (tool: { name: string; run: typeof toolRun }) => {
+        if (tool.name === "hypa_compress") toolRun = tool.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("compresses text via stdin", async () => {
+    let capturedInput: string | undefined;
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args, opts) => {
+      capturedArgs = args as unknown[];
+      capturedInput = (opts as Record<string, unknown>).input as string;
+      return execResult("compressed text");
+    });
+
+    const result = await toolRun({ cwd: "/tmp", args: { text: "long log output here" } });
+    expect(result).toBe("compressed text");
+    expect(capturedInput).toBe("long log output here");
+    expect(capturedArgs).toContain("compress");
+    expect(capturedArgs).toContain("--kind");
+    expect(capturedArgs).toContain("generic");
+  });
+
+  it("uses custom kind when provided", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("compressed");
+    });
+
+    const result = await toolRun({
+      cwd: "/tmp",
+      args: { text: "output", kind: "shell-output" },
+    });
+    expect(result).toBe("compressed");
+    expect(capturedArgs).toContain("shell-output");
+  });
+
+  it("returns error when text is missing", async () => {
+    const result = await toolRun({ cwd: "/tmp", args: {} });
+    expect(result).toEqual({ status: "error", content: "text is required" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypa_mcp_proxy tool
+// ---------------------------------------------------------------------------
+
+describe("hypa_mcp_proxy tool", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolRun: (ctx: { cwd: string; args: Record<string, unknown> }) => Promise<unknown>;
+  let registeredTool: { requiresApproval?: boolean; parallelSafe?: boolean } | undefined;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    process.env.HYPA_LETTA_ENABLE_MCP_PROXY = "1";
+    letta = makeLettaApi();
+    (letta.tools?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (tool: {
+        name: string;
+        run: typeof toolRun;
+        requiresApproval?: boolean;
+        parallelSafe?: boolean;
+      }) => {
+        if (tool.name === "hypa_mcp_proxy") {
+          toolRun = tool.run;
+          registeredTool = tool;
+        }
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+    delete process.env.HYPA_LETTA_ENABLE_MCP_PROXY;
+  });
+
+  it("requires approval and is not parallel-safe because invoke can be side-effectful", () => {
+    expect(registeredTool?.requiresApproval).toBe(true);
+    expect(registeredTool?.parallelSafe).toBe(false);
+  });
+
+  it("lists servers", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("server1\nserver2");
+    });
+
+    const result = await toolRun({ cwd: "/tmp", args: { action: "list" } });
+    expect(result).toBe("server1\nserver2");
+    expect(capturedArgs).toEqual(["mcp", "list"]);
+  });
+
+  it("searches for tools", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("github-pr tool");
+    });
+
+    const result = await toolRun({ cwd: "/tmp", args: { action: "search", query: "github" } });
+    expect(result).toBe("github-pr tool");
+    expect(capturedArgs).toContain("mcp");
+    expect(capturedArgs).toContain("search");
+    expect(capturedArgs).toContain("--query");
+    expect(capturedArgs).toContain("github");
+  });
+
+  it("returns error when query missing for search action", async () => {
+    const result = await toolRun({ cwd: "/tmp", args: { action: "search" } });
+    expect(result).toEqual({ status: "error", content: "query is required for 'search'" });
+  });
+
+  it("invokes a tool on a server", async () => {
+    let capturedArgs: unknown[] = [];
+    mockImplementation((_bin, args) => {
+      capturedArgs = args as unknown[];
+      return execResult("repo list");
+    });
+
+    const result = await toolRun({
+      cwd: "/tmp",
+      args: { action: "invoke", server: "my-server", tool: "list_repos" },
+    });
+    expect(result).toBe("repo list");
+    expect(capturedArgs).toContain("mcp");
+    expect(capturedArgs).toContain("invoke");
+    expect(capturedArgs).toContain("--server");
+    expect(capturedArgs).toContain("my-server");
+    expect(capturedArgs).toContain("--tool");
+    expect(capturedArgs).toContain("list_repos");
+  });
+
+  it("returns error when server missing for invoke", async () => {
+    const result = await toolRun({ cwd: "/tmp", args: { action: "invoke", tool: "test" } });
+    expect(result).toEqual({
+      status: "error",
+      content: "server and tool are required for 'invoke'",
+    });
+  });
+
+  it("returns error for unknown action", async () => {
+    const result = await toolRun({ cwd: "/tmp", args: { action: "unknown" } });
+    expect(result).toEqual({ status: "error", content: "Unknown action: unknown" });
+  });
+});

--- a/packages/hypa/tests/pbt.test.ts
+++ b/packages/hypa/tests/pbt.test.ts
@@ -1,0 +1,966 @@
+// Property-based tests for letta-hypa mod.
+// Uses fast-check to verify invariants across the input space.
+// Example-based tests in mod.test.ts serve as regression/documentation;
+// these PBT tests verify properties that should hold for ALL inputs.
+
+import fc from "fast-check";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mock setup (same as mod.test.ts) ---
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn() as unknown as (
+    ...args: unknown[]
+  ) => Promise<{ stdout: string; stderr: string }>,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+}));
+vi.mock("node:util", () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+import activate, {
+  extractCommandParts,
+  getLastRewrite,
+  getModStats,
+  hypaExec,
+  hypaRewrite,
+  type LettaModApi,
+  resetRewriteState,
+} from "../mods/index";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function execResult(stdout: string, stderr = ""): { stdout: string; stderr: string } {
+  return { stdout, stderr };
+}
+
+function execError(stderr: string, code?: number, stdout?: string): Error {
+  const err = new Error(stderr);
+  if (code !== undefined) (err as unknown as { code: number }).code = code;
+  (err as unknown as { stderr: string }).stderr = stderr;
+  if (stdout !== undefined) (err as unknown as { stdout: string }).stdout = stdout;
+  return err;
+}
+
+function makeLettaApi(overrides: Partial<LettaModApi> = {}): LettaModApi {
+  return {
+    capabilities: {
+      tools: true,
+      commands: true,
+      events: { tools: true, lifecycle: false, turns: false },
+      permissions: false,
+      providers: false,
+      ui: { panels: false, statusValues: false },
+    },
+    tools: { register: vi.fn(() => () => {}) },
+    commands: { register: vi.fn(() => () => {}) },
+    events: { on: vi.fn(() => () => {}) },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Generators (fast-check arbitraries)
+// ---------------------------------------------------------------------------
+
+const RECOGNIZED_OUTCOMES = ["Rewritten", "GenericWrapper", "Passthrough"] as const;
+const UNRECOGNIZED_OUTCOMES = [
+  "Unknown",
+  "Error",
+  "Pending",
+  "",
+  "rewritten",
+  "passthrough",
+] as const;
+
+/** Any string that could be a shell command (including compound, unicode). */
+const commandArb = fc.string({ maxLength: 200 });
+
+/** Any non-empty string (for fields that require non-empty after trim). */
+const nonEmptyStringArb = fc.string({ maxLength: 200 }).filter((s) => s.trim().length > 0);
+
+/** Any recognized outcome. */
+const outcomeArb = fc.constantFrom(...RECOGNIZED_OUTCOMES);
+
+/** Any unrecognized outcome string. */
+const unrecognizedOutcomeArb = fc.constantFrom(...UNRECOGNIZED_OUTCOMES);
+
+/** A valid RewriteResult object with a recognized outcome. */
+const rewriteResultArb = fc
+  .tuple(commandArb, outcomeArb, commandArb)
+  .map(([input, outcome, command]) => ({ input, outcome, command }));
+
+/** Any tool name (including Bash, exec_command, and arbitrary others). */
+const toolNameArb = fc.oneof(
+  fc.constantFrom("Bash", "exec_command", "Read", "Write", "Edit", "Glob", "Grep"),
+  fc.string({ maxLength: 30 }),
+);
+
+/** Any non-hypa, non-empty command string (doesn't start with "hypa" after trimming, and isn't just whitespace). */
+const nonHypaCommandArb = fc
+  .string({ maxLength: 200 })
+  .filter(
+    (s) =>
+      s.trim().length > 0 &&
+      !s.trimStart().startsWith("hypa") &&
+      !s.includes("\n") &&
+      !s.includes("<<"),
+  );
+
+/** Any hypa-prefixed command string. */
+const hypaCommandArb = fc.string({ maxLength: 50 }).map((s) => `hypa ${s}`.trim());
+
+/** Any valid hypa_read mode. */
+const readModeArb = fc.constantFrom("smart", "full", "outline", "signatures", "pruned");
+
+/** Any valid hypa_search scope. */
+const searchScopeArb = fc.constantFrom("project", "session", "code", "docs");
+
+/** Any valid hypa_search kind. */
+const searchKindArb = fc.constantFrom("text", "regex", "symbol");
+
+/** Any valid hypa_compress kind. */
+const compressKindArb = fc.constantFrom("shell-output", "log", "code", "generic");
+
+/** Any filesystem path (for cd prefix testing). */
+const pathArb = fc.oneof(
+  // Simple unquoted path
+  fc.stringMatching(/[a-zA-Z0-9/_.-]{1,50}/),
+  // Quoted path with spaces
+  fc.stringMatching(/[a-zA-Z0-9/_.-]{1,30}/).map((s) => `"${s} with spaces"`),
+);
+
+/** A command with optional cd prefix and optional 2>&1 suffix. */
+const wrappedCommandArb = fc
+  .tuple(
+    fc.oneof(
+      fc.constant(""),
+      pathArb.map((p) => `cd ${p} && `),
+    ),
+    nonHypaCommandArb,
+    fc.oneof(fc.constant(""), fc.constant(" 2>&1")),
+  )
+  .map(([prefix, core, suffix]) => ({ prefix, core, suffix, full: `${prefix}${core}${suffix}` }))
+  .filter(({ full }) => !full.includes("\n") && !full.includes("<<"));
+
+/** A hypa-prefixed command with optional harness cd-prefix and redirect suffix. */
+const wrappedHypaCommandArb = fc
+  .tuple(
+    fc.oneof(
+      fc.constant(""),
+      pathArb.map((p) => `cd ${p} && `),
+    ),
+    hypaCommandArb,
+    fc.oneof(fc.constant(""), fc.constant(" 2>&1")),
+  )
+  .map(([prefix, core, suffix]) => `${prefix}${core}${suffix}`)
+  .filter((command) => extractCommandParts(command).core.trimStart().startsWith("hypa"));
+
+// ---------------------------------------------------------------------------
+// Tests: hypaRewrite — recovery from success and error paths
+// ---------------------------------------------------------------------------
+
+describe("PBT: hypaRewrite recovery", () => {
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+  });
+
+  it("recovers any recognized outcome from success path (exit 0)", async () => {
+    await fc.assert(
+      fc.asyncProperty(rewriteResultArb, async (expected) => {
+        mockExecFile.mockResolvedValue(execResult(JSON.stringify(expected)));
+
+        const result = await hypaRewrite(expected.input, "/tmp");
+
+        expect(result).toEqual(expected);
+        expect(getLastRewrite()?.outcome).toBe(expected.outcome);
+        expect(getLastRewrite()?.error).toBeNull();
+      }),
+    );
+  });
+
+  it("recovers any recognized outcome from error path (non-zero exit with JSON on stdout)", async () => {
+    await fc.assert(
+      fc.asyncProperty(rewriteResultArb, async (expected) => {
+        mockExecFile.mockRejectedValue(execError("Command failed", 1, JSON.stringify(expected)));
+
+        const result = await hypaRewrite(expected.input, "/tmp");
+
+        expect(result).toEqual(expected);
+        expect(getLastRewrite()?.outcome).toBe(expected.outcome);
+        expect(getLastRewrite()?.error).toBeNull();
+      }),
+    );
+  });
+
+  it("returns null for any unrecognized outcome in err.stdout", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc
+          .tuple(commandArb, unrecognizedOutcomeArb, commandArb)
+          .map(([input, outcome, command]) => JSON.stringify({ input, outcome, command })),
+        async (jsonStr) => {
+          mockExecFile.mockRejectedValue(execError("Command failed", 1, jsonStr));
+
+          const result = await hypaRewrite("test", "/tmp");
+
+          expect(result).toBeNull();
+          expect(getLastRewrite()?.outcome).toBe("Error");
+        },
+      ),
+    );
+  });
+
+  it("returns null for any invalid JSON in err.stdout", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ maxLength: 100 }).filter((s) => {
+          try {
+            JSON.parse(s);
+            return false;
+          } catch {
+            return true;
+          }
+        }),
+        async (invalidJson) => {
+          mockExecFile.mockRejectedValue(execError("Command failed", 1, invalidJson));
+
+          const result = await hypaRewrite("test", "/tmp");
+
+          expect(result).toBeNull();
+          expect(getLastRewrite()?.outcome).toBe("Error");
+        },
+      ),
+    );
+  });
+
+  it("returns null for any error without stdout", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string({ maxLength: 100 }), async (errorMsg) => {
+        mockExecFile.mockRejectedValue(execError(errorMsg));
+
+        const result = await hypaRewrite("test", "/tmp");
+
+        expect(result).toBeNull();
+        expect(getLastRewrite()?.outcome).toBe("Error");
+        // Error message is recorded (may be empty string if execError msg was empty)
+        expect(getLastRewrite()?.error).not.toBeNull();
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypaRewrite — mod stats tracking
+// ---------------------------------------------------------------------------
+
+describe("PBT: hypaRewrite stats tracking", () => {
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+  });
+
+  it("increments rewrites counter for Rewritten and GenericWrapper outcomes", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.constantFrom("Rewritten", "GenericWrapper"), async (outcome) => {
+        resetRewriteState();
+        mockExecFile.mockResolvedValue(
+          execResult(JSON.stringify({ input: "cmd", outcome, command: "wrapped" })),
+        );
+
+        await hypaRewrite("cmd", "/tmp");
+
+        expect(getModStats().rewrites).toBe(1);
+        expect(getModStats().passthroughs).toBe(0);
+        expect(getModStats().errors).toBe(0);
+      }),
+    );
+  });
+
+  it("increments passthroughs counter for Passthrough outcome", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.constant("Passthrough"), async (outcome) => {
+        resetRewriteState();
+        mockExecFile.mockResolvedValue(
+          execResult(JSON.stringify({ input: "cmd", outcome, command: "cmd" })),
+        );
+
+        await hypaRewrite("cmd", "/tmp");
+
+        expect(getModStats().rewrites).toBe(0);
+        expect(getModStats().passthroughs).toBe(1);
+        expect(getModStats().errors).toBe(0);
+      }),
+    );
+  });
+
+  it("increments errors counter for any error without recovery", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string({ maxLength: 50 }), async (errorMsg) => {
+        resetRewriteState();
+        mockExecFile.mockRejectedValue(execError(errorMsg));
+
+        await hypaRewrite("cmd", "/tmp");
+
+        expect(getModStats().errors).toBe(1);
+        expect(getModStats().rewrites).toBe(0);
+        expect(getModStats().passthroughs).toBe(0);
+      }),
+    );
+  });
+
+  it("does not increment errors when recovering from non-zero exit", async () => {
+    await fc.assert(
+      fc.asyncProperty(rewriteResultArb, async (expected) => {
+        resetRewriteState();
+        mockExecFile.mockRejectedValue(execError("Command failed", 1, JSON.stringify(expected)));
+
+        await hypaRewrite(expected.input, "/tmp");
+
+        expect(getModStats().errors).toBe(0);
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tool_start handler — routing and invariants
+// ---------------------------------------------------------------------------
+
+describe("PBT: tool_start handler routing", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolStartHandler: (
+    event: { toolName: string; args: Record<string, unknown> },
+    ctx: { cwd?: string },
+  ) => Promise<{ args: Record<string, unknown> } | undefined>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+    letta = makeLettaApi();
+    (letta.events?.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (_name: string, handler: typeof toolStartHandler) => {
+        toolStartHandler = handler;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("only Bash and exec_command trigger rewrite; all other tool names are ignored", async () => {
+    await fc.assert(
+      fc.asyncProperty(toolNameArb, nonHypaCommandArb, async (toolName, command) => {
+        vi.mocked(mockExecFile).mockReset();
+        mockExecFile.mockResolvedValue(
+          execResult(
+            JSON.stringify({ input: command, outcome: "Rewritten", command: `hypa ${command}` }),
+          ),
+        );
+
+        const isShell = toolName === "Bash" || toolName === "exec_command";
+        const commandKey = toolName === "exec_command" ? "cmd" : "command";
+        const args = { [commandKey]: command };
+
+        const result = await toolStartHandler({ toolName, args }, { cwd: "/tmp" });
+
+        if (isShell) {
+          expect(mockExecFile).toHaveBeenCalled();
+          expect(result).toEqual({ args: { [commandKey]: `hypa ${command}` } });
+        } else {
+          expect(mockExecFile).not.toHaveBeenCalled();
+          expect(result).toBeUndefined();
+        }
+      }),
+    );
+  });
+
+  it("skips any command whose core starts with 'hypa'", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.oneof(hypaCommandArb, wrappedHypaCommandArb), async (command) => {
+        vi.mocked(mockExecFile).mockReset();
+        vi.mocked(mockExecFile).mockImplementation(() => {
+          throw new Error("should not be called");
+        });
+
+        const result = await toolStartHandler(
+          { toolName: "Bash", args: { command } },
+          { cwd: "/tmp" },
+        );
+
+        expect(result).toBeUndefined();
+        expect(mockExecFile).not.toHaveBeenCalled();
+      }),
+    );
+  });
+
+  it("fails open (returns undefined) for any error from hypaRewrite", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        nonHypaCommandArb,
+        fc.string({ maxLength: 100 }),
+        async (command, errorMsg) => {
+          vi.mocked(mockExecFile).mockReset();
+          mockExecFile.mockRejectedValue(execError(errorMsg));
+
+          const result = await toolStartHandler(
+            { toolName: "Bash", args: { command } },
+            { cwd: "/tmp" },
+          );
+
+          expect(result).toBeUndefined();
+        },
+      ),
+    );
+  });
+
+  it("returns undefined for any Passthrough outcome (no args modification)", async () => {
+    await fc.assert(
+      fc.asyncProperty(nonHypaCommandArb, async (command) => {
+        vi.mocked(mockExecFile).mockReset();
+        mockExecFile.mockResolvedValue(
+          execResult(JSON.stringify({ input: command, outcome: "Passthrough", command })),
+        );
+
+        const result = await toolStartHandler(
+          { toolName: "Bash", args: { command } },
+          { cwd: "/tmp" },
+        );
+
+        expect(result).toBeUndefined();
+      }),
+    );
+  });
+
+  it("preserves all other args when rewriting (Bash)", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        nonHypaCommandArb,
+        fc.record({
+          extra1: fc.string({ maxLength: 20 }),
+          extra2: fc.integer(),
+          extra3: fc.boolean(),
+        }),
+        async (command, extra) => {
+          vi.mocked(mockExecFile).mockReset();
+          const wrapped = `hypa ${command}`;
+          mockExecFile.mockResolvedValue(
+            execResult(JSON.stringify({ input: command, outcome: "Rewritten", command: wrapped })),
+          );
+
+          const result = await toolStartHandler(
+            { toolName: "Bash", args: { command, ...extra } },
+            { cwd: "/tmp" },
+          );
+
+          expect(result).toEqual({ args: { command: wrapped, ...extra } });
+        },
+      ),
+    );
+  });
+
+  it("preserves all other args when rewriting (exec_command)", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        nonHypaCommandArb,
+        fc.record({
+          timeout: fc.integer(),
+          shell: fc.string({ maxLength: 10 }),
+        }),
+        async (command, extra) => {
+          vi.mocked(mockExecFile).mockReset();
+          const wrapped = `hypa ${command}`;
+          mockExecFile.mockResolvedValue(
+            execResult(JSON.stringify({ input: command, outcome: "Rewritten", command: wrapped })),
+          );
+
+          const result = await toolStartHandler(
+            { toolName: "exec_command", args: { cmd: command, ...extra } },
+            { cwd: "/tmp" },
+          );
+
+          expect(result).toEqual({ args: { cmd: wrapped, ...extra } });
+        },
+      ),
+    );
+  });
+
+  it("recovers any recognized outcome from non-zero exit in handler", async () => {
+    await fc.assert(
+      fc.asyncProperty(nonHypaCommandArb, rewriteResultArb, async (command, expected) => {
+        vi.mocked(mockExecFile).mockReset();
+        mockExecFile.mockRejectedValue(execError("Command failed", 1, JSON.stringify(expected)));
+
+        const result = await toolStartHandler(
+          { toolName: "Bash", args: { command } },
+          { cwd: "/tmp" },
+        );
+
+        if (expected.outcome === "Rewritten" || expected.outcome === "GenericWrapper") {
+          expect(result).toEqual({ args: { command: expected.command } });
+        } else {
+          expect(result).toBeUndefined();
+        }
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypaExec — passthrough and error propagation
+// ---------------------------------------------------------------------------
+
+describe("PBT: hypaExec", () => {
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+  });
+
+  it("returns stdout unchanged for any string output", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string({ maxLength: 1000 }), async (output) => {
+        mockExecFile.mockResolvedValue(execResult(output));
+
+        const result = await hypaExec(["read", "/tmp/test.txt"], "/tmp");
+
+        expect(result).toBe(output);
+      }),
+    );
+  });
+
+  it("throws with stderr as message for any error with non-empty stderr", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ maxLength: 200 }).filter((s) => s.trim().length > 0),
+        async (stderr) => {
+          mockExecFile.mockRejectedValue(execError(stderr));
+
+          // hypaExec trims stderr before throwing, so the thrown message is the trimmed version
+          await expect(hypaExec(["read", "/nonexistent"], "/tmp")).rejects.toThrow(stderr.trim());
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypa_read — arg construction
+// ---------------------------------------------------------------------------
+
+describe("PBT: hypa_read arg construction", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolRun: (ctx: { cwd: string; args: Record<string, unknown> }) => Promise<unknown>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    letta = makeLettaApi();
+    (letta.tools?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (tool: { name: string; run: typeof toolRun }) => {
+        if (tool.name === "hypa_read") toolRun = tool.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("constructs correct args for any non-empty path and mode", async () => {
+    await fc.assert(
+      fc.asyncProperty(nonEmptyStringArb, readModeArb, async (path, mode) => {
+        let capturedArgs: unknown[] = [];
+        mockExecFile.mockImplementation((_bin, args) => {
+          capturedArgs = args as unknown[];
+          return execResult("output");
+        });
+
+        await toolRun({ cwd: "/tmp", args: { path, mode } });
+
+        // The tool trims the path before passing it to hypa
+        const trimmedPath = path.trim();
+        expect(capturedArgs).toContain("read");
+        expect(capturedArgs).toContain(trimmedPath);
+        expect(capturedArgs).toContain("--mode");
+        expect(capturedArgs).toContain(mode);
+      }),
+    );
+  });
+
+  it("returns error for any empty or missing path", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.oneof(fc.constant(""), fc.constant(undefined), fc.constant("   ")),
+        async (path) => {
+          const result = await toolRun({ cwd: "/tmp", args: { path } });
+          expect(result).toEqual({ status: "error", content: "path is required" });
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypa_search — arg construction
+// ---------------------------------------------------------------------------
+
+describe("PBT: hypa_search arg construction", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolRun: (ctx: { cwd: string; args: Record<string, unknown> }) => Promise<unknown>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    letta = makeLettaApi();
+    (letta.tools?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (tool: { name: string; run: typeof toolRun }) => {
+        if (tool.name === "hypa_search") toolRun = tool.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("constructs correct args for any non-empty query, scope, and kind", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        nonEmptyStringArb,
+        searchScopeArb,
+        searchKindArb,
+        async (query, scope, kind) => {
+          let capturedArgs: unknown[] = [];
+          mockExecFile.mockImplementation((_bin, args) => {
+            capturedArgs = args as unknown[];
+            return execResult("results");
+          });
+
+          await toolRun({ cwd: "/tmp", args: { query, scope, kind } });
+
+          // The tool trims the query before passing it to hypa
+          const trimmedQuery = query.trim();
+          expect(capturedArgs).toContain("search");
+          expect(capturedArgs).toContain(trimmedQuery);
+          expect(capturedArgs).toContain("--scope");
+          expect(capturedArgs).toContain(scope);
+          expect(capturedArgs).toContain("--kind");
+          expect(capturedArgs).toContain(kind);
+        },
+      ),
+    );
+  });
+
+  it("returns error for any empty or missing query", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.oneof(fc.constant(""), fc.constant(undefined), fc.constant("   ")),
+        async (query) => {
+          const result = await toolRun({ cwd: "/tmp", args: { query } });
+          expect(result).toEqual({ status: "error", content: "query is required" });
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: hypa_compress — stdin passthrough
+// ---------------------------------------------------------------------------
+
+describe("PBT: hypa_compress stdin passthrough", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolRun: (ctx: { cwd: string; args: Record<string, unknown> }) => Promise<unknown>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    letta = makeLettaApi();
+    (letta.tools?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (tool: { name: string; run: typeof toolRun }) => {
+        if (tool.name === "hypa_compress") toolRun = tool.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("passes any non-empty text as stdin input with correct kind", async () => {
+    await fc.assert(
+      fc.asyncProperty(nonEmptyStringArb, compressKindArb, async (text, kind) => {
+        let capturedInput: string | undefined;
+        let capturedArgs: unknown[] = [];
+        mockExecFile.mockImplementation((_bin, args, opts) => {
+          capturedArgs = args as unknown[];
+          capturedInput = (opts as Record<string, unknown>).input as string;
+          return execResult("compressed");
+        });
+
+        await toolRun({ cwd: "/tmp", args: { text, kind } });
+
+        expect(capturedInput).toBe(text);
+        expect(capturedArgs).toContain("compress");
+        expect(capturedArgs).toContain("--kind");
+        expect(capturedArgs).toContain(kind);
+      }),
+    );
+  });
+
+  it("returns error for any empty text", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.constant(""), async (text) => {
+        const result = await toolRun({ cwd: "/tmp", args: { text } });
+        expect(result).toEqual({ status: "error", content: "text is required" });
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: session stats parsing
+// ---------------------------------------------------------------------------
+
+describe("PBT: /hypa command session stats parsing", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let commandRun: (ctx: { cwd: string; args: string }) => Promise<{ type: string; output: string }>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+    letta = makeLettaApi();
+    (letta.commands?.register as ReturnType<typeof vi.fn>).mockImplementation(
+      (cmd: { id: string; run: typeof commandRun }) => {
+        if (cmd.id === "hypa") commandRun = cmd.run;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("extracts tokens_saved and tool_calls for any valid session status output", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.nat({ max: 100000 }),
+        fc.nat({ max: 100000 }),
+        async (tokensSaved, toolCalls) => {
+          mockExecFile.mockImplementation((_bin, args) => {
+            if (args?.includes?.("session")) {
+              return execResult(
+                `id:           test-id\nproject_root: /tmp\ncreated_at:   2026-01-01T00:00:00Z\nupdated_at:   2026-01-01T00:00:00Z\ntool_calls:   ${toolCalls}\nfile_touches: 0\ntokens_saved: ${tokensSaved}\n`,
+              );
+            }
+            return execResult("");
+          });
+
+          const result = await commandRun({ cwd: "/tmp", args: "" });
+
+          expect(result.output).toContain(`Tokens saved: ${tokensSaved}`);
+          expect(result.output).toContain(`Tool calls:   ${toolCalls}`);
+        },
+      ),
+    );
+  });
+
+  it("omits session section for any session status error", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string({ maxLength: 100 }), async (errorMsg) => {
+        mockExecFile.mockImplementation((_bin, args) => {
+          if (args?.includes?.("session")) {
+            return Promise.reject(execError(errorMsg));
+          }
+          return execResult("");
+        });
+
+        const result = await commandRun({ cwd: "/tmp", args: "" });
+
+        expect(result.output).toContain("Mod stats (this session):");
+        expect(result.output).not.toContain("Hypa session:");
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: extractCommandParts — round-trip and extraction properties
+// ---------------------------------------------------------------------------
+
+describe("PBT: extractCommandParts", () => {
+  it("prefix + core + suffix reconstructs the original command", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string({ maxLength: 200 }), async (command) => {
+        const parts = extractCommandParts(command);
+        expect(parts.prefix + parts.core + parts.suffix).toBe(command);
+      }),
+    );
+  });
+
+  it("core does not start with 'cd ' when a cd prefix was extracted", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string({ maxLength: 200 }), async (command) => {
+        const parts = extractCommandParts(command);
+        if (parts.prefix) {
+          expect(parts.core.startsWith("cd ")).toBe(false);
+        }
+      }),
+    );
+  });
+
+  it("core does not end with '2>&1' when a suffix was extracted", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string({ maxLength: 200 }), async (command) => {
+        const parts = extractCommandParts(command);
+        if (parts.suffix) {
+          expect(parts.core.endsWith("2>&1")).toBe(false);
+        }
+      }),
+    );
+  });
+
+  it("returns empty prefix and suffix for bare commands without cd or redirect", async () => {
+    await fc.assert(
+      fc.asyncProperty(nonHypaCommandArb, async (command) => {
+        // Ensure the command doesn't start with cd or end with 2>&1
+        const noCd = command.trimStart().startsWith("cd ") ? `x ${command}` : command;
+        const bare = noCd.endsWith("2>&1") ? noCd.slice(0, -4) : noCd;
+
+        const parts = extractCommandParts(bare);
+        expect(parts.prefix).toBe("");
+        expect(parts.suffix).toBe("");
+        expect(parts.core).toBe(bare);
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tool_start handler — cd/redirect stripping with reconstruction
+// ---------------------------------------------------------------------------
+
+describe("PBT: tool_start handler cd/redirect stripping", () => {
+  let letta: LettaModApi;
+  let dispose: (() => void) | undefined;
+  let toolStartHandler: (
+    event: { toolName: string; args: Record<string, unknown> },
+    ctx: { cwd?: string },
+  ) => Promise<{ args: Record<string, unknown> } | undefined>;
+
+  beforeEach(() => {
+    vi.mocked(mockExecFile).mockReset();
+    resetRewriteState();
+    letta = makeLettaApi();
+    (letta.events?.on as ReturnType<typeof vi.fn>).mockImplementation(
+      (_name: string, handler: typeof toolStartHandler) => {
+        toolStartHandler = handler;
+        return () => {};
+      },
+    );
+    dispose = activate(letta);
+  });
+
+  afterEach(() => {
+    dispose?.();
+  });
+
+  it("rewrites core and re-attaches prefix+suffix for any wrapped command", async () => {
+    await fc.assert(
+      fc.asyncProperty(wrappedCommandArb, async ({ full }) => {
+        vi.mocked(mockExecFile).mockReset();
+
+        // Use extractCommandParts to determine what the handler will actually send to hypa
+        const parts = extractCommandParts(full);
+        if (!parts.core.trim()) return; // skip empty core
+
+        const wrapped = `hypa ${parts.core}`;
+        mockExecFile.mockResolvedValue(
+          execResult(
+            JSON.stringify({
+              input: parts.core,
+              outcome: "Rewritten",
+              command: wrapped,
+            }),
+          ),
+        );
+
+        const result = await toolStartHandler(
+          { toolName: "Bash", args: { command: full } },
+          { cwd: "/tmp" },
+        );
+
+        // The rewritten command should be prefix + wrapped + suffix
+        expect(result).toBeDefined();
+        const rewritten = (result?.args?.command as string) ?? "";
+        expect(rewritten).toBe(`${parts.prefix}${wrapped}${parts.suffix}`);
+      }),
+    );
+  });
+
+  it("passes through original when core is Passthrough", async () => {
+    await fc.assert(
+      fc.asyncProperty(wrappedCommandArb, async ({ full, core }) => {
+        vi.mocked(mockExecFile).mockReset();
+        mockExecFile.mockResolvedValue(
+          execResult(JSON.stringify({ input: core, outcome: "Passthrough", command: core })),
+        );
+
+        const result = await toolStartHandler(
+          { toolName: "Bash", args: { command: full } },
+          { cwd: "/tmp" },
+        );
+
+        // Passthrough — no modification
+        expect(result).toBeUndefined();
+      }),
+    );
+  });
+
+  it("preserves other args when stripping cd/redirect", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        wrappedCommandArb,
+        fc.record({
+          timeout: fc.integer({ min: 0, max: 60000 }),
+          shell: fc.string({ maxLength: 10 }),
+        }),
+        async ({ full, core }, extra) => {
+          vi.mocked(mockExecFile).mockReset();
+          const wrapped = `hypa ${core}`;
+          mockExecFile.mockResolvedValue(
+            execResult(JSON.stringify({ input: core, outcome: "Rewritten", command: wrapped })),
+          );
+
+          const result = await toolStartHandler(
+            { toolName: "Bash", args: { command: full, ...extra } },
+            { cwd: "/tmp" },
+          );
+
+          expect(result).toBeDefined();
+          // Other args preserved
+          expect(result?.args?.timeout).toBe(extra.timeout);
+          expect(result?.args?.shell).toBe(extra.shell);
+        },
+      ),
+    );
+  });
+});

--- a/packages/hypa/tsconfig.json
+++ b/packages/hypa/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node", "vitest"]
+  },
+  "include": ["mods/**/*.ts"],
+  "exclude": ["tests/**/*.ts", "node_modules"]
+}


### PR DESCRIPTION
## Summary

Integrates [Hypa](https://github.com/Hypabolic/Hypa) — a local context runtime that compresses noisy tool output via deterministic, local rewriting — into Letta Code as a new mod package.

The mod intercepts `Bash` and `exec_command` tool calls and rewrites the command through `hypa rewrite --json`. When Hypa recognizes a command (e.g. `git status`, `npm install`, `npm run ci`), it wraps it so the output is compressed before the model sees it. The mod strips the harness `cd <workdir> &&` prefix and `2>&1` suffix so Hypa's reducers can match the core command, then re-attaches them after rewriting.

## What's included

- **Shell command rewriting** via `tool_start` event for `Bash` and `exec_command` tools
- **`/hypa` diagnostics command** showing binary availability, last rewrite, mod stats, and session stats (prefers command metrics from `~/.hypa/hypa.db` over stale `hypa session status` counters)
- **CLI-backed tools**: `hypa_diagnostics`, `hypa_read`, `hypa_search`, `hypa_compress`
- **Optional MCP proxy** (`hypa_mcp_proxy`, env-gated via `HYPA_LETTA_ENABLE_MCP_PROXY=1`, approval-required because `invoke` can be side-effectful)
- **Fail-open behavior**: missing Hypa binary or rewrite errors leave commands unchanged
- **Safety guards**: skips already-wrapped (`hypa ...`), multi-line, and heredoc commands to avoid changing shell semantics

## Package details

- `packages/hypa/` with `package.json`, `MOD.md`, `README.md`, `tsconfig.json`, `biome.json`
- Package-local linting via Biome (does not impose root-wide formatting on other mods)
- 107 tests (74 example-based + 33 property-based with fast-check)
- Quality gate: `npm run ci` → `vitest run && tsc --noEmit && biome check .`

## Test plan

- [ ] Install the [Hypa CLI](https://github.com/Hypabolic/Hypa) and ensure `hypa` is on `PATH`
- [ ] `cd packages/hypa && npm install && npm run ci` — 107 tests pass, typecheck clean, Biome clean
- [ ] `npm run validate` at repo root — all mod package manifests valid
- [ ] Install locally (copy `mods/index.ts` to `~/.letta/mods/letta-hypa.ts`), `/reload`, run `/hypa` — diagnostics render correctly with `Available: yes`
- [ ] Run a shell command (e.g. `git status`) and verify Hypa footer appears in compressed output
- [ ] Verify `cd /repo && hypa git status 2>&1` is NOT double-wrapped
- [ ] Verify heredoc/multi-line commands are not rewritten
- [ ] Uninstall Hypa (or set `HYPA_BIN=/nonexistent`), `/reload`, run `/hypa` — shows `Available: no` with install guidance, shell commands run unchanged

👾 Generated with [Letta Code](https://letta.com)
