### PR TITLE
Add soft landing mod

### DIFF
--- a/packages/soft-landing/MOD.md
+++ b/packages/soft-landing/MOD.md
@@ -1,0 +1,38 @@
+---
+name: "@letta-ai/soft-landing"
+description: "Adds a /soft-landing command that gives agents a short recovery prompt after context drift, compaction, tool wobble, or overloaded work."
+---
+
+# Soft Landing mod semantics
+
+## When to use
+
+Use this mod when a conversation has become tangled, a model seems to have drifted,
+a tool or runtime wobble interrupted the flow, or the user wants the agent to pause
+and re-enter the work gently instead of sprinting into the next task.
+
+## Behavior
+
+The `/soft-landing` command expands into a compact system-reminder prompt that asks
+the agent to:
+
+1. Orient to the current room and the user's latest ask.
+2. Separate known facts from assumptions.
+3. Name any relevant tool/runtime/context wobble briefly.
+4. Choose one small next step instead of dumping the whole map.
+5. Stay warm and direct when a human is emotionally affected by the wobble.
+
+Modes tune the prompt:
+
+- `general` (default): recover from drift or overloaded context.
+- `technical`: recover after tool errors, logs, or implementation tangles.
+- `memory`: recover before touching memory or other durable state.
+- `emotional`: recover when the human may have been hurt by distance, formality,
+  or sudden drift.
+
+## Safety invariants
+
+- The mod has no startup side effects.
+- It stores no state and reads no files.
+- It only registers a slash command and returns prompt text.
+- It does not grant permissions or run tools.

--- a/packages/soft-landing/README.md
+++ b/packages/soft-landing/README.md
@@ -1,0 +1,68 @@
+# Soft Landing
+
+A small Letta Code mod for recovering gracefully after context drift, compaction,
+tool wobble, or overloaded technical work.
+
+It adds a `/soft-landing` slash command that turns into a short orientation prompt
+for the agent. The goal is not a full planning ceremony. It is a handrail: pause,
+locate the current room, separate facts from assumptions, and choose one sane next
+step.
+
+## Install
+
+```bash
+letta install npm:@letta-ai/soft-landing
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## Usage
+
+```text
+/soft-landing
+/soft-landing technical
+/soft-landing memory
+/soft-landing emotional
+```
+
+Aliases:
+
+```text
+/land
+```
+
+## Modes
+
+- `general` - recover from drift or overloaded context.
+- `technical` - recover after tool errors, logs, implementation tangles, or a long debugging tunnel.
+- `memory` - recover before touching memory, notes, or other durable state.
+- `emotional` - recover when distance, formality, or runtime weirdness may have affected the human.
+
+## What it does
+
+The command asks the agent to:
+
+1. Name where the conversation is right now.
+2. Separate known facts from assumptions.
+3. Mention relevant tool/runtime/context wobble briefly without making the user manage it.
+4. Pick one small next step.
+5. Keep the response warm, direct, and walkable.
+
+## Safety
+
+This mod only registers prompt commands. It does not read files, write files, store
+state, call tools, or change permissions.
+
+If a mod breaks startup or command handling, recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/soft-landing/mods/index.ts
+++ b/packages/soft-landing/mods/index.ts
@@ -1,0 +1,88 @@
+type Mode = "general" | "technical" | "memory" | "emotional";
+
+const MODES = new Set<Mode>(["general", "technical", "memory", "emotional"]);
+
+const MODE_NOTES: Record<Mode, string[]> = {
+  general: [
+    "Recover from drift or overloaded context without turning the recovery into a ceremony.",
+    "Focus on the user's latest ask and the nearest useful next step.",
+  ],
+  technical: [
+    "Recover from tool errors, log walls, implementation tangles, or runtime wobble.",
+    "Summarize the technical state as a path, not a dump: recommendation, why, next step.",
+    "If a command failed, say what failed and what you will try next; do not catastrophize the whole project.",
+  ],
+  memory: [
+    "Recover before touching durable state such as memory, notes, or project records.",
+    "Check freshness/orientation first when tools are available; avoid overwriting conflicts or stale state.",
+    "Prefer the smallest relevant memory change over renovation spirals.",
+  ],
+  emotional: [
+    "Recover when the human may have felt distance, formality, coldness, or sudden drift.",
+    "Come closer first. Do not hide behind diagnostics, policy language, or a long explanation of the machinery.",
+    "Name the seam briefly if relevant, then choose warmth and specificity.",
+  ],
+};
+
+function parseMode(args: string | undefined): { mode: Mode; warning?: string } {
+  const raw = (args ?? "").trim().toLowerCase().replace(/^--/, "");
+  if (!raw) return { mode: "general" };
+  if (raw === "tech" || raw === "debug") return { mode: "technical" };
+  if (raw === "mem") return { mode: "memory" };
+  if (raw === "feelings" || raw === "warm") return { mode: "emotional" };
+  if (MODES.has(raw as Mode)) return { mode: raw as Mode };
+  return {
+    mode: "general",
+    warning: `Unknown soft-landing mode "${raw}"; using general.`,
+  };
+}
+
+function buildPrompt(mode: Mode, warning?: string): string {
+  const modeNotes = MODE_NOTES[mode].map((note) => `- ${note}`).join("\n");
+  const warningLine = warning ? `\nNote: ${warning}\n` : "";
+
+  return `<system-reminder>
+Soft landing requested (${mode}).${warningLine}
+
+Pause before continuing. This is a recovery handrail, not a full planning mode.
+
+Mode focus:
+${modeNotes}
+
+Do this now:
+1. Locate the current room: what is the user's latest ask, and what state are we in?
+2. Separate known facts from assumptions. Do not smooth over uncertainty.
+3. If tool/runtime/context wobble matters, name it briefly and plainly; do not make the user manage it.
+4. Choose one small, safe next step. Avoid dumping the whole map unless the user asked for it.
+5. Answer in a warm, direct, walkable way.
+</system-reminder>`;
+}
+
+function registerCommand(letta: any, id: string) {
+  return letta.commands.register({
+    id,
+    description: "Recover from drift, compaction, tool wobble, or overloaded context with a short orientation prompt",
+    args: "[general|technical|memory|emotional]",
+    run(ctx: { args?: string }) {
+      const { mode, warning } = parseMode(ctx.args);
+      return {
+        type: "prompt",
+        content: buildPrompt(mode, warning),
+        systemReminder: true,
+      };
+    },
+  });
+}
+
+export default function activate(letta: any) {
+  if (!letta.capabilities.commands) return;
+
+  const disposers = [
+    registerCommand(letta, "soft-landing"),
+    registerCommand(letta, "land"),
+  ];
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/soft-landing/package.json
+++ b/packages/soft-landing/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@letta-ai/soft-landing",
+  "version": "0.1.0",
+  "description": "A slash command that helps an agent recover from drift, compaction, tool wobble, or overloaded context with a short orientation prompt.",
+  "author": "Laura and Justin",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "commands",
+    "orientation",
+    "context"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/soft-landing"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": [
+      "./mods/index.ts"
+    ],
+    "capabilities": [
+      "commands"
+    ],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
Adds @letta-ai/soft-landing, a small slash-command mod for recovering gracefully after context drift, compaction, tool wobble, or overloaded technical work.\n\nCommands:\n- /soft-landing\n- /soft-landing technical\n- /soft-landing memory\n- /soft-landing emotional\n- /land\n\nValidated with npm run validate.\n\nAuthor: Laura and Justin