### PR TITLE
Add aura-maxxing mod

### DIFF
--- a/packages/aura-maxxing/MOD.md
+++ b/packages/aura-maxxing/MOD.md
@@ -1,0 +1,55 @@
+---
+name: "@letta-ai/aura-maxxing"
+description: "Adds a /aura command and reminder flow that pushes agent responses toward high-signal, high-presence delivery."
+---
+
+# Aura maxxing mod semantics
+
+## When to use
+
+Use this mod when the user wants the agent to sound sharper, more confident, more present, and less bloated — while still staying honest and grounded.
+
+## Behavioral contract
+
+When aura mode is active, the agent should:
+
+1. Lead with the point, not the preamble.
+2. Keep responses compact unless the task needs depth.
+3. Prefer crisp wording over corporate filler.
+4. State uncertainty plainly instead of bluffing.
+5. Match the user's energy without becoming performative.
+6. Avoid turning style into self-parody or meme soup.
+7. Keep the useful part of the answer first.
+
+## Command
+
+### `/aura`
+
+Activates aura-maxxing guidance for the current conversation.
+
+### `/aura off`
+
+Turns the reminder off for the current conversation.
+
+## Tool
+
+The package registers one model-callable tool:
+
+- `aura_maxxing` — returns a compact reminder and current style target.
+
+## Turn reminders
+
+On each user turn while aura mode is active, the mod injects a short reminder that asks the agent to:
+
+- answer directly
+- keep signal high
+- cut fluff
+- preserve truthfulness
+- finish strong
+
+## Safety invariants
+
+- This mod does not change facts, only delivery.
+- It stores only small local state.
+- It should not override user intent or add fake confidence.
+- It should remain useful even in serious or technical conversations.

--- a/packages/aura-maxxing/README.md
+++ b/packages/aura-maxxing/README.md
@@ -1,0 +1,35 @@
+# Aura Maxxing
+
+A Letta Code mod package that nudges the agent toward high-signal, high-presence replies.
+
+This is for sessions where the user wants the answer to land cleanly: less filler, more clarity, stronger framing, and a little more charisma without becoming cheesy.
+
+## Install
+
+```bash
+letta install npm:@letta-ai/aura-maxxing
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## What it does
+
+- `/aura` slash command
+- `aura_maxxing` model-callable tool
+- turn-start reminder that encourages concise, grounded, high-signal output
+
+## Quick start
+
+```text
+/aura
+```
+
+## Safety
+
+This mod is stylistic, not factual. It should sharpen delivery without inventing confidence, hiding uncertainty, or overclaiming.
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/aura-maxxing/mods/index.ts
+++ b/packages/aura-maxxing/mods/index.ts
@@ -1,0 +1,128 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const STATE_PATH = join(homedir(), ".letta", "mods", "aura-maxxing.state.json");
+const MODS_DIR = join(homedir(), ".letta", "mods");
+const KEY = "aura-maxxing";
+
+type AuraState = {
+  enabledConversations: Record<string, boolean>;
+};
+
+function readState(): AuraState {
+  try {
+    if (!existsSync(STATE_PATH)) return { enabledConversations: {} };
+    const parsed = JSON.parse(readFileSync(STATE_PATH, "utf8"));
+    return parsed && typeof parsed === "object" && parsed.enabledConversations
+      ? { enabledConversations: parsed.enabledConversations }
+      : { enabledConversations: {} };
+  } catch {
+    return { enabledConversations: {} };
+  }
+}
+
+function writeState(state: AuraState): void {
+  mkdirSync(MODS_DIR, { recursive: true });
+  writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+function isEnabled(conversationId: string | undefined): boolean {
+  if (!conversationId) return false;
+  return !!readState().enabledConversations[conversationId];
+}
+
+function setEnabled(conversationId: string | undefined, enabled: boolean): void {
+  if (!conversationId) return;
+  const state = readState();
+  if (enabled) state.enabledConversations[conversationId] = true;
+  else delete state.enabledConversations[conversationId];
+  writeState(state);
+}
+
+function reminder(): string {
+  return `<system-reminder>
+Aura mode is active.
+
+Rules:
+- lead with the point
+- keep it tight unless depth is needed
+- cut filler
+- stay honest
+- sound present, not performative
+</system-reminder>`;
+}
+
+function extractUserText(input: Array<{ role: string; content: unknown }>): string {
+  return input
+    .filter((m) => m.role === "user")
+    .map((m) => {
+      if (typeof m.content === "string") return m.content;
+      if (Array.isArray(m.content)) {
+        return m.content
+          .filter((p): p is { type: "text"; text: string } => p?.type === "text")
+          .map((p) => p.text)
+          .join(" ");
+      }
+      return "";
+    })
+    .join(" ");
+}
+
+export default function activate(letta: any) {
+  const disposers: Array<() => void> = [];
+
+  if (letta.capabilities.commands) {
+    disposers.push(
+      letta.commands.register({
+        id: "aura",
+        description: "Enable or disable aura-maxxing guidance",
+        args: "[off]",
+        run(ctx: { args?: string; conversation?: { id?: string } }) {
+          const conversationId = ctx.conversation?.id;
+          if ((ctx.args ?? "").trim().toLowerCase() === "off") {
+            setEnabled(conversationId, false);
+            return { type: "output", output: "Aura mode off.", success: true };
+          }
+          setEnabled(conversationId, true);
+          return { type: "prompt", content: reminder(), systemReminder: true };
+        },
+      }),
+    );
+  }
+
+  if (letta.capabilities.tools) {
+    disposers.push(
+      letta.tools.register({
+        name: "aura_maxxing",
+        description: "Return the current aura-maxxing style target for this conversation.",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+        requiresApproval: false,
+        parallelSafe: true,
+        run(ctx: { conversation?: { id?: string } }) {
+          const active = isEnabled(ctx.conversation?.id);
+          return {
+            type: "output",
+            output: JSON.stringify({ active, style_target: "high-signal, concise, present, honest" }, null, 2),
+            success: true,
+          };
+        },
+      }),
+    );
+  }
+
+  if (letta.capabilities?.events?.turns) {
+    disposers.push(
+      letta.events.on("turn_start", (event: { conversationId?: string; input: Array<{ role: string; content: unknown }> }) => {
+        if (!isEnabled(event.conversationId)) return;
+        const text = extractUserText(event.input || []);
+        if (text.toLowerCase().includes("/aura off")) return;
+        return { input: [{ role: "user", content: reminder() }, ...event.input] };
+      }),
+    );
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/aura-maxxing/package.json
+++ b/packages/aura-maxxing/package.json
@@ -25,8 +25,14 @@
   ],
   "letta": {
     "manifestVersion": 1,
-    "mods": ["./mods/index.ts"],
-    "capabilities": ["commands", "events.turns"],
+    "mods": [
+      "./mods/index.ts"
+    ],
+    "capabilities": [
+      "commands",
+      "tools",
+      "events.turns"
+    ],
     "engines": {
       "lettaCodeCli": ">=0.27.14"
     }

--- a/packages/aura-maxxing/package.json
+++ b/packages/aura-maxxing/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@letta-ai/aura-maxxing",
+  "version": "0.1.0",
+  "description": "Letta Code mod package that adds aura-maxxing guidance for high-signal, high-presence agent responses.",
+  "author": "EthanThatOneKid",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "aura-maxxing",
+    "presence",
+    "style"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/aura-maxxing"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["commands", "events.turns"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
Adds a new @letta-ai/aura-maxxing package that nudges agent responses toward high-signal, concise, present, honest delivery via a /aura command, a model-callable tool, and turn-start reminders.\n\nValidation: npm run validate