### PR TITLE
fix(muscle-memory): duplicate-create gates (P0) + hermetic tests + reachFn receiver bind

### DIFF
--- a/packages/muscle-memory/CHANGELOG.md
+++ b/packages/muscle-memory/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `@letta-ai/muscle-memory`. Format loosely follows [Keep a
 
 ## [Unreleased]
 
+### Fixed
+- **`reachFn` now binds the extracted method to its receiver** — letta-client `APIResource` methods
+  read `this._client`, so the previous unbound extraction threw at call time and the best-effort
+  catch blocks swallowed it into a silent no-op: the `MM_NATIVE=blocks` neocortex sync never actually
+  landed a block. Caught benchmarking live against a real Letta agent; regression test in
+  `test/native-fit.test.ts`, live block-readback verified.
+
 ### Added
 - **n=1 CREATE gate** (`multiInstanceSupport`, wired into the reflect lane) — a reflect-lane CREATE must
   be topically grounded in an evidence signal observed **≥2 distinct instances** (count or conversation

--- a/packages/muscle-memory/CHANGELOG.md
+++ b/packages/muscle-memory/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `@letta-ai/muscle-memory`. Format loosely follows [Keep a Changelog](https://keepachangelog.com/); this mod is pre-1.0, so the API may still change.
 
+## [Unreleased]
+
+### Added
+- **n=1 CREATE gate** (`multiInstanceSupport`, wired into the reflect lane) — a reflect-lane CREATE must
+  be topically grounded in an evidence signal observed **≥2 distinct instances** (count or conversation
+  spread). The aggregate items floor was not enough: an n=1 repair could ride in on an unrelated recurring
+  workflow and become a command-shaped skill (live receipt: `recovering-from-npx-failures`, "Observed 1×
+  across 1 session", created twice on consecutive days and retired twice). Parked creates never block a
+  pattern permanently — a second observed instance changes the evidence signature and re-opens the route.
+- **Structured evidence signals** — `buildCrossConversationEvidence` now returns `signals[]` (per-signal
+  `label`/`kind`/`count`/`convs`) alongside the prose digest, so create-gates count instances instead of
+  guessing from text.
+- **Staged shelf in the CREATE dedupe surface** (`createDedupeSurface`) — manual `create` and
+  `create_from_candidate` now dedupe against agent + global + **staged** shelves, so a near-duplicate of a
+  not-yet-graduated skill routes to PATCH instead of spraying siblings.
+- **Retired-skill quarantine in `dedupCheck`** — near-duplicates of *retired* skills under a **different
+  name** are refused with a restore/absorb hint (`retiredSkillBlocker` already caught same-name recreates;
+  this catches renamed clones).
+- **`test/create-gates.test.ts`** — deterministic regression suite for the duplicate-create class: the
+  n=1 hole, instance borrowing from unrelated signals, ungrounded creates, staged-sibling dedupe, and
+  retired-clone quarantine.
+
 ## [0.6.0] — 2026-06-28
 
 The "skill library that maintains itself" release. Observe → distill/update → quality-gate → graduate →

--- a/packages/muscle-memory/CHANGELOG.md
+++ b/packages/muscle-memory/CHANGELOG.md
@@ -24,6 +24,16 @@ All notable changes to `@letta-ai/muscle-memory`. Format loosely follows [Keep a
   n=1 hole, instance borrowing from unrelated signals, ungrounded creates, staged-sibling dedupe, and
   retired-clone quarantine.
 
+### Changed
+- **Hermetic reflect-lane testing** — `runReflectiveReview` now accepts injectable `dirs`/`stagedDir`
+  (same pattern as `experience`). The n=1 wiring test previously scanned the HOST's real skill shelves
+  (`~/.letta/skills`): on a populated machine the ambiguous-route guard fired before the n=1 gate and
+  the test failed — green only on an empty shelf. The test now pins empty tmp shelves.
+- **`HIGH_SIGNAL_TOOL_SET` is configuration, not hardcoded vocabulary** — the shipped set contained
+  deployment-specific tool names from the authors' own rigs. It now defaults to empty and is populated
+  via `MM_HIGH_SIGNAL_TOOLS` (comma-separated tool names); configured tools get a stable arg-shape
+  fingerprint template. The per-tool template special-cases for those private tools were removed.
+
 ## [0.6.0] — 2026-06-28
 
 The "skill library that maintains itself" release. Observe → distill/update → quality-gate → graduate →

--- a/packages/muscle-memory/mods/autopilot.ts
+++ b/packages/muscle-memory/mods/autopilot.ts
@@ -2,7 +2,7 @@
 import { mkdirSync, readFileSync, existsSync, writeFileSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { AUTOPILOT_STATE, Candidate, MM, MM_TAG, RECEIPTS_DIR, REFLECT_HANDLED, Row, STAGED_DIR, STAGED_RETIRED_DIR, STATE_DIR, agentSkillsDir, appendMeshFeed, appendUiEvent, ensureDir, hash, isManaged, listSkillNames, loadExperience, readSkill, scanDirs, scanSkillContent, skillDesc, slug, writeSkill, writeUiState } from "./core";
-import { DESTRUCTIVE, RepairChain, buildCrossConversationEvidence, detect, detectAntiPatterns, detectRepairChains, impactScore, isValidSkillName } from "./detect";
+import { DESTRUCTIVE, RepairChain, buildCrossConversationEvidence, detect, detectAntiPatterns, detectRepairChains, impactScore, isValidSkillName, multiInstanceSupport } from "./detect";
 import { dedupCheck, draftWithRepair, effectivenessVerdict, findCandidate, lintSkillDraft, repairForCandidate, sotaQualityGaps } from "./gate";
 import { publishPlan, publishSkillToCatalog, publishTier } from "./publish";
 import { ENGRAM, engramConsolidate } from "./engram";
@@ -613,12 +613,12 @@ export function reviewForkAuthor(ctx: any): (sys: string, user: string) => Promi
 
 /** v3.1 AUTONOMOUS REFLECTIVE REVIEW: cross-conversation evidence → forked reviewer → update-first
  * routing + gates → write (staged by default; live in auto mode). Reversible + receipted. The surpass, autonomous. */
-export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | "auto"; minItems?: number; authorFn?: (s: string, u: string) => Promise<string> } = {}): Promise<ReviewResult & { wrote?: string }> {
+export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | "auto"; minItems?: number; minInstances?: number; authorFn?: (s: string, u: string) => Promise<string>; experience?: ReturnType<typeof loadExperience> } = {}): Promise<ReviewResult & { wrote?: string }> {
   const dirs = scanDirs(ctx);
   // In staged mode, staged skills are part of the dedupe surface. Otherwise repeated manual reflects
   // can spray near-duplicate staged siblings before review/graduation (live dogfood catch).
   const reviewDirs = config.mode === "auto" ? dirs : [...dirs, STAGED_DIR];
-  const exp = loadExperience();
+  const exp = config.experience ?? loadExperience();
   const ev = buildCrossConversationEvidence(exp);
   // ENGRAM: the prioritized-replay + reconsolidation brief over the SAME trace. This is the
   // salience-triaged, reverse-replay-credited, reconsolidation-aware evidence that REPLACES a
@@ -665,6 +665,18 @@ export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | 
           appendUiEvent({ phase: "reflect_none", summary: `retire-sticky blocked '${res.name}'` });
           writeUiState({ phase: "idle", last: `retire-sticky blocked '${res.name}'`, route: "SKIP · retired" });
           return { action: "none", name: res.name, reason: retiredBlock } as ReviewResult & { wrote?: string };
+        }
+        // P0 2a · n=1 CREATE gate: a create must be topically grounded in a >=2-instance signal.
+        // The aggregate items floor is NOT enough — an n=1 repair can ride in on an unrelated
+        // recurring workflow (receipt: recovering-from-npx-failures, created 2×, retired 2×).
+        // A second observed instance changes the evidence signature, so parking here never
+        // permanently blocks a pattern that later matures.
+        const n1 = multiInstanceSupport(`${res.name} ${res.description ?? ""}`, ev.signals ?? [], config.minInstances ?? 2);
+        if (!n1.ok) {
+          markHandledReflect(sig, `N1-PARKED:${res.name}`);
+          appendUiEvent({ phase: "reflect_none", summary: `n=1 gate parked '${res.name}': ${n1.reason.slice(0, 120)}` });
+          writeUiState({ phase: "idle", last: `n=1 gate parked '${res.name}'`, route: "SKIP · n=1" });
+          return { action: "none", name: res.name, reason: `n=1 gate: ${n1.reason}` } as ReviewResult & { wrote?: string };
         }
       }
       const oldContent = res.action === "update" && res.updateTarget ? (() => { const d = reviewDirs.find((x) => existsSync(join(x, res.updateTarget!, "SKILL.md"))); return d ? readSkill(d, res.updateTarget!) : undefined; })() : undefined;

--- a/packages/muscle-memory/mods/autopilot.ts
+++ b/packages/muscle-memory/mods/autopilot.ts
@@ -613,11 +613,15 @@ export function reviewForkAuthor(ctx: any): (sys: string, user: string) => Promi
 
 /** v3.1 AUTONOMOUS REFLECTIVE REVIEW: cross-conversation evidence → forked reviewer → update-first
  * routing + gates → write (staged by default; live in auto mode). Reversible + receipted. The surpass, autonomous. */
-export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | "auto"; minItems?: number; minInstances?: number; authorFn?: (s: string, u: string) => Promise<string>; experience?: ReturnType<typeof loadExperience> } = {}): Promise<ReviewResult & { wrote?: string }> {
-  const dirs = scanDirs(ctx);
+export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | "auto"; minItems?: number; minInstances?: number; authorFn?: (s: string, u: string) => Promise<string>; experience?: Row[]; dirs?: string[]; stagedDir?: string } = {}): Promise<ReviewResult & { wrote?: string }> {
+  // dirs/stagedDir injectable (same pattern as `experience`) so callers/tests are hermetic —
+  // scanDirs(ctx) reads the HOST's real shelves (agent MemFS + ~/.letta/skills), which made the
+  // n=1 wiring test pass only on machines with an empty global shelf (fake-green class).
+  const dirs = config.dirs ?? scanDirs(ctx);
+  const stagedShelf = config.stagedDir ?? STAGED_DIR;
   // In staged mode, staged skills are part of the dedupe surface. Otherwise repeated manual reflects
   // can spray near-duplicate staged siblings before review/graduation (live dogfood catch).
-  const reviewDirs = config.mode === "auto" ? dirs : [...dirs, STAGED_DIR];
+  const reviewDirs = config.mode === "auto" ? dirs : [...dirs, stagedShelf];
   const exp = config.experience ?? loadExperience();
   const ev = buildCrossConversationEvidence(exp);
   // ENGRAM: the prioritized-replay + reconsolidation brief over the SAME trace. This is the
@@ -655,7 +659,7 @@ export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | 
   if ((res.action === "create" || res.action === "update") && res.name && res.content) {
     const live = config.mode === "auto";
     const graduate = live || res.action === "update" || isHighConfidenceCreate(res, ev);
-    const dir = graduate ? agentSkillsDir(ctx) : STAGED_DIR;
+    const dir = graduate ? agentSkillsDir(ctx) : stagedShelf;
     const tagged = res.content.includes(MM_TAG) ? res.content : res.content + `\n<!-- ${MM_TAG}: reflective ${new Date().toISOString().slice(0, 10)}; action=${res.action}; convs=${ev.convs}; ${graduate ? "graduated=true" : "staged=true"} -->\n`;
     try {
       if (res.action === "create" && !res.updateTarget) {

--- a/packages/muscle-memory/mods/core.ts
+++ b/packages/muscle-memory/mods/core.ts
@@ -323,6 +323,11 @@ export function removeSupportFile(name: string, filePath: string, ctx?: any): st
 // ════════════════════════════════════════════════════════════════════════════
 export const STAGED_DIR = join(STATE_DIR, "staged");
 
+/** P0 2b · the CREATE-lane dedupe surface: agent + global + STAGED shelves. Manual create and
+ * create_from_candidate previously deduped against scanDirs only, so a near-duplicate of a
+ * staged (not-yet-graduated) skill sailed through and sprayed siblings. */
+export function createDedupeSurface(ctx?: any): string[] { return [...new Set([...scanDirs(ctx), STAGED_DIR])]; }
+
 export const STAGED_RETIRED_DIR = join(STATE_DIR, "staged-retired");
 
 export const AUTOPILOT_STATE = join(STATE_DIR, "autopilot-state.json");

--- a/packages/muscle-memory/mods/detect.ts
+++ b/packages/muscle-memory/mods/detect.ts
@@ -37,15 +37,11 @@ export function commandTemplate(cmd: string): string {
 }
 
 
-export const HIGH_SIGNAL_TOOL_SET = new Set(["visual_receipt", "im8_claims_lint", "no_cap_gate_check", "repo_radar_evidence", "kev_final_buzzer_gate", "im8_theme_done_gate", "im8_product_intel", "im8_write_plan"]);
-
-
-export function hostOrToken(s: unknown): string {
-  const raw = String(s || "");
-  try { return new URL(raw).hostname.replace(/^www\./, ""); } catch { return slug(raw).slice(0, 48) || "unknown"; }
-}
-
-export function countMaybeArray(v: unknown): number { return Array.isArray(v) ? v.length : v == null ? 0 : 1; }
+/** High-signal tools get their reps tracked as first-class evidence signals. This is
+ * deployment-specific vocabulary, so it is CONFIGURED, never hardcoded: set
+ * MM_HIGH_SIGNAL_TOOLS to a comma-separated list of your own gate/receipt tool names
+ * (e.g. "design_review_gate,release_readiness_check"). Empty by default. */
+export const HIGH_SIGNAL_TOOL_SET = new Set<string>((process.env.MM_HIGH_SIGNAL_TOOLS || "").split(",").map((s) => s.trim()).filter(Boolean));
 
 
 export function fingerprint(tool: string, args: Record<string, unknown>): { fp: string; tmpl: string | null } {
@@ -64,22 +60,9 @@ export function fingerprint(tool: string, args: Record<string, unknown>): { fp: 
     tmpl = `${tool} ${keys.join(",")}`;
   } else if (tool === "Skill" && typeof args?.skill === "string") {
     tmpl = `Skill ${slug(String(args.skill))}`;
-  } else if (tool === "visual_receipt") {
-    tmpl = `visual_receipt ${hostOrToken(args?.url)} ${countMaybeArray(args?.viewports)} viewports ${countMaybeArray(args?.selectors)} selectors`;
-  } else if (tool === "im8_claims_lint") {
-    tmpl = `im8_claims_lint supplement-copy ${countMaybeArray(args?.files)} files`;
-  } else if (tool === "no_cap_gate_check") {
-    tmpl = `no_cap_gate_check high-trust-claim`;
-  } else if (tool === "repo_radar_evidence" && typeof args?.kind === "string") {
-    tmpl = `repo_radar_evidence ${slug(String(args.kind))}`;
-  } else if (tool === "kev_final_buzzer_gate") {
-    tmpl = `kev_final_buzzer_gate final-readiness`;
-  } else if (tool === "im8_theme_done_gate") {
-    tmpl = `im8_theme_done_gate theme-readiness`;
-  } else if (tool === "im8_product_intel") {
-    tmpl = `im8_product_intel ${slug(String(args?.mode || "lookup"))}`;
-  } else if (tool === "im8_write_plan") {
-    tmpl = `im8_write_plan ${slug(String(args?.operation || "write-plan"))}`;
+  } else if (HIGH_SIGNAL_TOOL_SET.has(tool)) {
+    // Configured high-signal tools (MM_HIGH_SIGNAL_TOOLS) get a stable arg-shape template.
+    tmpl = `${tool} ${keys.join(",")}`;
   }
   const shape = keys.filter((k) => !SECRETISH.test(k)).join(",");
   const fp = `${tool}(${shape})${tmpl ? " :: " + tmpl : ""}`;

--- a/packages/muscle-memory/mods/detect.ts
+++ b/packages/muscle-memory/mods/detect.ts
@@ -525,7 +525,33 @@ export function isValidSkillName(name: unknown): boolean {
 
 /** THE LETTA EDGE: aggregate REAL grounded pitfalls across ALL conversations in the log
  * (Letta recall). Hermes reviews one conversation; this digests the agent's whole history. */
-export function buildCrossConversationEvidence(rows: Row[]): { digest: string; convs: number; items: number } {
+/** Structured per-signal instance counts — the n=1 CREATE gate's ground truth (P0 2a).
+ * label carries the signal's identifying text; count/convs carry how often and how widely
+ * it was actually observed. Instances = max(count, convs). */
+export type EvidenceSignal = { label: string; kind: "repair" | "antipattern" | "template" | "high-signal"; count: number; convs: number };
+
+/** P0 2a · n=1 CREATE gate (pure). A reflect-lane CREATE must be topically grounded in a signal
+ * with >= minInstances observed instances (count OR conversation spread). Receipt: the aggregate
+ * items floor let `recovering-from-npx-failures` ("Observed 1× across 1 session") ship TWICE by
+ * riding in on an unrelated recurring workflow. Topic-matching stops instance borrowing. */
+export function multiInstanceSupport(topic: string, signals: EvidenceSignal[], minInstances = 2): { ok: boolean; matched?: string; instances?: number; reason: string } {
+  const GENERIC = new Set(["recovering", "recover", "failure", "failures", "fails", "failed", "failing", "when", "never", "running", "using", "with", "from", "this", "that", "command", "commands", "error", "errors", "instead", "blind", "retrying", "workflow", "recurring", "skill", "use", "then", "same", "exact", "exit", "code"]);
+  const tok = (s: string) => new Set(String(s || "").toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length > 3 && !GENERIC.has(w)));
+  const topicTokens = tok(topic);
+  let best: { label: string; instances: number; overlap: number } | null = null;
+  for (const s of signals || []) {
+    const lt = tok(s.label);
+    let inter = 0; for (const w of topicTokens) if (lt.has(w)) inter++;
+    if (inter < 1) continue; // topically unrelated — its instances may NOT be borrowed
+    const instances = Math.max(s.count || 0, s.convs || 0);
+    if (!best || instances > best.instances || (instances === best.instances && inter > best.overlap)) best = { label: s.label, instances, overlap: inter };
+  }
+  if (!best) return { ok: false, reason: "no grounded evidence signal matches this skill's topic — refusing ungrounded create" };
+  if (best.instances < minInstances) return { ok: false, matched: best.label, instances: best.instances, reason: `single-instance evidence: strongest topical signal "${best.label}" was observed ${best.instances}× — need >=${minInstances} distinct instances before a CREATE` };
+  return { ok: true, matched: best.label, instances: best.instances, reason: `grounded: "${best.label}" observed ${best.instances}×` };
+}
+
+export function buildCrossConversationEvidence(rows: Row[]): { digest: string; convs: number; items: number; signals: EvidenceSignal[]; rejected: Array<{ item: string; reason: string }> } {
   const convs = new Set(rows.map((r) => String(r.conv ?? "?"))).size;
   const allRepairs = detectRepairChains(rows), allAps = detectAntiPatterns(rows);
   const repairs = allRepairs.filter((r) => isDurableLesson(r.errClass));
@@ -556,5 +582,12 @@ export function buildCrossConversationEvidence(rows: Row[]): { digest: string; c
   for (const p of aps.slice(0, 8)) L.push(`- recurring failure (no clean fix yet): "${p.step}" — ${p.errClass} [${p.fails}×]`);
   for (const [t, c] of topTmpl) L.push(`- recurring workflow: ${t} [${c}×]`);
   for (const [t, e] of high) L.push(`- high-signal receipt workflow: ${t} [${e.count}× across ${e.convs.size} session${e.convs.size === 1 ? "" : "s"}${e.failures ? `, ${e.failures} failed/partial receipt${e.failures === 1 ? "" : "s"}` : ""}]`);
-  return { digest: L.join("\n"), convs, items: repairs.length + aps.length + topTmpl.length + high.length, rejected };
+  // P0 2a: structured per-signal instance counts for the n=1 CREATE gate (same items, now countable).
+  const signals: EvidenceSignal[] = [
+    ...repairs.map((r) => ({ label: `${r.trigger} ${r.errClass} ${r.fixStep}`, kind: "repair" as const, count: r.count, convs: r.convs })),
+    ...aps.map((p) => ({ label: `${p.step} ${p.errClass}`, kind: "antipattern" as const, count: p.fails, convs: p.convs })),
+    ...topTmpl.map(([t, c]) => ({ label: t, kind: "template" as const, count: c, convs: 1 })),
+    ...high.map(([t, e]) => ({ label: t, kind: "high-signal" as const, count: e.count, convs: e.convs.size })),
+  ];
+  return { digest: L.join("\n"), convs, items: repairs.length + aps.length + topTmpl.length + high.length, rejected, signals };
 }

--- a/packages/muscle-memory/mods/engram.ts
+++ b/packages/muscle-memory/mods/engram.ts
@@ -295,15 +295,21 @@ export function nativeEnabled(channel: string): boolean {
 
 
 // Walk a nested path on an unknown SDK client with typeof narrowing — no fabricated object shape,
-// no inline cast-to-read. Returns the verified callable at the end of the path, or null.
+// no inline cast-to-read. Returns the verified callable at the end of the path, BOUND to its
+// receiver, or null. The binding is load-bearing: SDK resource methods (letta-client APIResource)
+// read `this._client`, so an unbound extraction throws "undefined is not an object" at call time —
+// which the best-effort catch blocks then swallow into a silent no-op (caught benchmarking live
+// against the real letta-client SDK; the MM_NATIVE=blocks neocortex sync was silently failing).
 export function reachFn(root: unknown, path: readonly string[]): ((...args: unknown[]) => unknown) | null {
   let cur: unknown = root;
+  let receiver: unknown = null;
   for (const key of path) {
     if (!cur || typeof cur !== "object") return null;
+    receiver = cur;
     cur = Reflect.get(cur, key); // unknown-assignable; no shape assertion
   }
   // A verified function whose call signature can't be runtime-checked → narrow cast at the boundary.
-  return typeof cur === "function" ? (cur as (...args: unknown[]) => unknown) : null;
+  return typeof cur === "function" ? (cur as (...args: unknown[]) => unknown).bind(receiver) : null;
 }
 
 

--- a/packages/muscle-memory/mods/gate.ts
+++ b/packages/muscle-memory/mods/gate.ts
@@ -7,14 +7,27 @@ import { reviewAndAuthor } from "./autopilot";
 /** Anti-bloat gate: refuse near-duplicate skills (token overlap on description), scanning all dirs. */
 export function dedupCheck(name: string, description: string, dirs: string[] = [GLOBAL_SKILLS]): { dup: boolean; reason: string; name: string; overlap: number } {
   const words = new Set(description.toLowerCase().split(/\W+/).filter((w) => w.length > 3));
+  const overlapWith = (desc: string): number => {
+    const dw = new Set(desc.toLowerCase().split(/\W+/).filter((w) => w.length > 3));
+    let inter = 0; for (const w of words) if (dw.has(w)) inter++;
+    return words.size ? inter / words.size : 0;
+  };
   let worst = { name: "", overlap: 0 };
   for (const dir of dirs) {
     for (const n of listSkillNames(dir)) {
       if (n === name) return { dup: true, reason: `skill '${n}' already exists — patch it, don't duplicate`, name: n, overlap: 1 };
-      const dw = new Set(skillDesc(dir, n).toLowerCase().split(/\W+/).filter((w) => w.length > 3));
-      let inter = 0; for (const w of words) if (dw.has(w)) inter++;
-      const overlap = words.size ? inter / words.size : 0;
+      const overlap = overlapWith(skillDesc(dir, n));
       if (overlap > worst.overlap) worst = { name: n, overlap };
+    }
+    // P0 2b · RETIRED QUARANTINE: near-duplicates of retired skills must not be silently recreated
+    // under a new name. retiredSkillBlocker catches same-name recreates; this catches renamed clones.
+    // (Receipt: the recovering-from-npx-failures class — retire, then recreate a sibling next day.)
+    const retiredRoot = join(dir, "_retired");
+    for (const rn of listSkillNames(retiredRoot)) {
+      const base = rn.replace(/-\d{4}-\d{2}-\d{2}T[\dZ.-]+$/, "");
+      if (base === name) return { dup: true, reason: `retired skill '${base}' exists in quarantine (${retiredRoot}/${rn}) — restore it or absorb instead of recreating`, name: base, overlap: 1 };
+      const overlap = overlapWith(skillDesc(retiredRoot, rn));
+      if (overlap > 0.6) return { dup: true, reason: `>60% description overlap with RETIRED skill '${base}' (${retiredRoot}/${rn}) — quarantined: restore/absorb instead of recreating a sibling`, name: base, overlap };
     }
   }
   return { dup: worst.overlap > 0.6, reason: worst.overlap > 0.6 ? `>60% description overlap with '${worst.name}' — patch/absorb instead` : "", name: worst.name, overlap: worst.overlap };

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -1,6 +1,6 @@
 // mods/index.ts
 import { mkdirSync as mkdirSync5, readFileSync as readFileSync5, existsSync as existsSync5, writeFileSync as writeFileSync5, readdirSync as readdirSync3 } from "node:fs";
-import { join as join5 } from "node:path";
+import { join as join6 } from "node:path";
 
 // mods/core.ts
 import { appendFileSync, mkdirSync, readFileSync, existsSync, writeFileSync, readdirSync, renameSync } from "node:fs";
@@ -259,6 +259,9 @@ function removeSupportFile(name, filePath, ctx) {
   return grave;
 }
 var STAGED_DIR = join(STATE_DIR, "staged");
+function createDedupeSurface(ctx) {
+  return [...new Set([...scanDirs(ctx), STAGED_DIR])];
+}
 var STAGED_RETIRED_DIR = join(STATE_DIR, "staged-retired");
 var AUTOPILOT_STATE = join(STATE_DIR, "autopilot-state.json");
 var UI_EVENTS = join(STATE_DIR, "ui-events.jsonl");
@@ -854,6 +857,29 @@ function isValidSkillName(name) {
   const ANTI = [/^fix-/, /^debug-/, /^audit-/, /^patch-/, /-to-/, /\d{3,}/, /v?\d+[._]\d+/, /\berror\b|\bexception\b/, /-today$|-now$|-temp$|-wip$/];
   return !ANTI.some((p) => p.test(n));
 }
+function multiInstanceSupport(topic, signals, minInstances = 2) {
+  const GENERIC = new Set(["recovering", "recover", "failure", "failures", "fails", "failed", "failing", "when", "never", "running", "using", "with", "from", "this", "that", "command", "commands", "error", "errors", "instead", "blind", "retrying", "workflow", "recurring", "skill", "use", "then", "same", "exact", "exit", "code"]);
+  const tok = (s) => new Set(String(s || "").toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length > 3 && !GENERIC.has(w)));
+  const topicTokens = tok(topic);
+  let best = null;
+  for (const s of signals || []) {
+    const lt = tok(s.label);
+    let inter = 0;
+    for (const w of topicTokens)
+      if (lt.has(w))
+        inter++;
+    if (inter < 1)
+      continue;
+    const instances = Math.max(s.count || 0, s.convs || 0);
+    if (!best || instances > best.instances || instances === best.instances && inter > best.overlap)
+      best = { label: s.label, instances, overlap: inter };
+  }
+  if (!best)
+    return { ok: false, reason: "no grounded evidence signal matches this skill's topic — refusing ungrounded create" };
+  if (best.instances < minInstances)
+    return { ok: false, matched: best.label, instances: best.instances, reason: `single-instance evidence: strongest topical signal "${best.label}" was observed ${best.instances}× — need >=${minInstances} distinct instances before a CREATE` };
+  return { ok: true, matched: best.label, instances: best.instances, reason: `grounded: "${best.label}" observed ${best.instances}×` };
+}
 function buildCrossConversationEvidence(rows) {
   const convs = new Set(rows.map((r) => String(r.conv ?? "?"))).size;
   const allRepairs = detectRepairChains(rows), allAps = detectAntiPatterns(rows);
@@ -898,25 +924,44 @@ function buildCrossConversationEvidence(rows) {
     L.push(`- recurring workflow: ${t} [${c}×]`);
   for (const [t, e] of high)
     L.push(`- high-signal receipt workflow: ${t} [${e.count}× across ${e.convs.size} session${e.convs.size === 1 ? "" : "s"}${e.failures ? `, ${e.failures} failed/partial receipt${e.failures === 1 ? "" : "s"}` : ""}]`);
+  const signals = [
+    ...repairs.map((r) => ({ label: `${r.trigger} ${r.errClass} ${r.fixStep}`, kind: "repair", count: r.count, convs: r.convs })),
+    ...aps.map((p) => ({ label: `${p.step} ${p.errClass}`, kind: "antipattern", count: p.fails, convs: p.convs })),
+    ...topTmpl.map(([t, c]) => ({ label: t, kind: "template", count: c, convs: 1 })),
+    ...high.map(([t, e]) => ({ label: t, kind: "high-signal", count: e.count, convs: e.convs.size }))
+  ];
   return { digest: L.join(`
-`), convs, items: repairs.length + aps.length + topTmpl.length + high.length, rejected };
+`), convs, items: repairs.length + aps.length + topTmpl.length + high.length, rejected, signals };
 }
 // mods/gate.ts
+import { join as join2 } from "node:path";
 function dedupCheck(name, description, dirs = [GLOBAL_SKILLS]) {
   const words = new Set(description.toLowerCase().split(/\W+/).filter((w) => w.length > 3));
+  const overlapWith = (desc) => {
+    const dw = new Set(desc.toLowerCase().split(/\W+/).filter((w) => w.length > 3));
+    let inter = 0;
+    for (const w of words)
+      if (dw.has(w))
+        inter++;
+    return words.size ? inter / words.size : 0;
+  };
   let worst = { name: "", overlap: 0 };
   for (const dir of dirs) {
     for (const n of listSkillNames(dir)) {
       if (n === name)
         return { dup: true, reason: `skill '${n}' already exists — patch it, don't duplicate`, name: n, overlap: 1 };
-      const dw = new Set(skillDesc(dir, n).toLowerCase().split(/\W+/).filter((w) => w.length > 3));
-      let inter = 0;
-      for (const w of words)
-        if (dw.has(w))
-          inter++;
-      const overlap = words.size ? inter / words.size : 0;
+      const overlap = overlapWith(skillDesc(dir, n));
       if (overlap > worst.overlap)
         worst = { name: n, overlap };
+    }
+    const retiredRoot = join2(dir, "_retired");
+    for (const rn of listSkillNames(retiredRoot)) {
+      const base = rn.replace(/-\d{4}-\d{2}-\d{2}T[\dZ.-]+$/, "");
+      if (base === name)
+        return { dup: true, reason: `retired skill '${base}' exists in quarantine (${retiredRoot}/${rn}) — restore it or absorb instead of recreating`, name: base, overlap: 1 };
+      const overlap = overlapWith(skillDesc(retiredRoot, rn));
+      if (overlap > 0.6)
+        return { dup: true, reason: `>60% description overlap with RETIRED skill '${base}' (${retiredRoot}/${rn}) — quarantined: restore/absorb instead of recreating a sibling`, name: base, overlap };
     }
   }
   return { dup: worst.overlap > 0.6, reason: worst.overlap > 0.6 ? `>60% description overlap with '${worst.name}' — patch/absorb instead` : "", name: worst.name, overlap: worst.overlap };
@@ -1194,11 +1239,11 @@ A recovery discipline distilled from ${repair.count} real \`${repair.verifyStep}
 }
 // mods/autopilot.ts
 import { mkdirSync as mkdirSync4, readFileSync as readFileSync4, existsSync as existsSync4, writeFileSync as writeFileSync4, renameSync as renameSync3 } from "node:fs";
-import { join as join4 } from "node:path";
+import { join as join5 } from "node:path";
 
 // mods/publish.ts
 import { mkdirSync as mkdirSync2, readFileSync as readFileSync2, existsSync as existsSync2, writeFileSync as writeFileSync2 } from "node:fs";
-import { join as join2 } from "node:path";
+import { join as join3 } from "node:path";
 import { execFileSync } from "node:child_process";
 import { userInfo } from "node:os";
 var PUBLISH_SECRET_RES = [
@@ -1353,7 +1398,7 @@ function stageSanitizedPublish(skill) {
   const tier = publishTier(plan);
   if (plan.hardBlocks.length)
     return { staged: false, dir: "", plan, tier, reason: `blocked: ${plan.hardBlocks.join("; ")}` };
-  const dir = join2(PUBLISH_STAGED_DIR, slug(skill.name));
+  const dir = join3(PUBLISH_STAGED_DIR, slug(skill.name));
   try {
     mkdirSync2(dir, { recursive: true });
   } catch {}
@@ -1370,12 +1415,12 @@ ${Object.entries(meta).map(([k, v]) => `${k}: ${v}`).join(`
 ---
 
 ${plan.sanitizedPreview}`;
-  writeFileSync2(join2(dir, "SKILL.md"), body);
-  writeFileSync2(join2(dir, "PUBLISH-PLAN.json"), JSON.stringify({ skill: skill.name, tier, publishability: plan.publishability, recommended: plan.recommended, issues: plan.issues, replacements: plan.replacements, metadata: meta, staged_at: Date.now() }, null, 2));
+  writeFileSync2(join3(dir, "SKILL.md"), body);
+  writeFileSync2(join3(dir, "PUBLISH-PLAN.json"), JSON.stringify({ skill: skill.name, tier, publishability: plan.publishability, recommended: plan.recommended, issues: plan.issues, replacements: plan.replacements, metadata: meta, staged_at: Date.now() }, null, 2));
   return { staged: true, dir, plan, tier };
 }
 function approveStagedPublish(name, globalDir) {
-  const staged = join2(PUBLISH_STAGED_DIR, slug(name), "SKILL.md");
+  const staged = join3(PUBLISH_STAGED_DIR, slug(name), "SKILL.md");
   if (!existsSync2(staged))
     return { published: false, reason: "no staged copy — run `publish stage <skill>` first" };
   const body = readFileSync2(staged, "utf8");
@@ -1385,15 +1430,15 @@ function approveStagedPublish(name, globalDir) {
   const sec = scanSkillContent(body);
   if (!sec.ok)
     return { published: false, reason: `security: ${sec.issues.join("; ")}` };
-  const dst = join2(globalDir, slug(name));
+  const dst = join3(globalDir, slug(name));
   try {
     mkdirSync2(dst, { recursive: true });
   } catch {}
-  writeFileSync2(join2(dst, "SKILL.md"), body);
-  return { published: true, path: join2(dst, "SKILL.md") };
+  writeFileSync2(join3(dst, "SKILL.md"), body);
+  return { published: true, path: join3(dst, "SKILL.md") };
 }
 function publishVisibilityReceipt(name, globalDir) {
-  const p = join2(globalDir, slug(name), "SKILL.md");
+  const p = join3(globalDir, slug(name), "SKILL.md");
   return { exists: existsSync2(p), path: p, reloadHint: "run /reload (or restart the agent) so the skill index surfaces the new Custom Skill" };
 }
 function liveSkillVisible(name, agentId) {
@@ -1428,10 +1473,10 @@ function publishSkillToCatalog(name, ctx) {
   const nm = slug(name);
   if (!nm)
     throw new Error("name required");
-  const d = scanDirs(ctx).find((x) => existsSync2(join2(x, nm, "SKILL.md")));
+  const d = scanDirs(ctx).find((x) => existsSync2(join3(x, nm, "SKILL.md")));
   if (!d)
     throw new Error(`no active skill '${nm}'`);
-  const src = join2(d, nm, "SKILL.md");
+  const src = join3(d, nm, "SKILL.md");
   if (!existsSync2(src))
     throw new Error(`no SKILL.md for '${nm}'`);
   const content = readFileSync2(src, "utf8");
@@ -1443,21 +1488,21 @@ function publishSkillToCatalog(name, ctx) {
   const priv = catalogPrivacyScan(content);
   if (!priv.ok)
     throw new Error(`privacy blocked: ${priv.issues.join("; ")}`);
-  const dstDir = join2(GLOBAL_SKILLS_DIR, nm);
+  const dstDir = join3(GLOBAL_SKILLS_DIR, nm);
   mkdirSync2(dstDir, { recursive: true });
   const published = content.includes(MM_TAG) ? content : content + `
 <!-- ${MM_TAG}: published ${new Date().toISOString().slice(0, 10)}; catalog=global -->
 `;
-  writeFileSync2(join2(dstDir, "SKILL.md"), published);
+  writeFileSync2(join3(dstDir, "SKILL.md"), published);
   appendUiEvent({ phase: "skill_published", summary: `published '${nm}' to custom skill catalog`, skill: nm, action: "publish", route: "global-catalog" });
   appendMeshFeed({ type: "skill_published", skill: nm, route: "PUBLISH", signals: 0 });
   writeUiState({ phase: "done", last: `published '${nm}' to catalog`, route: "PUBLISH · catalog" });
-  return join2(dstDir, "SKILL.md");
+  return join3(dstDir, "SKILL.md");
 }
 
 // mods/lifecycle.ts
 import { mkdirSync as mkdirSync3, readFileSync as readFileSync3, existsSync as existsSync3, writeFileSync as writeFileSync3, readdirSync as readdirSync2, renameSync as renameSync2 } from "node:fs";
-import { join as join3 } from "node:path";
+import { join as join4 } from "node:path";
 function managedSkillUsage(name, rows = loadRows()) {
   const n = slug(name);
   return rows.filter((r) => (r.tmpl || r.fp || "").toLowerCase().includes(`skill ${n}`)).length;
@@ -1484,7 +1529,7 @@ function curateManagedSkills(ctx) {
 }
 function retireManagedSkill(name, reason, ctx, absorbedInto, restrictDirs) {
   const dirs = restrictDirs ?? scanDirs(ctx);
-  const d = dirs.find((x) => existsSync3(join3(x, name, "SKILL.md")));
+  const d = dirs.find((x) => existsSync3(join4(x, name, "SKILL.md")));
   if (!d)
     throw new Error(`no skill '${name}'`);
   if (!isManaged(d, name))
@@ -1492,15 +1537,15 @@ function retireManagedSkill(name, reason, ctx, absorbedInto, restrictDirs) {
   if (isPinned(name))
     throw new Error(`'${name}' is pinned — unpin first (pin protects from retire, not from patch)`);
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const retiredRoot = join3(d, "_retired");
+  const retiredRoot = join4(d, "_retired");
   mkdirSync3(retiredRoot, { recursive: true });
-  const target = join3(retiredRoot, `${name}-${stamp}`);
+  const target = join4(retiredRoot, `${name}-${stamp}`);
   const forward = absorbedInto ? `absorbed_into: ${absorbedInto}
 ` : "";
-  writeFileSync3(join3(d, name, "RETIRE-REASON.txt"), `${new Date().toISOString()}
+  writeFileSync3(join4(d, name, "RETIRE-REASON.txt"), `${new Date().toISOString()}
 ${reason || "retired by muscle-memory curate"}
 ${forward}`);
-  renameSync2(join3(d, name), target);
+  renameSync2(join4(d, name), target);
   const u = loadUsage();
   u[name] = { ...u[name] || {}, state: "archived", absorbedInto: absorbedInto || undefined };
   saveUsage(u);
@@ -1515,7 +1560,7 @@ function retiredSkillBlocker(name, ctx) {
     return `skill '${nm}' is archived/retired; restore it before recreating or patch an existing replacement`;
   }
   for (const d of scanDirs(ctx)) {
-    const retiredRoot = join3(d, "_retired");
+    const retiredRoot = join4(d, "_retired");
     try {
       if (!existsSync3(retiredRoot))
         continue;
@@ -1664,18 +1709,18 @@ function isPinned(name) {
 function restoreManagedSkill(name, ctx) {
   const dirs = scanDirs(ctx);
   for (const d of dirs) {
-    const retiredRoot = join3(d, "_retired");
+    const retiredRoot = join4(d, "_retired");
     if (!existsSync3(retiredRoot))
       continue;
     const matches = readdirSync2(retiredRoot).filter((n) => n === name || n.startsWith(`${name}-`)).sort().reverse();
     if (matches.length) {
-      if (existsSync3(join3(d, name, "SKILL.md")))
+      if (existsSync3(join4(d, name, "SKILL.md")))
         throw new Error(`'${name}' already active`);
-      renameSync2(join3(retiredRoot, matches[0]), join3(d, name));
+      renameSync2(join4(retiredRoot, matches[0]), join4(d, name));
       const u = loadUsage();
       u[name] = { ...u[name] || {}, state: "active", lastActivity: Date.now() };
       saveUsage(u);
-      return join3(d, name);
+      return join4(d, name);
     }
   }
   throw new Error(`no retired skill '${name}' to restore`);
@@ -2044,7 +2089,7 @@ function provenanceBlock(c) {
 `;
 }
 function appendRecurrenceNote(dir, name, note) {
-  if (!existsSync4(join4(dir, name, "SKILL.md")))
+  if (!existsSync4(join5(dir, name, "SKILL.md")))
     return false;
   let t = readSkill(dir, name);
   const stamp = new Date().toISOString().slice(0, 10);
@@ -2239,7 +2284,7 @@ async function runAutopilot(ctx, config) {
   try {
     ensureDir();
     mkdirSync4(RECEIPTS_DIR, { recursive: true });
-    writeFileSync4(join4(RECEIPTS_DIR, `autopilot-${Date.now()}.json`), JSON.stringify({ mode: cfg.mode, ...result, published, ts: Date.now() }, null, 2));
+    writeFileSync4(join5(RECEIPTS_DIR, `autopilot-${Date.now()}.json`), JSON.stringify({ mode: cfg.mode, ...result, published, ts: Date.now() }, null, 2));
   } catch {}
   return { ...plan, result };
 }
@@ -2363,7 +2408,7 @@ async function reviewAndAuthor(evidence, dirs, authorFn, opts = {}) {
   }
   const existingForUpdate = updTarget ? (() => {
     try {
-      const d = dirs.find((x) => existsSync4(join4(x, updTarget.name, "SKILL.md")));
+      const d = dirs.find((x) => existsSync4(join5(x, updTarget.name, "SKILL.md")));
       return d ? readSkill(d, updTarget.name) : "";
     } catch {
       return "";
@@ -2462,7 +2507,7 @@ The ~70-line cap is LIFTED (target a rich ~120-180 lines); be EXHAUSTIVE on the 
   }
   try {
     ensureDir();
-    writeFileSync4(join4(STATE_DIR, "reflect-last-raw.txt"), `=== ${new Date().toISOString()}${degraded ? " [" + degraded + "]" : ""} ===
+    writeFileSync4(join5(STATE_DIR, "reflect-last-raw.txt"), `=== ${new Date().toISOString()}${degraded ? " [" + degraded + "]" : ""} ===
 ${raw}
 `);
   } catch {}
@@ -2493,7 +2538,7 @@ YOUR PREVIOUS DRAFT IS NOT YET SOTA (${why.join("; ")}). A top-tier skill ALWAYS
     try {
       const raw2 = await authorFn(REVIEW_PROMPT, evidence + hint + depthDirective + corrective) || "";
       try {
-        writeFileSync4(join4(STATE_DIR, "reflect-last-raw.txt"), `=== ${new Date().toISOString()} (retry) ===
+        writeFileSync4(join5(STATE_DIR, "reflect-last-raw.txt"), `=== ${new Date().toISOString()} (retry) ===
 ${raw2}
 `);
       } catch {}
@@ -2580,7 +2625,7 @@ function retrievePreferences(evidence, memDir) {
     return [];
   const prefs = [];
   for (const s of ["persona.md", "system/persona.md", "system/human.md", "human.md", "system/human/preferences.md"]) {
-    const p = join4(dir, s);
+    const p = join5(dir, s);
     if (!existsSync4(p))
       continue;
     try {
@@ -2626,8 +2671,8 @@ function graduateStagedSkill(name, ctx) {
   const nm = slug(name);
   if (!nm)
     throw new Error("name required");
-  const srcDir = join4(STAGED_DIR, nm);
-  const src = join4(srcDir, "SKILL.md");
+  const srcDir = join5(STAGED_DIR, nm);
+  const src = join5(srcDir, "SKILL.md");
   if (!existsSync4(src))
     throw new Error(`no staged skill '${nm}'`);
   const retiredBlock = retiredSkillBlocker(nm, ctx);
@@ -2648,7 +2693,7 @@ function graduateStagedSkill(name, ctx) {
 `);
   mkdirSync4(STAGED_RETIRED_DIR, { recursive: true });
   try {
-    renameSync3(srcDir, join4(STAGED_RETIRED_DIR, `${nm}-graduated-${Date.now()}`));
+    renameSync3(srcDir, join5(STAGED_RETIRED_DIR, `${nm}-graduated-${Date.now()}`));
   } catch {}
   appendUiEvent({ phase: "skill_graduated", summary: `graduated '${nm}'`, skill: nm, action: "graduate", route: "manual" });
   appendMeshFeed({ type: "skill_graduated", skill: nm, route: "GRADUATE", signals: 0 });
@@ -2681,7 +2726,7 @@ ${user}` }]);
 async function runReflectiveReview(ctx, config = {}) {
   const dirs = scanDirs(ctx);
   const reviewDirs = config.mode === "auto" ? dirs : [...dirs, STAGED_DIR];
-  const exp = loadExperience();
+  const exp = config.experience ?? loadExperience();
   const ev = buildCrossConversationEvidence(exp);
   const engram = engramConsolidate(exp, managedView(reviewDirs).map((m) => ({ name: m.name, body: m.body })));
   appendUiEvent({ phase: "review_started", summary: `reviewing ${ev.convs} sessions / ${ev.items} durable signals` });
@@ -2736,19 +2781,26 @@ ${prefs.map((p) => `- ${p}`).join(`
           writeUiState({ phase: "idle", last: `retire-sticky blocked '${res.name}'`, route: "SKIP · retired" });
           return { action: "none", name: res.name, reason: retiredBlock };
         }
+        const n1 = multiInstanceSupport(`${res.name} ${res.description ?? ""}`, ev.signals ?? [], config.minInstances ?? 2);
+        if (!n1.ok) {
+          markHandledReflect(sig, `N1-PARKED:${res.name}`);
+          appendUiEvent({ phase: "reflect_none", summary: `n=1 gate parked '${res.name}': ${n1.reason.slice(0, 120)}` });
+          writeUiState({ phase: "idle", last: `n=1 gate parked '${res.name}'`, route: "SKIP · n=1" });
+          return { action: "none", name: res.name, reason: `n=1 gate: ${n1.reason}` };
+        }
       }
       const oldContent = res.action === "update" && res.updateTarget ? (() => {
-        const d = reviewDirs.find((x) => existsSync4(join4(x, res.updateTarget, "SKILL.md")));
+        const d = reviewDirs.find((x) => existsSync4(join5(x, res.updateTarget, "SKILL.md")));
         return d ? readSkill(d, res.updateTarget) : undefined;
       })() : undefined;
       writeSkill(dir, res.name, tagged);
       const manifest = buildEvidenceManifest({ action: res.action, skill: res.name, updateTarget: res.updateTarget, convs: ev.convs, signals: ev.items, memfsHits: res.matches || [], preferences: prefs, rejected: ev.rejected, newContent: tagged, oldContent });
-      const evDir = join4(dir, res.name, "references", "evidence");
+      const evDir = join5(dir, res.name, "references", "evidence");
       mkdirSync4(evDir, { recursive: true });
-      writeFileSync4(join4(evDir, `${Date.now()}.json`), JSON.stringify(manifest, null, 2));
+      writeFileSync4(join5(evDir, `${Date.now()}.json`), JSON.stringify(manifest, null, 2));
       ensureDir();
       mkdirSync4(RECEIPTS_DIR, { recursive: true });
-      writeFileSync4(join4(RECEIPTS_DIR, `reflect-${Date.now()}.json`), JSON.stringify({ action: res.action, name: res.name, updateTarget: res.updateTarget, convs: ev.convs, items: ev.items, prefsInjected: prefs.length, rejected: ev.rejected.length, degraded: res.degraded || null, dir, ts: Date.now() }, null, 2));
+      writeFileSync4(join5(RECEIPTS_DIR, `reflect-${Date.now()}.json`), JSON.stringify({ action: res.action, name: res.name, updateTarget: res.updateTarget, convs: ev.convs, items: ev.items, prefsInjected: prefs.length, rejected: ev.rejected.length, degraded: res.degraded || null, dir, ts: Date.now() }, null, 2));
       if (res.degraded)
         appendUiEvent({ phase: "author_degraded", summary: `authored via graceful degradation: ${res.degraded}`, skill: res.name });
       const phase = graduate ? "skill_graduated" : "skill_staged";
@@ -2763,7 +2815,7 @@ ${prefs.map((p) => `- ${p}`).join(`
       if (prefs.length)
         appendUiEvent({ phase: "memory_pref_injected", summary: `injected ${prefs.length} user preferences` });
       writeUiState({ phase: "done", last: summary, route: `${graduate ? "GRADUATE" : res.action.toUpperCase()}${res.updateTarget ? " " + res.updateTarget : ""} · ${graduate ? "live" : "staged"}` });
-      return { ...res, wrote: join4(dir, res.name) };
+      return { ...res, wrote: join5(dir, res.name) };
     } catch (e) {
       appendUiEvent({ phase: "reflect_error", summary: `write failed: ${String(e?.message ?? e).slice(0, 80)}` });
       return { ...res, reason: String(e?.message ?? e) };
@@ -2775,7 +2827,7 @@ ${prefs.map((p) => `- ${p}`).join(`
     try {
       ensureDir();
       mkdirSync4(RECEIPTS_DIR, { recursive: true });
-      writeFileSync4(join4(RECEIPTS_DIR, `reflect-rejected-${Date.now()}.json`), JSON.stringify({ action: "reject", safe, reason: res.reason || "(none)", degraded: res.degraded || null, convs: ev.convs, items: ev.items, ts: Date.now() }, null, 2));
+      writeFileSync4(join5(RECEIPTS_DIR, `reflect-rejected-${Date.now()}.json`), JSON.stringify({ action: "reject", safe, reason: res.reason || "(none)", degraded: res.degraded || null, convs: ev.convs, items: ev.items, ts: Date.now() }, null, 2));
     } catch {}
     appendUiEvent({ phase: safe ? "blocked_unsafe" : "reflect_none", summary: safe ? `\uD83D\uDEE1️ blocked unsafe content (safe): ${res.reason}` : `draft rejected; nothing saved (${res.reason})${res.degraded ? " [degraded: " + res.degraded + "]" : ""}` });
     writeUiState({ phase: safe ? "protected" : "idle", last: safe ? "blocked unsafe content (safe)" : `draft rejected; nothing saved`, route: safe ? "BLOCKED · protected" : "SKIP · rejected-draft" });
@@ -2941,7 +2993,7 @@ var __mm = {
 function activate(letta) {
   const disposers = [];
   let panel = null;
-  const DEFENSE_HITS = join5(STATE_DIR, "defense-hits.jsonl");
+  const DEFENSE_HITS = join6(STATE_DIR, "defense-hits.jsonl");
   let defensesCache = [];
   const refreshDefenses = () => {
     try {
@@ -3036,14 +3088,14 @@ function activate(letta) {
         ensureDir();
         mkdirSync5(RECEIPTS_DIR, { recursive: true });
         const { candidates } = detect(loadExperience());
-        writeFileSync5(join5(RECEIPTS_DIR, `compact-${Date.now()}.json`), JSON.stringify({ phase: "start", conv: event?.conversationId ?? null, candidatesPreserved: candidates.length, ts: Date.now() }));
+        writeFileSync5(join6(RECEIPTS_DIR, `compact-${Date.now()}.json`), JSON.stringify({ phase: "start", conv: event?.conversationId ?? null, candidatesPreserved: candidates.length, ts: Date.now() }));
       } catch {}
     }));
     disposers.push(letta.events.on("compact_end", (event) => {
       try {
         ensureDir();
         mkdirSync5(RECEIPTS_DIR, { recursive: true });
-        writeFileSync5(join5(RECEIPTS_DIR, `compact-end-${Date.now()}.json`), JSON.stringify({ phase: "end", conv: event?.conversationId ?? null, trigger: event?.trigger ?? null, messagesBefore: event?.messagesBefore ?? null, messagesAfter: event?.messagesAfter ?? null, contextTokensBefore: event?.contextTokensBefore ?? null, contextTokensAfter: event?.contextTokensAfter ?? null, ts: Date.now() }));
+        writeFileSync5(join6(RECEIPTS_DIR, `compact-end-${Date.now()}.json`), JSON.stringify({ phase: "end", conv: event?.conversationId ?? null, trigger: event?.trigger ?? null, messagesBefore: event?.messagesBefore ?? null, messagesAfter: event?.messagesAfter ?? null, contextTokensBefore: event?.contextTokensBefore ?? null, contextTokensAfter: event?.contextTokensAfter ?? null, ts: Date.now() }));
       } catch {}
     }));
   }
@@ -3147,7 +3199,7 @@ function activate(letta) {
         if (sub === "staged") {
           let s = [];
           try {
-            s = existsSync5(STAGED_DIR) ? readdirSync3(STAGED_DIR).filter((n) => existsSync5(join5(STAGED_DIR, n, "SKILL.md"))) : [];
+            s = existsSync5(STAGED_DIR) ? readdirSync3(STAGED_DIR).filter((n) => existsSync5(join6(STAGED_DIR, n, "SKILL.md"))) : [];
           } catch {}
           return { type: "output", output: s.length ? `staged skills (1-tap to graduate):
 ` + s.map((n) => `  · ${n}`).join(`
@@ -3271,7 +3323,7 @@ ${plan.digest}` };
           const reg = buildRegistry(dirs);
           let staged2 = [];
           try {
-            staged2 = existsSync5(STAGED_DIR) ? readdirSync3(STAGED_DIR).filter((n) => existsSync5(join5(STAGED_DIR, n, "SKILL.md"))) : [];
+            staged2 = existsSync5(STAGED_DIR) ? readdirSync3(STAGED_DIR).filter((n) => existsSync5(join6(STAGED_DIR, n, "SKILL.md"))) : [];
           } catch {}
           const used = reg.skills.filter((s) => s.uses > 0);
           const idle = reg.skills.filter((s) => s.uses === 0 && s.state !== "archived");
@@ -3313,7 +3365,7 @@ ${plan.digest}` };
                 managed++;
         } catch {}
         try {
-          staged = existsSync5(STAGED_DIR) ? readdirSync3(STAGED_DIR).filter((n) => existsSync5(join5(STAGED_DIR, n, "SKILL.md"))).length : 0;
+          staged = existsSync5(STAGED_DIR) ? readdirSync3(STAGED_DIR).filter((n) => existsSync5(join6(STAGED_DIR, n, "SKILL.md"))).length : 0;
         } catch {}
         const cov = (() => {
           try {
@@ -3381,7 +3433,7 @@ ${plan.digest}` };
     const readRun = async (ctx) => {
       const a = ctx?.args || {};
       const dirs = scanDirs(ctx);
-      const findSkillDir = (name) => dirs.find((d) => existsSync5(join5(d, name, "SKILL.md")));
+      const findSkillDir = (name) => dirs.find((d) => existsSync5(join6(d, name, "SKILL.md")));
       try {
         if (a.action === "candidates") {
           const rows = loadExperience();
@@ -3498,7 +3550,7 @@ ${d.body}` };
       const a = ctx?.args || {};
       const dir = agentSkillsDir(ctx);
       const dirs = scanDirs(ctx);
-      const findSkillDir = (name) => dirs.find((d) => existsSync5(join5(d, name, "SKILL.md")));
+      const findSkillDir = (name) => dirs.find((d) => existsSync5(join6(d, name, "SKILL.md")));
       try {
         if (a.action === "autopilot_run") {
           const cfg = { ...AUTOPILOT_DEFAULT, mode: a.mode === "auto" ? "auto" : "staged" };
@@ -3548,7 +3600,7 @@ ${d.body}` };
           if (retiredBlock)
             return { status: "error", content: `retire-sticky blocked: ${retiredBlock}`, candidate: c };
           const desc = String(a.description || d.description);
-          const dc = dedupCheck(nm, desc, dirs);
+          const dc = dedupCheck(nm, desc, createDedupeSurface(ctx));
           if (dc.dup)
             return { status: "error", content: `anti-bloat blocked: ${dc.reason}. Use action:patch on '${dc.name}' instead.`, candidate: c };
           const lint = lintSkillDraft({ name: nm, description: desc, body: d.body }, { needsPitfalls: !!c.fixes });
@@ -3578,7 +3630,7 @@ Load with muscle_memory_skill_read action:load, then invoke the normal Skill too
           const retiredBlock = retiredSkillBlocker(nm, ctx);
           if (retiredBlock)
             return { status: "error", content: `retire-sticky blocked: ${retiredBlock}` };
-          const dc = dedupCheck(nm, a.description, dirs);
+          const dc = dedupCheck(nm, a.description, createDedupeSurface(ctx));
           if (dc.dup)
             return { status: "error", content: `anti-bloat blocked: ${dc.reason}. Use action:patch on '${dc.name}' instead.` };
           const lint = lintSkillDraft({ name: nm, description: a.description, body: a.body });

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -1962,12 +1962,14 @@ function nativeEnabled(channel) {
 }
 function reachFn(root, path) {
   let cur = root;
+  let receiver = null;
   for (const key of path) {
     if (!cur || typeof cur !== "object")
       return null;
+    receiver = cur;
     cur = Reflect.get(cur, key);
   }
-  return typeof cur === "function" ? cur : null;
+  return typeof cur === "function" ? cur.bind(receiver) : null;
 }
 async function syncNeocortexBlock(client, agentId, content) {
   if (!agentId || !nativeEnabled("blocks"))

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -372,18 +372,7 @@ function commandTemplate2(cmd) {
   t = t.replace(/\s+/g, " ").trim();
   return t.slice(0, 240);
 }
-var HIGH_SIGNAL_TOOL_SET = new Set(["visual_receipt", "im8_claims_lint", "no_cap_gate_check", "repo_radar_evidence", "kev_final_buzzer_gate", "im8_theme_done_gate", "im8_product_intel", "im8_write_plan"]);
-function hostOrToken(s) {
-  const raw = String(s || "");
-  try {
-    return new URL(raw).hostname.replace(/^www\./, "");
-  } catch {
-    return slug(raw).slice(0, 48) || "unknown";
-  }
-}
-function countMaybeArray(v) {
-  return Array.isArray(v) ? v.length : v == null ? 0 : 1;
-}
+var HIGH_SIGNAL_TOOL_SET = new Set((process.env.MM_HIGH_SIGNAL_TOOLS || "").split(",").map((s) => s.trim()).filter(Boolean));
 function fingerprint2(tool, args) {
   let tmpl = null;
   const keys = Object.keys(args || {}).sort();
@@ -398,22 +387,8 @@ function fingerprint2(tool, args) {
     tmpl = `${tool} ${keys.join(",")}`;
   } else if (tool === "Skill" && typeof args?.skill === "string") {
     tmpl = `Skill ${slug(String(args.skill))}`;
-  } else if (tool === "visual_receipt") {
-    tmpl = `visual_receipt ${hostOrToken(args?.url)} ${countMaybeArray(args?.viewports)} viewports ${countMaybeArray(args?.selectors)} selectors`;
-  } else if (tool === "im8_claims_lint") {
-    tmpl = `im8_claims_lint supplement-copy ${countMaybeArray(args?.files)} files`;
-  } else if (tool === "no_cap_gate_check") {
-    tmpl = `no_cap_gate_check high-trust-claim`;
-  } else if (tool === "repo_radar_evidence" && typeof args?.kind === "string") {
-    tmpl = `repo_radar_evidence ${slug(String(args.kind))}`;
-  } else if (tool === "kev_final_buzzer_gate") {
-    tmpl = `kev_final_buzzer_gate final-readiness`;
-  } else if (tool === "im8_theme_done_gate") {
-    tmpl = `im8_theme_done_gate theme-readiness`;
-  } else if (tool === "im8_product_intel") {
-    tmpl = `im8_product_intel ${slug(String(args?.mode || "lookup"))}`;
-  } else if (tool === "im8_write_plan") {
-    tmpl = `im8_write_plan ${slug(String(args?.operation || "write-plan"))}`;
+  } else if (HIGH_SIGNAL_TOOL_SET.has(tool)) {
+    tmpl = `${tool} ${keys.join(",")}`;
   }
   const shape = keys.filter((k) => !SECRETISH.test(k)).join(",");
   const fp = `${tool}(${shape})${tmpl ? " :: " + tmpl : ""}`;
@@ -2724,8 +2699,9 @@ ${user}` }]);
   };
 }
 async function runReflectiveReview(ctx, config = {}) {
-  const dirs = scanDirs(ctx);
-  const reviewDirs = config.mode === "auto" ? dirs : [...dirs, STAGED_DIR];
+  const dirs = config.dirs ?? scanDirs(ctx);
+  const stagedShelf = config.stagedDir ?? STAGED_DIR;
+  const reviewDirs = config.mode === "auto" ? dirs : [...dirs, stagedShelf];
   const exp = config.experience ?? loadExperience();
   const ev = buildCrossConversationEvidence(exp);
   const engram = engramConsolidate(exp, managedView(reviewDirs).map((m) => ({ name: m.name, body: m.body })));
@@ -2768,7 +2744,7 @@ ${prefs.map((p) => `- ${p}`).join(`
   if ((res.action === "create" || res.action === "update") && res.name && res.content) {
     const live = config.mode === "auto";
     const graduate = live || res.action === "update" || isHighConfidenceCreate(res, ev);
-    const dir = graduate ? agentSkillsDir(ctx) : STAGED_DIR;
+    const dir = graduate ? agentSkillsDir(ctx) : stagedShelf;
     const tagged = res.content.includes(MM_TAG) ? res.content : res.content + `
 <!-- ${MM_TAG}: reflective ${new Date().toISOString().slice(0, 10)}; action=${res.action}; convs=${ev.convs}; ${graduate ? "graduated=true" : "staged=true"} -->
 `;

--- a/packages/muscle-memory/mods/index.ts
+++ b/packages/muscle-memory/mods/index.ts
@@ -34,7 +34,7 @@ export type { Defense } from "./engram";
 export { detect, detectRepairChains, isSkillWorthy } from "./detect";
 export { draftWithRepair } from "./gate";
 export { preserveExistingFrontmatterMetadata, isAmbiguousExistingRoute, compareSkillSections } from "./autopilot";
-import { GLOBAL_SKILLS, LOG_PATH, MM, MM_TAG, NEOCORTEX_BLOCK, OUTCOME_PATH, RECEIPTS_DIR, SESSIONS_PATH, STAGED_DIR, STATE_DIR, TELEMETRY_PATH, agentSkillsDir, appendJsonl, appendMeshFeed, appendUiEvent, ensureDir, hash, isManaged, listSkillNames, loadExperience, loadMeshFeed, loadRows, loadUiEvents, readSkill, readUiState, redactFragment, removeSupportFile, renderMeshFeed, scanDirs, scanSkillContent, scanSupportFile, setLivePanel, skillDesc, slug, validateSupportPath, writeSkill, writeSupportFile, writeUiState } from "./core";
+import { GLOBAL_SKILLS, LOG_PATH, MM, MM_TAG, NEOCORTEX_BLOCK, OUTCOME_PATH, RECEIPTS_DIR, SESSIONS_PATH, STAGED_DIR, STATE_DIR, TELEMETRY_PATH, agentSkillsDir, appendJsonl, appendMeshFeed, appendUiEvent, createDedupeSurface, ensureDir, hash, isManaged, listSkillNames, loadExperience, loadMeshFeed, loadRows, loadUiEvents, readSkill, readUiState, redactFragment, removeSupportFile, renderMeshFeed, scanDirs, scanSkillContent, scanSupportFile, setLivePanel, skillDesc, slug, validateSupportPath, writeSkill, writeSupportFile, writeUiState } from "./core";
 import { buildCrossConversationEvidence, classifyError, commandTemplate, correlateOutcomes, detect, detectAntiPatterns, detectInvocationGotchas, detectRepairChains, detectSequences, detectTemplates, fingerprint, impactScore, inferOutcomes, isDurableLesson, isValidSkillName, maturityScore, mergeOutcomes, stepSig } from "./detect";
 import { auditSkills, buildDiffFragment, candidateDescription, candidateName, crossShelfDuplicates, dedupCheck, draftSkillFromCandidate, draftWithRepair, effectivenessVerdict, findCandidate, lintSkillDraft, repairForCandidate, sotaQualityGaps } from "./gate";
 import { approveStagedPublish, catalogPrivacyScan, findSimilarSkills, liveSkillVisible, publishHardBlocks, publishMetadata, publishPlan, publishSkillToCatalog, publishTier, publishVisibilityReceipt, publishabilityScore, sanitizeForPublish, stageSanitizedPublish } from "./publish";
@@ -526,7 +526,7 @@ export default function activate(letta: any) {
           const retiredBlock = retiredSkillBlocker(nm, ctx);
           if (retiredBlock) return { status: "error", content: `retire-sticky blocked: ${retiredBlock}`, candidate: c };
           const desc = String(a.description || d.description);
-          const dc = dedupCheck(nm, desc, dirs);
+          const dc = dedupCheck(nm, desc, createDedupeSurface(ctx)); // P0 2b: active + staged + retired-quarantine surface
           if (dc.dup) return { status: "error", content: `anti-bloat blocked: ${dc.reason}. Use action:patch on '${dc.name}' instead.`, candidate: c };
           const lint = lintSkillDraft({ name: nm, description: desc, body: d.body }, { needsPitfalls: !!c.fixes });
           if (!lint.ok) return { status: "error", content: `authoring-linter blocked: ${lint.issues.join("; ")}`, candidate: c };
@@ -541,7 +541,7 @@ export default function activate(letta: any) {
           const nm = slug(a.name);
           const retiredBlock = retiredSkillBlocker(nm, ctx);
           if (retiredBlock) return { status: "error", content: `retire-sticky blocked: ${retiredBlock}` };
-          const dc = dedupCheck(nm, a.description, dirs);
+          const dc = dedupCheck(nm, a.description, createDedupeSurface(ctx)); // P0 2b: active + staged + retired-quarantine surface
           if (dc.dup) return { status: "error", content: `anti-bloat blocked: ${dc.reason}. Use action:patch on '${dc.name}' instead.` };
           const lint = lintSkillDraft({ name: nm, description: a.description, body: a.body });
           if (!lint.ok) return { status: "error", content: `authoring-linter blocked: ${lint.issues.join("; ")}` };

--- a/packages/muscle-memory/test/create-gates.test.ts
+++ b/packages/muscle-memory/test/create-gates.test.ts
@@ -127,7 +127,12 @@ test("2a · wiring: reflect lane parks an n=1 create as action:none with an n=1 
       mode: "staged",
       authorFn: async () => N1_DRAFT,
       experience,
-    } as any);
+      // HERMETIC: pin the routing/dedupe surface to empty tmp shelves. Without this the lane
+      // scans the HOST's real shelves (~/.letta/skills) and on a populated machine the
+      // ambiguous-route guard fires before the n=1 gate — green only on an empty shelf.
+      dirs: [mkdtempSync(join(tmpdir(), "mm-n1-shelf-"))],
+      stagedDir: mkdtempSync(join(tmpdir(), "mm-n1-staged-")),
+    });
     expect(res.action).toBe("none");
     expect(res.reason || "").toMatch(/n=1|single.instance|multi.instance/i);
     expect(res.wrote).toBeFalsy();

--- a/packages/muscle-memory/test/create-gates.test.ts
+++ b/packages/muscle-memory/test/create-gates.test.ts
@@ -1,0 +1,180 @@
+// muscle-memory · CREATE-gate tests (P0: n=1 gate + pre-create dedupe surface).
+//
+// RECEIPT this suite exists for: `recovering-from-npx-failures` — an n=1, command-shaped
+// skill ("Observed 1× across 1 session") that was reflect-created TWICE on consecutive days
+// and retired twice. Two holes let it happen:
+//   (2a) the reflect lane's evidence floor is AGGREGATE (items >= 2): an n=1 repair can ride
+//        in on an unrelated recurring workflow and become a skill with no multi-instance support;
+//   (2b) the manual create / create_from_candidate dedupe surface (scanDirs) does NOT include
+//        the STAGED shelf, and near-duplicates of RETIRED skills are invisible to dedupCheck
+//        (retiredSkillBlocker is same-name only).
+// Run: `bun test test/create-gates.test.ts`
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Row } from "../mods/index";
+import { buildCrossConversationEvidence, multiInstanceSupport } from "../mods/detect";
+import { runReflectiveReview } from "../mods/autopilot";
+import { dedupCheck } from "../mods/gate";
+import { createDedupeSurface, STAGED_DIR } from "../mods/core";
+
+const T0 = 1_700_000_000_000;
+let seq = 0;
+function R(tool: string, tmpl: string, ok: boolean | undefined, opts: { conv?: string; ts?: number; err?: string } = {}): Row {
+  return { tool, tmpl, fp: tmpl, h: tmpl, ok, ts: opts.ts ?? T0 + seq++ * 1000, conv: opts.conv ?? "c1", ...(opts.err ? { err: opts.err } : {}) } as Row;
+}
+
+/** The npx hole, reconstructed: ONE fail→fix→verify arc for a distinctive command in ONE
+ * conversation, padded by an UNRELATED recurring workflow so the aggregate items floor passes. */
+function n1Experience(): Row[] {
+  seq = 0;
+  return [
+    // n=1 repair arc (single conversation, single instance)
+    R("Bash", "npx quokka-visor migrate", false, { conv: "c1", err: "exit-code-1" }),
+    R("Edit", "visor.config.mjs", true, { conv: "c1" }),
+    R("Bash", "npx quokka-visor migrate", true, { conv: "c1" }),
+    // unrelated padding workflow (3× → topTmpl signal) — this is what sneaks items past the floor
+    R("Bash", "agenttrace --overview", true, { conv: "c2" }),
+    R("Bash", "agenttrace --overview", true, { conv: "c3" }),
+    R("Bash", "agenttrace --overview", true, { conv: "c4" }),
+  ];
+}
+
+/** Same arc observed in TWO conversations → legitimately create-worthy. */
+function n2Experience(): Row[] {
+  const rows = n1Experience();
+  return [
+    ...rows,
+    R("Bash", "npx quokka-visor migrate", false, { conv: "c5", err: "exit-code-1" }),
+    R("Edit", "visor.config.mjs", true, { conv: "c5" }),
+    R("Bash", "npx quokka-visor migrate", true, { conv: "c5" }),
+  ];
+}
+
+const N1_DRAFT = [
+  "---",
+  "name: recovering-from-quokka-visor-failures",
+  "description: Use when npx quokka-visor migrate fails — recover by editing visor.config.mjs and re-running, never blind-retrying.",
+  "---",
+  "## Procedure",
+  "1. Read the exact error. 2. Edit visor.config.mjs. 3. Re-run the same command.",
+  "## Pitfalls",
+  "- Blind retry without editing the config reproduces the failure.",
+  "## Verification",
+  "Re-run `npx quokka-visor migrate` and confirm exit 0.",
+].join("\n");
+
+// ── 2a · evidence signals are structural, not just prose ────────────────────────────────────
+
+test("2a · buildCrossConversationEvidence exposes per-signal instance counts (signals[])", () => {
+  const ev = buildCrossConversationEvidence(n1Experience()) as any;
+  expect(Array.isArray(ev.signals)).toBe(true);
+  const repair = ev.signals.find((s: any) => /quokka-visor/.test(s.label));
+  expect(repair).toBeTruthy();
+  expect(repair.count).toBe(1);
+  expect(repair.convs).toBe(1);
+  const tmplSig = ev.signals.find((s: any) => /agenttrace/.test(s.label));
+  expect(tmplSig).toBeTruthy();
+  expect(tmplSig.count).toBeGreaterThanOrEqual(3);
+});
+
+// ── 2a · the pure gate ──────────────────────────────────────────────────────────────────────
+
+test("2a · n=1 gate: a create grounded ONLY in a single-instance signal is refused", () => {
+  const ev = buildCrossConversationEvidence(n1Experience()) as any;
+  const g = multiInstanceSupport("recovering-from-quokka-visor-failures npx quokka-visor migrate fails", ev.signals);
+  expect(g.ok).toBe(false);
+  expect(g.reason).toMatch(/single|1|instance/i);
+});
+
+test("2a · n=1 gate: the SAME topic with 2 distinct instances (2 convs) passes", () => {
+  const ev = buildCrossConversationEvidence(n2Experience()) as any;
+  const g = multiInstanceSupport("recovering-from-quokka-visor-failures npx quokka-visor migrate fails", ev.signals);
+  expect(g.ok).toBe(true);
+  expect(g.matched).toMatch(/quokka-visor/);
+});
+
+test("2a · n=1 gate: a topically UNGROUNDED create (no matching signal at all) is refused", () => {
+  const ev = buildCrossConversationEvidence(n2Experience()) as any;
+  const g = multiInstanceSupport("orchestrating-kubernetes-blue-green-deploys", ev.signals);
+  expect(g.ok).toBe(false);
+  expect(g.reason).toMatch(/no .*(grounded|matching|evidence)/i);
+});
+
+test("2a · n=1 gate: cannot ride in on an UNRELATED multi-instance signal (the padding hole)", () => {
+  const ev = buildCrossConversationEvidence(n1Experience()) as any;
+  // the padding workflow (agenttrace 3×) must NOT lend its instances to the quokka-visor topic
+  const g = multiInstanceSupport("recovering-from-quokka-visor-failures npx quokka-visor migrate fails", ev.signals);
+  expect(g.ok).toBe(false);
+});
+
+// ── 2a · wiring: runReflectiveReview refuses the n=1 create end-to-end ──────────────────────
+
+test("2a · wiring: reflect lane parks an n=1 create as action:none with an n=1 reason (no write)", async () => {
+  const memBefore = process.env.MEMORY_DIR;
+  const tmpMem = mkdtempSync(join(tmpdir(), "mm-n1-mem-"));
+  process.env.MEMORY_DIR = tmpMem; // isolate agent shelf; restored below
+  try {
+    // nonce the UNRELATED padding workflow so each run gets a fresh evidence signature —
+    // the park writes a handled-reflects mark, and a fixed fixture would collide with
+    // its own mark from a previous run ("already reflected") instead of exercising the gate.
+    const nonce = `run${Date.now()}`;
+    const experience = n1Experience().map((r) =>
+      /agenttrace/.test(String(r.tmpl)) ? { ...r, tmpl: `agenttrace --overview --${nonce}`, fp: `agenttrace --overview --${nonce}`, h: `agenttrace --overview --${nonce}` } : r,
+    );
+    const res = await runReflectiveReview({}, {
+      mode: "staged",
+      authorFn: async () => N1_DRAFT,
+      experience,
+    } as any);
+    expect(res.action).toBe("none");
+    expect(res.reason || "").toMatch(/n=1|single.instance|multi.instance/i);
+    expect(res.wrote).toBeFalsy();
+  } finally {
+    if (memBefore === undefined) delete process.env.MEMORY_DIR; else process.env.MEMORY_DIR = memBefore;
+  }
+});
+
+// ── 2b · dedupe surface includes the STAGED shelf ───────────────────────────────────────────
+
+test("2b · createDedupeSurface includes agent, global AND staged shelves", () => {
+  const surface = createDedupeSurface();
+  expect(surface).toContain(STAGED_DIR);
+  expect(surface.length).toBeGreaterThanOrEqual(2);
+});
+
+test("2b · dedupCheck: a near-duplicate of a STAGED skill routes to PATCH, not a sibling create", () => {
+  const staged = mkdtempSync(join(tmpdir(), "mm-staged-"));
+  mkdirSync(join(staged, "recovering-from-quokka-visor-failures"), { recursive: true });
+  writeFileSync(
+    join(staged, "recovering-from-quokka-visor-failures", "SKILL.md"),
+    "---\nname: recovering-from-quokka-visor-failures\ndescription: Use when npx quokka-visor migrate fails — recover by editing visor.config.mjs and re-running, never blind-retrying.\n---\n## Procedure\nfix then re-run.\n",
+  );
+  const dc = dedupCheck(
+    "recovering-from-visor-migrate-errors",
+    "Use when npx quokka-visor migrate fails — recover by editing visor.config.mjs and re-running instead of blind-retrying.",
+    [staged],
+  );
+  expect(dc.dup).toBe(true);
+  expect(dc.name).toBe("recovering-from-quokka-visor-failures");
+});
+
+// ── 2b · near-duplicates of RETIRED skills are quarantined (not silently recreated) ─────────
+
+test("2b · dedupCheck: a near-duplicate of a RETIRED skill (different name) is quarantined", () => {
+  const shelf = mkdtempSync(join(tmpdir(), "mm-shelf-"));
+  const retired = join(shelf, "_retired", "recovering-from-quokka-visor-failures-2026-06-29T00-00-00-000Z");
+  mkdirSync(retired, { recursive: true });
+  writeFileSync(
+    join(retired, "SKILL.md"),
+    "---\nname: recovering-from-quokka-visor-failures\ndescription: Use when npx quokka-visor migrate fails — recover by editing visor.config.mjs and re-running, never blind-retrying.\n---\n## Procedure\nfix then re-run.\n",
+  );
+  const dc = dedupCheck(
+    "recovering-from-visor-migrate-errors",
+    "Use when npx quokka-visor migrate fails — recover by editing visor.config.mjs and re-running instead of blind-retrying.",
+    [shelf],
+  );
+  expect(dc.dup).toBe(true);
+  expect(dc.reason).toMatch(/retired|quarantine/i);
+});

--- a/packages/muscle-memory/test/native-fit.test.ts
+++ b/packages/muscle-memory/test/native-fit.test.ts
@@ -4,6 +4,7 @@
 import { test, expect } from "bun:test";
 import { mkdtempSync, existsSync, readFileSync } from "node:fs"; import { tmpdir } from "node:os"; import { join } from "node:path";
 import { skillShelves, autonomousShelves, agentSkillsDir, GLOBAL_SKILLS, writeSkill } from "../mods/core";
+import { reachFn } from "../mods/engram";
 
 function withMemoryDir<T>(dir: string, fn: () => T): T {
   const orig = process.env.MEMORY_DIR; process.env.MEMORY_DIR = dir;
@@ -44,4 +45,18 @@ test("native-fit MemFS-first: MEMORY_DIR ⇒ agentSkillsDir = $MEMORY_DIR/skills
     expect(readFileSync(p, "utf8")).toContain("name: a-skill");
     expect(existsSync(join(mem, "skills", "a-skill", ".SKILL.md.tmp"))).toBe(false); // atomic: no temp leftover
   });
+});
+
+test("native-fit: reachFn binds the extracted method to its receiver (SDK resources read this._client)", () => {
+  class Resource {
+    private _client = { ok: true };
+    call(): boolean { return this._client.ok; } // throws if `this` is lost
+  }
+  const client = { agents: { passages: new Resource() } };
+  const fn = reachFn(client, ["agents", "passages", "call"]);
+  expect(fn).not.toBeNull();
+  // Unbound extraction would throw "undefined is not an object (evaluating 'this._client')" —
+  // the exact failure the live benchmark caught against the real letta-client, which the
+  // best-effort catch blocks had been swallowing into a silent no-op (MM_NATIVE=blocks sync).
+  expect(fn!()).toBe(true);
 });


### PR DESCRIPTION
Three tightly-scoped fixes for the merged muscle-memory package (follow-up to #19/#36):

## 1 · Duplicate-create gates (P0)
Receipt-backed by a live incident (an n=1 command-shaped skill created twice on consecutive days and retired twice):
- **n=1 CREATE gate** — `buildCrossConversationEvidence` now returns structured `signals[]` (per-signal count/convs); a reflect-lane CREATE must be topically grounded in a signal observed **≥2 distinct instances**. The aggregate items floor allowed an n=1 repair to ride in on an unrelated recurring workflow. Parking never permanently blocks: a second instance changes the evidence signature and re-opens the route.
- **CREATE-lane dedupe surface** — manual `create` / `create_from_candidate` now dedupe against agent + global + **staged** shelves, and `dedupCheck` quarantines near-duplicates of RETIRED skills under a different name.

## 2 · Hermetic tests + de-personalized config
- The n=1 wiring test scanned the HOST's real skill shelves — green only on an empty `~/.letta/skills`. `runReflectiveReview` now accepts injectable `dirs`/`stagedDir` (same pattern as the existing `experience` injection); the test pins tmp shelves. Verified green on a 98-entry host shelf.
- `HIGH_SIGNAL_TOOL_SET` shipped deployment-specific tool names from the authors' rigs; now empty by default, configured via `MM_HIGH_SIGNAL_TOOLS`.

## 3 · reachFn receiver bind (production bug in main today)
`reachFn` extracted SDK methods **unbound**; letta-client `APIResource` methods read `this._client`, threw at call time, and the best-effort catch blocks swallowed it — so the `MM_NATIVE=blocks` neocortex sync has never actually landed a block. Caught benchmarking live against a real Letta agent. Fixed with `.bind(receiver)`; regression test constructs a this-dependent resource; live block-readback verified (7/7 smoke checks on a real agent).

## Verification
- `bun run verify`: 77 pass / 0 fail; bundle rebuilt; `test/create-gates.test.ts` adds 9 deterministic regressions + 1 reachFn regression.
- Follow-up branches (semantic routing via native passages with live-benchmark receipts; in-context failure coaching) are staged on the fork and will come as separate incremental PRs once this lands.

👾 Co-authored with Mack (local Letta agent) — muscle-memory dogfooding itself throughout.