### PR TITLE
feat(image-understanding): add agent-scoped gating for auto-caption and strip-images

### DIFF
--- a/packages/image-understanding/MOD.md
+++ b/packages/image-understanding/MOD.md
@@ -39,6 +39,8 @@ Configuration is controlled by environment variables, especially:
 - `IMAGE_UNDERSTANDING_REQUIRE_LOCAL`
 - `IMAGE_UNDERSTANDING_AUTO_CAPTION`
 - `IMAGE_UNDERSTANDING_AUTO_MODE`
+- `IMAGE_UNDERSTANDING_STRIP_IMAGES`
+- `IMAGE_UNDERSTANDING_AGENTS` (comma-separated agent IDs or names; scopes auto-caption/strip-images to specific agents)
 
 ## Tool behavior
 

--- a/packages/image-understanding/MOD.md
+++ b/packages/image-understanding/MOD.md
@@ -11,6 +11,8 @@ Use this package when the current model cannot inspect images directly but needs
 
 The package does not make the main model natively multimodal. It sends the image to a separate configured vision backend and returns text.
 
+Note: on Letta Code's local backend, text-only models never receive raw image parts even without this package — the provider runtime replaces them with a lossy placeholder. This package exists to replace that discarded content with useful text (captions or an inspect-on-demand note), not to guard against provider errors. The configured vision backend itself must be a vision-capable model.
+
 ## Capabilities
 
 This package registers:

--- a/packages/image-understanding/README.md
+++ b/packages/image-understanding/README.md
@@ -9,6 +9,14 @@ This does not make the main model natively multimodal. It adds a trusted bridge:
 3. The backend returns a text description, OCR extraction, UI-debug analysis, diagram explanation, or accessibility description.
 4. The text-only agent uses that returned text like any other context.
 
+## How this relates to the model pipeline
+
+On Letta Code's local backend, text-only models never receive raw image parts even without this mod: the provider runtime (pi-ai) replaces unsupported image parts with a `(image omitted: model does not support images)` placeholder based on the model's catalog capabilities. Images are not a crash risk there — they are silently *discarded*.
+
+This mod's purpose is to replace that discarded content with something useful: a real caption (auto-caption mode), or a note telling the agent the images exist and can be inspected on demand (strip-images mode, `image_understand` tool).
+
+**The vision backend must be vision-capable.** The mod's vision request is a direct API call that bypasses the provider runtime's capability handling. If you point `IMAGE_UNDERSTANDING_MODEL` / `IMAGE_UNDERSTANDING_BASE_URL` at a text-only model (for example a GLM text handle), the *mod's own request* will fail with a provider 400 rejecting image content — an error that is easy to misread as your conversation model failing.
+
 Original source: <https://tangled.org/cameron.stream/image-understanding>
 
 ## Install

--- a/packages/image-understanding/README.md
+++ b/packages/image-understanding/README.md
@@ -89,6 +89,8 @@ Any Ollama model that supports image input should work. Other possible models in
 | `IMAGE_UNDERSTANDING_REQUIRE_LOCAL` | `0` | Set `1` to require local provider use. Currently this requires `provider=ollama`. |
 | `IMAGE_UNDERSTANDING_AUTO_CAPTION` | `0` | Set `1` to enable automatic image caption injection on `turn_start`. |
 | `IMAGE_UNDERSTANDING_AUTO_MODE` | `describe` | Mode used for auto-captioning. Supports `describe`, `ocr`, `ui_debug`, `diagram`, `accessibility`. |
+| `IMAGE_UNDERSTANDING_STRIP_IMAGES` | `0` | Set `1` to strip image parts from user messages on `turn_start` without captioning (protects text-only models without requiring a vision backend). Ignored when auto-caption is enabled. |
+| `IMAGE_UNDERSTANDING_AGENTS` | unset | Comma-separated agent IDs or names. When set, auto-caption and strip-images only apply to matching agents; other agents' messages are left untouched. Unset applies to all agents. |
 
 ## Tool usage
 

--- a/packages/image-understanding/mods/index.mjs
+++ b/packages/image-understanding/mods/index.mjs
@@ -55,6 +55,7 @@ const CONFIG_KEYS = {
   autoCaption: "boolean",
   autoMode: "string",
   stripImages: "boolean",
+  agents: "string",
 };
 
 function parseConfigValue(key, value) {
@@ -131,7 +132,30 @@ function getConfig() {
     autoCaption: runtimeOverrides.autoCaption ?? envBool("IMAGE_UNDERSTANDING_AUTO_CAPTION", false),
     autoMode: runtimeOverrides.autoMode ?? (process.env.IMAGE_UNDERSTANDING_AUTO_MODE || "describe"),
     stripImages: runtimeOverrides.stripImages ?? envBool("IMAGE_UNDERSTANDING_STRIP_IMAGES", false),
+    agents: runtimeOverrides.agents ?? (process.env.IMAGE_UNDERSTANDING_AGENTS || ""),
   };
+}
+
+/**
+ * Agent allowlist for turn-level behavior (auto-caption / strip-images).
+ * `agents` is a comma-separated list of agent IDs or names. When empty, turn
+ * handlers apply to every agent (previous behavior). When set, they only apply
+ * to matching agents, so a globally installed mod does not silently change
+ * message content for every agent on the machine.
+ */
+function agentAllowed(config, ctx) {
+  const allowlist = String(config.agents || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (allowlist.length === 0) return true;
+  const agentId = ctx?.agent?.id ?? null;
+  const agentName = ctx?.agent?.name ?? null;
+  return allowlist.some((entry) => {
+    if (agentId && entry === agentId) return true;
+    if (agentName && entry.toLowerCase() === String(agentName).toLowerCase()) return true;
+    return false;
+  });
 }
 
 function isHttpUrl(value) {
@@ -347,6 +371,7 @@ async function providerStatus() {
     `auto_caption: ${config.autoCaption ? "yes" : "no"}`,
     `auto_mode: ${config.autoMode}`,
     `strip_images: ${config.stripImages ? "yes" : "no"}`,
+    `agents: ${config.agents || "(all)"}`,
     `config_file: ${PERSISTENT_CONFIG_PATH}`,
     `supported_providers: openai-compatible, ollama`,
     `modes: ${Object.keys(MODE_PROMPTS).join(", ")}`,
@@ -459,6 +484,7 @@ function createSystemMessage(content) {
 async function autoCaptionTurn(event, ctx) {
   const config = getConfig();
   if (!config.autoCaption) return;
+  if (!agentAllowed(config, ctx)) return;
   const input = Array.isArray(event.input) ? event.input : [];
   const descriptions = [];
 
@@ -501,9 +527,10 @@ async function autoCaptionTurn(event, ctx) {
  * protects text-only models from 400 errors without requiring a vision
  * backend call.
  */
-function stripImagesTurn(event) {
+function stripImagesTurn(event, ctx) {
   const config = getConfig();
   if (!config.stripImages || config.autoCaption) return;
+  if (!agentAllowed(config, ctx)) return;
   const input = Array.isArray(event.input) ? event.input : [];
   let changed = false;
   let totalImages = 0;

--- a/packages/image-understanding/mods/index.mjs
+++ b/packages/image-understanding/mods/index.mjs
@@ -302,9 +302,18 @@ async function askOpenAiCompatible({ image, prompt, detail }, config, ctx) {
   const body = parseJson(await response.text());
   if (!response.ok) {
     const rendered = typeof body === "string" ? body : JSON.stringify(body);
-    const hint = response.status === 400
-      ? " The configured endpoint/model may not support image input. Use a vision-capable model or provider=ollama with a vision model."
-      : "";
+    // A 400 rejecting the content type means the configured vision backend
+    // model is itself text-only (e.g. a GLM text handle). This error comes
+    // from the mod's own vision request, not the conversation model — say so
+    // explicitly, because these errors have historically been misattributed
+    // to core model dispatch.
+    const textOnlyRejection = response.status === 400 &&
+      /content(\.|\s|_)?type|allowed values|does not support image|invalid content/i.test(rendered);
+    const hint = textOnlyRejection
+      ? ` The configured vision backend model "${config.model}" rejected image input — it appears to be a text-only model. This error is from the image-understanding mod's own vision request, not your conversation model. Configure a vision-capable model (image_understand action=config key=model) or use provider=ollama with a vision model.`
+      : response.status === 400
+        ? " The configured endpoint/model may not support image input. Use a vision-capable model or provider=ollama with a vision model."
+        : "";
     return { status: "error", content: errorContent(`Vision request failed: HTTP ${response.status} ${response.statusText}: ${rendered}.${hint}`, config) };
   }
 
@@ -476,10 +485,17 @@ function createSystemMessage(content) {
 
 /**
  * Turn handler for auto-caption mode: sends images to a vision backend,
- * gets text descriptions back, then STRIPS image parts from the user message
- * and appends a system message with the caption text. This prevents text-only
- * providers from rejecting the request with 400 "content.type is invalid,
- * allowed values: ['text']".
+ * gets text descriptions back, then strips the image parts from the user
+ * message and appends a system message with the caption text.
+ *
+ * Why this exists: on Letta Code's local backend, image parts never reach a
+ * text-only model in the first place — pi-ai's message transform replaces
+ * them with a lossy "(image omitted: model does not support images)"
+ * placeholder based on the model's catalog capabilities. This handler's job
+ * is enrichment, not protection: it replaces that otherwise-discarded image
+ * content with a real caption the model can reason over. Stripping the
+ * original parts here keeps the turn canonical and avoids shipping image
+ * bytes that would be placeholdered anyway.
  */
 async function autoCaptionTurn(event, ctx) {
   const config = getConfig();
@@ -523,9 +539,14 @@ async function autoCaptionTurn(event, ctx) {
 /**
  * Turn handler for strip-images mode: when auto-caption is off but
  * strip_images is on, removes image parts from user messages and appends a
- * system message pointing the agent to the image_understand tool. This
- * protects text-only models from 400 errors without requiring a vision
- * backend call.
+ * system message pointing the agent to the image_understand tool.
+ *
+ * On Letta Code's local backend this is not needed as a 400 guard — pi-ai
+ * already downgrades image parts to a placeholder for text-only models. The
+ * value of this mode is the actionable note: instead of a silent
+ * "(image omitted)" placeholder, the agent learns the images exist and can
+ * inspect them on demand with image_understand, without requiring a vision
+ * call on every turn.
  */
 function stripImagesTurn(event, ctx) {
   const config = getConfig();


### PR DESCRIPTION
## Summary
- Adds an `agents` config key (`IMAGE_UNDERSTANDING_AGENTS` env var, `image_understand` `action=config`, persistable) holding a comma-separated allowlist of agent IDs or names.
- When set, `autoCaptionTurn` and `stripImagesTurn` only mutate turns for matching agents (IDs matched exactly, names case-insensitively); other agents' messages pass through untouched. When unset, behavior is unchanged (applies to all agents).
- Conservative default: if the allowlist is set but the turn context carries no agent info, messages are left untouched.
- `action=status` now reports the active `agents` scope; README/MOD.md document the new key and the previously undocumented `IMAGE_UNDERSTANDING_STRIP_IMAGES` from #38.

## Context
Follow-up to #38 / #39 and the LET-9437 discussion: with a globally installed mod, strip/caption behavior silently applied to every agent on the machine. This makes "only agent X gets strip/caption behavior" configurable without per-agent mod placement (which the shared websocket listener does not support today — `LISTENER_MOD_CAPABILITIES` in letta-code disables turn events entirely, so listener-routed agents need a separate core-side answer regardless).

## Verification
- `node --check` and `node scripts/validate-manifests.mjs` pass.
- Functional harness test: activated the mod with a stub `letta` object and fired `turn_start` events — allowlisted ID strips, allowlisted name strips case-insensitively, non-allowlisted agent kept, missing agent context kept, empty allowlist strips for all (previous behavior).

👾 Generated with [Letta Code](https://letta.com)