### PR TITLE
fix(image-understanding): correct pipeline framing and vision-backend misconfig diagnostics

### DIFF
--- a/packages/image-understanding/MOD.md
+++ b/packages/image-understanding/MOD.md
@@ -11,6 +11,8 @@ Use this package when the current model cannot inspect images directly but needs
 
 The package does not make the main model natively multimodal. It sends the image to a separate configured vision backend and returns text.
 
+Note: on Letta Code's local backend, text-only models never receive raw image parts even without this package — the provider runtime replaces them with a lossy placeholder. This package exists to replace that discarded content with useful text (captions or an inspect-on-demand note), not to guard against provider errors. The configured vision backend itself must be a vision-capable model.
+
 ## Capabilities
 
 This package registers:

--- a/packages/image-understanding/README.md
+++ b/packages/image-understanding/README.md
@@ -9,6 +9,14 @@ This does not make the main model natively multimodal. It adds a trusted bridge:
 3. The backend returns a text description, OCR extraction, UI-debug analysis, diagram explanation, or accessibility description.
 4. The text-only agent uses that returned text like any other context.
 
+## How this relates to the model pipeline
+
+On Letta Code's local backend, text-only models never receive raw image parts even without this mod: the provider runtime (pi-ai) replaces unsupported image parts with a `(image omitted: model does not support images)` placeholder based on the model's catalog capabilities. Images are not a crash risk there — they are silently *discarded*.
+
+This mod's purpose is to replace that discarded content with something useful: a real caption (auto-caption mode), or a note telling the agent the images exist and can be inspected on demand (strip-images mode, `image_understand` tool).
+
+**The vision backend must be vision-capable.** The mod's vision request is a direct API call that bypasses the provider runtime's capability handling. If you point `IMAGE_UNDERSTANDING_MODEL` / `IMAGE_UNDERSTANDING_BASE_URL` at a text-only model (for example a GLM text handle), the *mod's own request* will fail with a provider 400 rejecting image content — an error that is easy to misread as your conversation model failing.
+
 Original source: <https://tangled.org/cameron.stream/image-understanding>
 
 ## Install

--- a/packages/image-understanding/mods/index.mjs
+++ b/packages/image-understanding/mods/index.mjs
@@ -302,9 +302,18 @@ async function askOpenAiCompatible({ image, prompt, detail }, config, ctx) {
   const body = parseJson(await response.text());
   if (!response.ok) {
     const rendered = typeof body === "string" ? body : JSON.stringify(body);
-    const hint = response.status === 400
-      ? " The configured endpoint/model may not support image input. Use a vision-capable model or provider=ollama with a vision model."
-      : "";
+    // A 400 rejecting the content type means the configured vision backend
+    // model is itself text-only (e.g. a GLM text handle). This error comes
+    // from the mod's own vision request, not the conversation model — say so
+    // explicitly, because these errors have historically been misattributed
+    // to core model dispatch.
+    const textOnlyRejection = response.status === 400 &&
+      /content(\.|\s|_)?type|allowed values|does not support image|invalid content/i.test(rendered);
+    const hint = textOnlyRejection
+      ? ` The configured vision backend model "${config.model}" rejected image input — it appears to be a text-only model. This error is from the image-understanding mod's own vision request, not your conversation model. Configure a vision-capable model (image_understand action=config key=model) or use provider=ollama with a vision model.`
+      : response.status === 400
+        ? " The configured endpoint/model may not support image input. Use a vision-capable model or provider=ollama with a vision model."
+        : "";
     return { status: "error", content: errorContent(`Vision request failed: HTTP ${response.status} ${response.statusText}: ${rendered}.${hint}`, config) };
   }
 
@@ -476,10 +485,17 @@ function createSystemMessage(content) {
 
 /**
  * Turn handler for auto-caption mode: sends images to a vision backend,
- * gets text descriptions back, then STRIPS image parts from the user message
- * and appends a system message with the caption text. This prevents text-only
- * providers from rejecting the request with 400 "content.type is invalid,
- * allowed values: ['text']".
+ * gets text descriptions back, then strips the image parts from the user
+ * message and appends a system message with the caption text.
+ *
+ * Why this exists: on Letta Code's local backend, image parts never reach a
+ * text-only model in the first place — pi-ai's message transform replaces
+ * them with a lossy "(image omitted: model does not support images)"
+ * placeholder based on the model's catalog capabilities. This handler's job
+ * is enrichment, not protection: it replaces that otherwise-discarded image
+ * content with a real caption the model can reason over. Stripping the
+ * original parts here keeps the turn canonical and avoids shipping image
+ * bytes that would be placeholdered anyway.
  */
 async function autoCaptionTurn(event, ctx) {
   const config = getConfig();
@@ -523,9 +539,14 @@ async function autoCaptionTurn(event, ctx) {
 /**
  * Turn handler for strip-images mode: when auto-caption is off but
  * strip_images is on, removes image parts from user messages and appends a
- * system message pointing the agent to the image_understand tool. This
- * protects text-only models from 400 errors without requiring a vision
- * backend call.
+ * system message pointing the agent to the image_understand tool.
+ *
+ * On Letta Code's local backend this is not needed as a 400 guard — pi-ai
+ * already downgrades image parts to a placeholder for text-only models. The
+ * value of this mode is the actionable note: instead of a silent
+ * "(image omitted)" placeholder, the agent learns the images exist and can
+ * inspect them on demand with image_understand, without requiring a vision
+ * call on every turn.
  */
 function stripImagesTurn(event, ctx) {
   const config = getConfig();


### PR DESCRIPTION
## Summary
- Corrects the mod's core premise: on Letta Code's local backend, raw image parts never reach text-only models — pi-ai downgrades them to a lossy placeholder based on catalog capabilities. The mod's job is **enrichment** (replace discarded image content with captions / an inspect-on-demand note), not protection from provider 400s. Turn-handler doc comments and README/MOD.md now say so explicitly.
- Adds targeted diagnostics for the real failure mode behind the LET-9437 reports: pointing the mod's vision backend at a text-only model (e.g. a GLM text handle). A 400 matching the content-type-rejection signature now returns a hint that names the configured model and states explicitly that the error comes from the mod's own vision request, **not the conversation model** — so these errors cannot be misattributed to core dispatch again.
- Documents the vision-capable backend requirement.

Stacked on #42 (agent-scoped gating). Context: letta-ai/letta-code#3215 (closed) — the "images leak to text-only models" premise originated in this mod's comments, propagated through #39's framing into LET-9437, and nearly landed a redundant capability-gated sanitizer in core.

## Verification
- `node --check` and `node scripts/validate-manifests.mjs` pass.
- Agent-gating harness test from #42 still passes.
- New harness test: stub vision backend returning GLM-style `INVALID_ARGUMENT ... allowed values: ['text']` — tool output names the configured model, identifies it as text-only, and carries the provenance disclaimer.

👾 Generated with [Letta Code](https://letta.com)