### PR TITLE
Update conversation summary mod context

### DIFF
--- a/packages/conversation-summary/MOD.md
+++ b/packages/conversation-summary/MOD.md
@@ -12,24 +12,20 @@ Use this mod when the user wants Letta Code's idle statusline to show the curren
 ## Behavior
 
 - Registers an order-0 panel, replacing the built-in agent/model line while idle.
-- Shows the current conversation summary on the left side of the statusline.
+- Shows the host-provided `ctx.conversationSummary` on the left side of the statusline.
 - Renders the agent name and model on the right so the row stays useful when the conversation has no summary yet.
-- Fetches on `conversation_open`; it does not poll.
-- Uses `letta.client.conversations.retrieve(conversationId)` for API-backed conversations.
-- Supports local agents by reading local backend conversation metadata from `~/.letta/lc-local-backend/conversations/<base64url-key>/conversation.json`.
-- Honors `LETTA_LOCAL_BACKEND_DIR` when resolving local backend storage.
+- Does not poll, fetch conversation records, call the model, or read local conversation files.
 - Clears the left segment when the current conversation summary is empty or unavailable.
 
 ## Safety invariants
 
 - Renderer stays synchronous and side-effect-free.
-- API/file reads happen only during activation and lifecycle events, never during render.
-- Local file access is read-only and limited to local backend conversation metadata.
+- The mod only reads host-provided panel context.
 - The panel is closed when the mod is disposed.
-- Panel and lifecycle APIs are capability-guarded.
+- Panel API is capability-guarded.
 
 ## Adaptation notes for agents
 
-- Keep this mod one-fetch-per-open; do not add polling unless the user explicitly wants live title refresh.
+- This package requires Letta Code `>=0.27.21` because it depends on `ctx.conversationSummary` in panel render context.
 - If adding a fallback label, preserve the distinction between “no summary yet” and a real conversation title.
 - If composing with other statusline data, remember an order-0 panel owns the full idle row.

--- a/packages/conversation-summary/README.md
+++ b/packages/conversation-summary/README.md
@@ -22,25 +22,22 @@ Then reload local mods:
 
 - Current conversation summary/title on the left side of the idle statusline
 - Fallback right-side agent/model display
-- Support for both API-backed and local agents
 
 ## Behavior
 
-- Fetches the conversation summary when a conversation opens.
-- Does not poll or call the model.
-- Uses the Letta API client for API-backed conversations.
-- Reads local agent conversation metadata from `~/.letta/lc-local-backend/conversations/.../conversation.json`, respecting `LETTA_LOCAL_BACKEND_DIR`.
+- Reads the current conversation summary from the host-provided panel context.
+- Does not poll, call the model, call the Letta API, or read local conversation files.
 - Renders no left segment when the current conversation has no summary yet.
 
 ## Requirements
 
-- Letta Code `>=0.27.20` with panel-based statusline support and lifecycle events
+- Letta Code `>=0.27.21` with panel context `conversationSummary` support
 
 ## Safety
 
 Mods are trusted local code. Review the source before installing third-party mods.
 
-This mod reads conversation metadata and does not mutate files or conversations.
+This mod only renders host-provided context and does not mutate files or conversations.
 
 If a mod breaks startup or command handling, recover with:
 

--- a/packages/conversation-summary/mods/index.tsx
+++ b/packages/conversation-summary/mods/index.tsx
@@ -1,102 +1,15 @@
-import { Buffer } from "node:buffer";
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
 function cleanSummary(summary: unknown): string | null {
   return typeof summary === "string" && summary.trim() ? summary.trim() : null;
-}
-
-function localBackendStorageDir(): string {
-  return (
-    process.env.LETTA_LOCAL_BACKEND_DIR ??
-    join(homedir(), ".letta", "lc-local-backend")
-  );
-}
-
-function encodePathSegment(value: string): string {
-  return Buffer.from(value).toString("base64url");
-}
-
-function summaryKey(
-  conversationId: string | null | undefined,
-  agentId: string | null | undefined,
-): string | null {
-  if (!conversationId) return null;
-  return conversationId === "default"
-    ? `default:${agentId ?? ""}`
-    : conversationId;
-}
-
-function localConversationKey(
-  conversationId: string,
-  agentId: string | null | undefined,
-): string | null {
-  if (conversationId === "default") {
-    return agentId ? `default:${agentId}` : null;
-  }
-  return `conversation:${conversationId}`;
-}
-
-function isLocalConversation(
-  conversationId: string,
-  agentId: string | null | undefined,
-): boolean {
-  return agentId?.startsWith("agent-local-") === true ||
-    conversationId.startsWith("local-conv-") ||
-    conversationId === "default";
-}
-
-function readLocalConversationSummary(
-  conversationId: string,
-  agentId: string | null | undefined,
-): string | null | undefined {
-  const key = localConversationKey(conversationId, agentId);
-  if (!key) return undefined;
-
-  const conversationPath = join(
-    localBackendStorageDir(),
-    "conversations",
-    encodePathSegment(key),
-    "conversation.json",
-  );
-  if (!existsSync(conversationPath)) return undefined;
-
-  try {
-    const conversation = JSON.parse(readFileSync(conversationPath, "utf8"));
-    return cleanSummary(conversation?.summary);
-  } catch {
-    return undefined;
-  }
 }
 
 export default function activate(letta: any) {
   if (!letta.capabilities.ui?.panels) return;
 
-  let activeConversationId: string | null = process.env.CONVERSATION_ID ?? null;
-  let activeAgentId: string | null =
-    process.env.LETTA_AGENT_ID ?? process.env.AGENT_ID ?? null;
-  const summariesByConversation = new Map<string, string>();
-
-  const setSummary = (
-    conversationId: string,
-    agentId: string | null | undefined,
-    summary: string | null,
-  ) => {
-    const key = summaryKey(conversationId, agentId);
-    if (!key) return;
-    if (summary) summariesByConversation.set(key, summary);
-    else summariesByConversation.delete(key);
-  };
-
   const panel = letta.ui.openPanel({
     id: "conversation-summary",
     order: 0,
-    render({ width, sessionId, agent, model, row, chalk }: any) {
-      const conversationId = sessionId ?? activeConversationId;
-      const agentId = agent.id ?? activeAgentId;
-      const key = summaryKey(conversationId, agentId);
-      const summary = key ? summariesByConversation.get(key) : null;
+    render({ width, agent, model, conversationSummary, row, chalk }: any) {
+      const summary = cleanSummary(conversationSummary);
       const left = summary ? chalk.hex("#8C8CF9")(summary) : "";
       const modelLabel = model.displayName ?? model.id ?? "unknown";
       const right = chalk.dim(`${agent.name ?? "Letta"} · ${modelLabel}`);
@@ -105,53 +18,5 @@ export default function activate(letta: any) {
     },
   });
 
-  async function fetchConversationSummary(
-    conversationId: string | null | undefined,
-    agentId: string | null | undefined,
-  ) {
-    if (!conversationId) return;
-
-    if (isLocalConversation(conversationId, agentId)) {
-      const localSummary = readLocalConversationSummary(conversationId, agentId);
-      if (localSummary !== undefined) {
-        setSummary(conversationId, agentId, localSummary);
-        if (conversationId === activeConversationId) panel.update();
-        return;
-      }
-      if (agentId?.startsWith("agent-local-") || conversationId === "default") {
-        setSummary(conversationId, agentId, null);
-        if (conversationId === activeConversationId) panel.update();
-        return;
-      }
-    }
-
-    try {
-      const conversation = await letta.client.conversations.retrieve(
-        conversationId,
-      );
-      setSummary(conversationId, agentId, cleanSummary(conversation?.summary));
-      if (conversationId === activeConversationId) panel.update();
-    } catch {
-      // Keep the previous cached title/fallback if the fetch fails.
-    }
-  }
-
-  const disposers: Array<() => void> = [];
-
-  if (letta.capabilities.events?.lifecycle) {
-    disposers.push(
-      letta.events.on("conversation_open", (event: any) => {
-        activeConversationId = event.conversationId ?? null;
-        activeAgentId = event.agentId ?? null;
-        void fetchConversationSummary(activeConversationId, activeAgentId);
-      }),
-    );
-  }
-
-  void fetchConversationSummary(activeConversationId, activeAgentId);
-
-  return () => {
-    for (const dispose of disposers.reverse()) dispose();
-    panel.close();
-  };
+  return () => panel.close();
 }

--- a/packages/conversation-summary/package.json
+++ b/packages/conversation-summary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/conversation-summary",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Letta Code statusline mod that shows the current conversation summary.",
   "author": "carenthomas",
   "license": "Apache-2.0",
@@ -24,10 +24,14 @@
   ],
   "letta": {
     "manifestVersion": 1,
-    "mods": ["./mods/index.tsx"],
-    "capabilities": ["ui.panels", "events.lifecycle"],
+    "mods": [
+      "./mods/index.tsx"
+    ],
+    "capabilities": [
+      "ui.panels"
+    ],
     "engines": {
-      "lettaCodeCli": ">=0.27.20"
+      "lettaCodeCli": ">=0.27.21"
     }
   }
 }


### PR DESCRIPTION
## Summary
- simplify `@letta-ai/conversation-summary` to render from host-provided `ctx.conversationSummary`
- remove lifecycle fetch/cache logic and local backend file reads
- bump package version to `0.1.1` and require Letta Code CLI `>=0.27.21`

## Tests
- npm run validate