### PR TITLE
fix(image-understanding): support base64 CLI images, strip image parts, add runtime config, transient feedback

### DIFF
--- a/packages/image-understanding/mods/index.mjs
+++ b/packages/image-understanding/mods/index.mjs
@@ -417,7 +417,7 @@ function extractImageRefsFromContent(content) {
 function replaceImageParts(content, replacementText) {
   if (typeof content === "string") {
     const cleaned = content.replace(/!\[[^\]]*\]\([^)]+\)/g, "").trim();
-    if (!replacementText) return cleaned || content;
+    if (!replacementText) return cleaned || "[image content removed by image-understanding mod]";
     return cleaned ? `${cleaned}\n\n${replacementText}` : replacementText;
   }
   if (!Array.isArray(content)) return content;
@@ -579,6 +579,11 @@ let notifyUser = () => {};
 
 export default function activate(letta) {
   const disposers = [];
+  // Clear any stale runtime overrides from a previous activation so that
+  // non-persisted settings don't survive /reload when the module is cached.
+  for (const key of Object.keys(runtimeOverrides)) {
+    delete runtimeOverrides[key];
+  }
   loadPersistentConfig();
   notifyUser = createNotifier(letta);
 
@@ -699,6 +704,9 @@ export default function activate(letta) {
 
   return () => {
     notifyUser = () => {};
+    for (const key of Object.keys(runtimeOverrides)) {
+      delete runtimeOverrides[key];
+    }
     for (const dispose of disposers.reverse()) dispose();
   };
 }

--- a/packages/image-understanding/mods/index.mjs
+++ b/packages/image-understanding/mods/index.mjs
@@ -200,12 +200,15 @@ async function urlImage(pathOrUrl, signal) {
 }
 
 async function dataUrlImage(pathOrUrl) {
-  const match = pathOrUrl.match(/^data:([^;]+);base64,(.+)$/);
+  const match = pathOrUrl.match(/^data:(image\/[a-z+]+);base64,(.+)$/is);
   if (!match) {
-    throw new Error(`Invalid data URL: ${pathOrUrl.slice(0, 40)}...`);
+    throw new Error(`Invalid image data URI: ${pathOrUrl.slice(0, 40)}...`);
   }
   const [, mime, base64] = match;
   const bytes = Buffer.from(base64, "base64");
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    throw new Error(`Image is too large (${bytes.length} bytes). Limit is ${MAX_IMAGE_BYTES} bytes.`);
+  }
   return { bytes, base64, mime: mime || "image/png", source: "data-url", isUrl: false };
 }
 
@@ -413,7 +416,9 @@ function extractImageRefsFromContent(content) {
  */
 function replaceImageParts(content, replacementText) {
   if (typeof content === "string") {
-    return replacementText ? `${content}\n\n${replacementText}` : content;
+    const cleaned = content.replace(/!\[[^\]]*\]\([^)]+\)/g, "").trim();
+    if (!replacementText) return cleaned || content;
+    return cleaned ? `${cleaned}\n\n${replacementText}` : replacementText;
   }
   if (!Array.isArray(content)) return content;
   const filtered = content.filter((part) => {

--- a/packages/image-understanding/mods/index.mjs
+++ b/packages/image-understanding/mods/index.mjs
@@ -1,9 +1,10 @@
 import { readFile } from "node:fs/promises";
-import { statSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 
 const DEFAULT_PROVIDER = "openai-compatible";
-const DEFAULT_OPENAI_MODEL = "gpt-4o-mini";
+const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_OLLAMA_MODEL = "llava:latest";
 const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
@@ -43,25 +44,93 @@ function normalizeProvider(value) {
   return provider;
 }
 
+const CONFIG_KEYS = {
+  provider: "string",
+  model: "string",
+  baseUrl: "string",
+  maxTokens: "number",
+  allowCloud: "boolean",
+  allowUrls: "boolean",
+  requireLocal: "boolean",
+  autoCaption: "boolean",
+  autoMode: "string",
+  stripImages: "boolean",
+};
+
+function parseConfigValue(key, value) {
+  const type = CONFIG_KEYS[key];
+  if (type === "boolean") {
+    return !["0", "false", "no", "off", ""].includes(String(value).toLowerCase());
+  }
+  if (type === "number") {
+    const n = Number.parseInt(String(value), 10);
+    if (!Number.isFinite(n)) throw new Error(`${key} must be a number.`);
+    return n;
+  }
+  let s = String(value);
+  if (key === "provider") s = normalizeProvider(s);
+  return s;
+}
+
+// Runtime overrides: set via the image_understand tool's config action.
+// These take precedence over env vars, allowing agents to change settings
+// at runtime without shell access or slash commands.
+const runtimeOverrides = {};
+
+// Persistent config file: written when action=config has persist=true.
+// Loaded at mod activation so settings survive /reload.
+const PERSISTENT_CONFIG_PATH = process.env.IMAGE_UNDERSTANDING_CONFIG_PATH ??
+  path.join(homedir(), ".letta", "mods", "image-understanding.config.json");
+
+function loadPersistentConfig() {
+  try {
+    const raw = JSON.parse(readFileSync(PERSISTENT_CONFIG_PATH, "utf-8"));
+    if (raw && typeof raw === "object") {
+      for (const key of Object.keys(CONFIG_KEYS)) {
+        if (key in raw) {
+          try {
+            runtimeOverrides[key] = parseConfigValue(key, raw[key]);
+          } catch {
+            // skip invalid persisted values
+          }
+        }
+      }
+    }
+  } catch {
+    // no persistent config yet — fine
+  }
+}
+
+function savePersistentConfig() {
+  try {
+    mkdirSync(path.dirname(PERSISTENT_CONFIG_PATH), { recursive: true });
+    const toSave = {};
+    for (const key of Object.keys(runtimeOverrides)) {
+      toSave[key] = runtimeOverrides[key];
+    }
+    writeFileSync(PERSISTENT_CONFIG_PATH, JSON.stringify(toSave, null, 2));
+  } catch {
+    // persistence is best-effort
+  }
+}
+
 function getConfig() {
-  const provider = normalizeProvider(process.env.IMAGE_UNDERSTANDING_PROVIDER);
+  const provider = normalizeProvider(runtimeOverrides.provider ?? process.env.IMAGE_UNDERSTANDING_PROVIDER);
   const openaiApiKey = process.env.IMAGE_UNDERSTANDING_API_KEY || process.env.OPENAI_API_KEY || "";
   return {
     provider,
     apiKey: openaiApiKey,
-    model:
-      process.env.IMAGE_UNDERSTANDING_MODEL ||
-      (provider === "ollama" ? DEFAULT_OLLAMA_MODEL : DEFAULT_OPENAI_MODEL),
-    baseUrl: (
-      process.env.IMAGE_UNDERSTANDING_BASE_URL ||
-      (provider === "ollama" ? DEFAULT_OLLAMA_BASE_URL : DEFAULT_OPENAI_BASE_URL)
-    ).replace(/\/$/, ""),
-    maxTokens: Number.parseInt(process.env.IMAGE_UNDERSTANDING_MAX_TOKENS || "1200", 10),
-    allowCloud: envBool("IMAGE_UNDERSTANDING_ALLOW_CLOUD", true),
-    allowUrls: envBool("IMAGE_UNDERSTANDING_ALLOW_URLS", true),
-    requireLocal: envBool("IMAGE_UNDERSTANDING_REQUIRE_LOCAL", false),
-    autoCaption: envBool("IMAGE_UNDERSTANDING_AUTO_CAPTION", false),
-    autoMode: process.env.IMAGE_UNDERSTANDING_AUTO_MODE || "describe",
+    model: runtimeOverrides.model ?? (process.env.IMAGE_UNDERSTANDING_MODEL ||
+      (provider === "ollama" ? DEFAULT_OLLAMA_MODEL : DEFAULT_OPENAI_MODEL)),
+    baseUrl: (runtimeOverrides.baseUrl ?? (process.env.IMAGE_UNDERSTANDING_BASE_URL ||
+      (provider === "ollama" ? DEFAULT_OLLAMA_BASE_URL : DEFAULT_OPENAI_BASE_URL))).replace(/\/$/, ""),
+    maxTokens: runtimeOverrides.maxTokens ?? Number.parseInt(process.env.IMAGE_UNDERSTANDING_MAX_TOKENS || "1200", 10),
+    allowCloud: runtimeOverrides.allowCloud ?? envBool("IMAGE_UNDERSTANDING_ALLOW_CLOUD", true),
+    allowUrls: runtimeOverrides.allowUrls ?? envBool("IMAGE_UNDERSTANDING_ALLOW_URLS", true),
+    requireLocal: runtimeOverrides.requireLocal ?? envBool("IMAGE_UNDERSTANDING_REQUIRE_LOCAL", false),
+    autoCaption: runtimeOverrides.autoCaption ?? envBool("IMAGE_UNDERSTANDING_AUTO_CAPTION", false),
+    autoMode: runtimeOverrides.autoMode ?? (process.env.IMAGE_UNDERSTANDING_AUTO_MODE || "describe"),
+    stripImages: runtimeOverrides.stripImages ?? envBool("IMAGE_UNDERSTANDING_STRIP_IMAGES", false),
   };
 }
 
@@ -72,6 +141,10 @@ function isHttpUrl(value) {
   } catch {
     return false;
   }
+}
+
+function isDataUrl(value) {
+  return typeof value === "string" && value.startsWith("data:");
 }
 
 function resolveLocalPath(input, cwd) {
@@ -126,7 +199,18 @@ async function urlImage(pathOrUrl, signal) {
   return { bytes, base64: bytes.toString("base64"), mime: contentType, source: pathOrUrl, isUrl: true };
 }
 
+async function dataUrlImage(pathOrUrl) {
+  const match = pathOrUrl.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) {
+    throw new Error(`Invalid data URL: ${pathOrUrl.slice(0, 40)}...`);
+  }
+  const [, mime, base64] = match;
+  const bytes = Buffer.from(base64, "base64");
+  return { bytes, base64, mime: mime || "image/png", source: "data-url", isUrl: false };
+}
+
 async function loadImage(pathOrUrl, ctx) {
+  if (isDataUrl(pathOrUrl)) return await dataUrlImage(pathOrUrl);
   return isHttpUrl(pathOrUrl) ? await urlImage(pathOrUrl, ctx.signal) : await localImage(pathOrUrl, ctx.cwd);
 }
 
@@ -259,6 +343,8 @@ async function providerStatus() {
     `require_local: ${config.requireLocal ? "yes" : "no"}`,
     `auto_caption: ${config.autoCaption ? "yes" : "no"}`,
     `auto_mode: ${config.autoMode}`,
+    `strip_images: ${config.stripImages ? "yes" : "no"}`,
+    `config_file: ${PERSISTENT_CONFIG_PATH}`,
     `supported_providers: openai-compatible, ollama`,
     `modes: ${Object.keys(MODE_PROMPTS).join(", ")}`,
   ];
@@ -290,6 +376,9 @@ function imageRefFromPart(part) {
   if (part.source && typeof part.source === "object") {
     if (typeof part.source.path === "string") return part.source.path;
     if (typeof part.source.url === "string") return part.source.url;
+    if (part.source.type === "base64" && typeof part.source.data === "string") {
+      return `data:${part.source.media_type || "image/png"};base64,${part.source.data}`;
+    }
   }
   return null;
 }
@@ -315,12 +404,53 @@ function extractImageRefsFromContent(content) {
   return refs;
 }
 
-function appendTextContent(content, text) {
-  if (typeof content === "string") return `${content}\n\n${text}`;
-  if (Array.isArray(content)) return [...content, { type: "text", text }];
-  return text;
+/**
+ * Replace image parts in message content with replacement text.
+ * Strips any part whose type includes "image" or has an image_url field,
+ * then appends the replacement text as a new text part.
+ * For string content (markdown images), the text is appended as-is since
+ * markdown image syntax is just text and won't cause provider 400s.
+ */
+function replaceImageParts(content, replacementText) {
+  if (typeof content === "string") {
+    return replacementText ? `${content}\n\n${replacementText}` : content;
+  }
+  if (!Array.isArray(content)) return content;
+  const filtered = content.filter((part) => {
+    const type = String(part?.type || "").toLowerCase();
+    const isImage = type.includes("image") || Boolean(part?.image_url);
+    return !isImage;
+  });
+  if (replacementText) {
+    filtered.push({ type: "text", text: replacementText });
+  }
+  // Ensure we never leave the content completely empty after stripping images.
+  const hasText = filtered.some((part) => part?.type === "text" && typeof part.text === "string" && part.text.trim() !== "");
+  if (!hasText) {
+    filtered.push({ type: "text", text: "[image content removed by image-understanding mod]" });
+  }
+  return filtered;
 }
 
+function displayRef(ref) {
+  if (isDataUrl(ref)) {
+    const match = ref.match(/^data:([^;]+);base64,/);
+    return `pasted ${match ? match[1] : "image"}`;
+  }
+  return ref;
+}
+
+function createSystemMessage(content) {
+  return { type: "message", role: "system", content };
+}
+
+/**
+ * Turn handler for auto-caption mode: sends images to a vision backend,
+ * gets text descriptions back, then STRIPS image parts from the user message
+ * and appends a system message with the caption text. This prevents text-only
+ * providers from rejecting the request with 400 "content.type is invalid,
+ * allowed values: ['text']".
+ */
 async function autoCaptionTurn(event, ctx) {
   const config = getConfig();
   if (!config.autoCaption) return;
@@ -334,21 +464,56 @@ async function autoCaptionTurn(event, ctx) {
       try {
         const result = await askVision({ pathOrUrl: ref, mode: config.autoMode }, ctx);
         const text = typeof result === "string" ? result : result.content || JSON.stringify(result);
-        descriptions.push(`Image ${descriptions.length + 1} (${ref}):\n${text}`);
+        descriptions.push(`Image ${descriptions.length + 1} (${displayRef(ref)}):\n${text}`);
       } catch (error) {
-        descriptions.push(`Image ${descriptions.length + 1} (${ref}): auto-caption failed: ${error instanceof Error ? error.message : String(error)}`);
+        descriptions.push(`Image ${descriptions.length + 1} (${displayRef(ref)}): auto-caption failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
   }
 
   if (descriptions.length === 0) return;
-  const note = `[Auto image understanding (${config.provider}/${config.model})]\n${descriptions.join("\n\n")}`;
-  event.input = input.map((item) => {
+  const imageCount = descriptions.length;
+  const note = `[image-understanding: ${imageCount} image${imageCount === 1 ? "" : "s"} auto-captioned and replaced (via ${config.provider}/${config.model})]\n<image_understanding>\n${descriptions.join("\n\n")}\n</image_understanding>`;
+  notifyUser(`${imageCount} image${imageCount === 1 ? "" : "s"} auto-captioned by ${config.provider}/${config.model}`);
+
+  let changed = false;
+  const strippedInput = input.map((item) => {
     if (!item || item.type === "approval" || item.role !== "user") return item;
     const refs = extractImageRefsFromContent(item.content);
     if (refs.length === 0) return item;
-    return { ...item, content: appendTextContent(item.content, note) };
+    changed = true;
+    return { ...item, content: replaceImageParts(item.content, "") };
   });
+  if (!changed) return;
+  event.input = [...strippedInput, createSystemMessage(note)];
+  return { input: event.input };
+}
+
+/**
+ * Turn handler for strip-images mode: when auto-caption is off but
+ * strip_images is on, removes image parts from user messages and appends a
+ * system message pointing the agent to the image_understand tool. This
+ * protects text-only models from 400 errors without requiring a vision
+ * backend call.
+ */
+function stripImagesTurn(event) {
+  const config = getConfig();
+  if (!config.stripImages || config.autoCaption) return;
+  const input = Array.isArray(event.input) ? event.input : [];
+  let changed = false;
+  let totalImages = 0;
+  const strippedInput = input.map((item) => {
+    if (!item || item.type === "approval" || item.role !== "user") return item;
+    const refs = extractImageRefsFromContent(item.content);
+    if (refs.length === 0) return item;
+    changed = true;
+    totalImages += refs.length;
+    return { ...item, content: replaceImageParts(item.content, "") };
+  });
+  if (!changed) return;
+  const note = `[image-understanding: ${totalImages} image${totalImages === 1 ? "" : "s"} stripped (via ${config.provider}/${config.model})] The user pasted image(s) but the current model is text-only. Use the image_understand tool to inspect them if needed.`;
+  notifyUser(`${totalImages} image${totalImages === 1 ? "" : "s"} stripped from turn (strip_images mode)`);
+  event.input = [...strippedInput, createSystemMessage(note)];
   return { input: event.input };
 }
 
@@ -366,20 +531,76 @@ function parseCommandArgs(args) {
   return { pathOrUrl, question: rest.join(" ").trim() };
 }
 
+/**
+ * Build a user-feedback helper. In TUI/desktop/listener, opens a transient
+ * panel above the input (order=100) and auto-closes after a few seconds.
+ * Falls back silently if no UI panels capability is available.
+ */
+function createNotifier(letta) {
+  if (!letta.capabilities.ui?.panels) {
+    return () => {};
+  }
+  let panel = null;
+  let statusText = "";
+  let hideTimer = null;
+  const show = (text) => {
+    statusText = text;
+    if (!panel) {
+      panel = letta.ui.openPanel({
+        id: "image-understanding-notify",
+        order: 100,
+        render: ({ width, row, chalk }) => {
+          if (!statusText) return "";
+          return row(chalk.dim("image-understanding:"), statusText, width);
+        },
+      });
+    }
+    panel.update();
+    if (hideTimer) clearTimeout(hideTimer);
+    hideTimer = setTimeout(() => {
+      statusText = "";
+      if (panel) {
+        panel.close();
+        panel = null;
+      }
+    }, 5_000);
+  };
+  return show;
+}
+
+// Module-level notifier: set during activation so turn handlers can show
+// transient UI feedback without needing it passed through the harness ctx.
+let notifyUser = () => {};
+
 export default function activate(letta) {
   const disposers = [];
+  loadPersistentConfig();
+  notifyUser = createNotifier(letta);
 
   if (letta.capabilities.tools) {
     disposers.push(letta.tools.register({
       name: "image_understand",
-      description: "Use a vision model to answer questions about a local image path or image URL when the current model cannot inspect images directly. Supports OpenAI-compatible vision and local Ollama vision backends. Useful for screenshots, UI errors, diagrams, photos, OCR, and visual debugging.",
+      description: "Use a vision model to answer questions about a local image path or image URL when the current model cannot inspect images directly. Supports OpenAI-compatible vision and local Ollama vision backends. Useful for screenshots, UI errors, diagrams, photos, OCR, and visual debugging. Also use action=config to read or change runtime settings for the mod.",
       parameters: {
         type: "object",
         properties: {
           action: {
             type: "string",
-            enum: ["understand", "status"],
-            description: "Use status to inspect provider configuration. Defaults to understand.",
+            enum: ["understand", "status", "config"],
+            description: "Use status to inspect provider configuration. Use config to read or set runtime settings. Defaults to understand.",
+          },
+          config_key: {
+            type: "string",
+            enum: ["provider", "model", "baseUrl", "maxTokens", "allowCloud", "allowUrls", "requireLocal", "autoCaption", "autoMode", "stripImages"],
+            description: "Config key to read or set when action=config. Boolean keys accept true/false/on/off/yes/no/1/0.",
+          },
+          config_value: {
+            type: "string",
+            description: "Value to set for config_key. Omit or leave empty to clear the override and revert to env/default.",
+          },
+          persist: {
+            type: "boolean",
+            description: "If true, write this setting to disk so it survives /reload. Defaults to false (runtime-only).",
           },
           path_or_url: {
             type: "string",
@@ -407,8 +628,32 @@ export default function activate(letta) {
       async run(ctx) {
         const action = String(ctx.args.action || "understand");
         if (action === "status") return await providerStatus();
+        if (action === "config") {
+          const key = ctx.args.config_key;
+          const value = ctx.args.config_value;
+          const persist = ctx.args.persist === true || String(ctx.args.persist).toLowerCase() === "true";
+          if (!key) return await providerStatus();
+          if (!(key in CONFIG_KEYS)) {
+            return { status: "error", content: `Unknown config key "${key}". Available: ${Object.keys(CONFIG_KEYS).join(", ")}` };
+          }
+          if (value === undefined || value === null || value === "") {
+            delete runtimeOverrides[key];
+            if (persist) savePersistentConfig();
+            return `${key} override cleared. Current effective value will be shown by action=status.`;
+          }
+          try {
+            const parsed = parseConfigValue(key, value);
+            runtimeOverrides[key] = parsed;
+            if (persist) savePersistentConfig();
+            const display = typeof parsed === "boolean" ? (parsed ? "on" : "off") : parsed;
+            const scope = persist ? "persistent override" : "runtime override";
+            return `${key} set to ${display} (${scope}).`;
+          } catch (err) {
+            return { status: "error", content: err.message };
+          }
+        }
         const pathOrUrl = String(ctx.args.path_or_url || "").trim();
-        if (!pathOrUrl) return { status: "error", content: "path_or_url is required for image understanding. Use action=status to inspect configuration." };
+        if (!pathOrUrl) return { status: "error", content: "path_or_url is required for image understanding. Use action=status to inspect configuration. Use action=config to change settings." };
         const question = typeof ctx.args.question === "string" ? ctx.args.question : "";
         const detail = typeof ctx.args.detail === "string" ? ctx.args.detail : undefined;
         const mode = typeof ctx.args.mode === "string" ? ctx.args.mode : "describe";
@@ -419,6 +664,7 @@ export default function activate(letta) {
 
   if (letta.capabilities.events?.turns) {
     disposers.push(letta.events.on("turn_start", autoCaptionTurn));
+    disposers.push(letta.events.on("turn_start", stripImagesTurn));
   }
 
   if (letta.capabilities.commands) {
@@ -447,6 +693,7 @@ export default function activate(letta) {
   }
 
   return () => {
+    notifyUser = () => {};
     for (const dispose of disposers.reverse()) dispose();
   };
 }


### PR DESCRIPTION
## Summary

The image-understanding mod had several issues when used with text-only models and the Letta Code CLI:

1. **Pasted CLI images were invisible** — the CLI embeds images as Anthropic-style `{ type: "image", source: { type: "base64", data: "...", media_type: "image/png" } }` parts, but `imageRefFromPart` only looked for file paths and HTTP URLs. These images were silently ignored by auto-caption and strip-images.

2. **Images stayed in context after captioning** — `autoCaptionTurn` appended caption text to the user message but left the original base64 image parts in place. Text-only models (Z.AI, GLM, etc.) would still see the image parts and reject the request with `400 "content.type is invalid, allowed values: [text]"`.

3. **Context window explosions** — caption text embedded full base64 data URLs as the image reference, causing 211K+ token context blow-ups on a single image.

4. **Settings reset on `/reload`** — runtime overrides were ephemeral, so any config changes made via the tool were lost on reload.

5. **No user feedback** — auto-caption and strip-images ran silently, with no indication that the mod was doing work.

## What changed

### Base64 CLI image support
- `imageRefFromPart()` now recognizes `source.type === "base64"` parts and synthesizes a `data:image/png;base64,...` data URL from them
- Added `isDataUrl()` and `dataUrlImage()` to parse data URLs in `loadImage()`
- Pasted images in the CLI are now correctly detected and processed

### Image stripping (replaces `appendTextContent`)
- Removed `appendTextContent` — replaced with `replaceImageParts()` which **removes** image parts from the user message content instead of leaving them in place
- `replaceImageParts` filters out any part whose `type` includes "image" or has an `image_url` field, then appends replacement text as a new text part
- Guards against leaving content empty after stripping (inserts `"[image content removed by image-understanding mod]"` if no text parts remain)

### System message injection
- Both `autoCaptionTurn` and `stripImagesTurn` now **strip image parts from the user message** and **append a separate `role: "system"` message** to `event.input` with the caption/note text
- This follows the canonical pattern for mod-injected context: don\`t mutate user message content, append a system message instead
- Captions are wrapped in `<image_understanding>` XML tags for model clarity

### Context-efficient captions
- Added `displayRef()` helper — shows friendly names like `pasted image/png` instead of full base64 data URLs in caption text
- Prevents context window explosions from embedded base64 data

### `stripImages` mode (new)
- New `stripImages` config option — when `autoCaption` is off but `stripImages` is on, the mod strips image parts and appends a system message telling the agent to use the `image_understand` tool if needed
- Protects text-only models from 400 errors without requiring a vision backend call
- `autoCaption` takes precedence (strips + captions); `stripImages` alone just strips

### Runtime configuration via tool
- Added `action: "config"` to the `image_understand` tool
- New parameters: `config_key`, `config_value`, `persist`
- Agents can now read and change mod settings at runtime without shell access or slash commands
- Setting `config_value` to empty/null clears the override and reverts to env/default
- `action: "status"` now also shows the config file path and `strip_images` state

### Persistent configuration
- `persist: true` flag on `action=config` writes settings to `~/.letta/mods/image-understanding.config.json`
- `loadPersistentConfig()` runs at mod activation, so persisted settings survive `/reload`
- Config file path is overridable via `IMAGE_UNDERSTANDING_CONFIG_PATH` env var
- All persistence is best-effort (silently skips on I/O errors)

### Transient panel feedback
- `createNotifier()` opens a transient UI panel (order=100) that auto-closes after 5 seconds
- Shows when auto-caption or strip-images runs (e.g. "1 image auto-captioned by ollama/llava:latest")
- Falls back silently if UI panels capability is not available

### Default model update
- Changed from `gpt-4o-mini` to `gpt-5.4-mini` (vision-capable, better for computer-use tasks at lower cost)

## Files changed

- `packages/image-understanding/mods/index.mjs` — 276 insertions, 29 deletions

## Test plan

- [x] Pasted a CLI image with `autoCaption=true` — image was detected, captioned, and stripped from the user message
- [x] Verified context didn\`t blow up (captions use `displayRef()` friendly names, not full base64)
- [x] Tested `stripImages=true` with `autoCaption=false` — image parts stripped, system message appended
- [x] Used `action=config` with `persist=true` — settings saved to `~/.letta/mods/image-understanding.config.json`
- [x] Ran `/reload` — persisted settings restored automatically
- [x] Tested with Ollama/gemma4:latest as vision backend — successfully captioned a pasted CLI image
- [x] `action=status` shows config file path and all current settings

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>