### PR TITLE
fix(sprite): keep agent tools available without panels

### DIFF
--- a/packages/sprite/MOD.md
+++ b/packages/sprite/MOD.md
@@ -51,6 +51,11 @@ action results carry what the pet did and said (petting returns its response),
 and `sprite_status` reports species, level, stats, mood, and a small diary of
 what it said recently — how the owner hears its companion.
 
+The sprite is agent-owned rather than UI-owned. If the host has no panel UI
+(for example, a headless channel listener), sprite skips visual rendering but
+still registers its tools and event hooks so the agent can care for the same
+companion from Signal, Telegram, Discord, or CLI turns.
+
 ## Commands
 
 | Command | What |

--- a/packages/sprite/README.md
+++ b/packages/sprite/README.md
@@ -119,6 +119,12 @@ human sees, so action results carry its responses (petting returns what it
 said), and `sprite_status` reports level, stats, mood, and a little diary of
 recent utterances — the owner's way of catching up on its companion.
 
+The companion belongs to the agent, not to a particular UI. In headless
+surfaces such as channel listeners, where no statusline panel exists, the
+visual panel is skipped but the agent tools and passive event hooks still
+activate. A Signal or Telegram conversation should be able to ask the agent to
+check on or pet its sprite just like a CLI conversation can.
+
 ## Commands
 
 | Command | What |

--- a/packages/sprite/mods/sprite.tsx
+++ b/packages/sprite/mods/sprite.tsx
@@ -775,7 +775,10 @@ function statForTool(name: string): (typeof STAT_KEYS)[number] {
 // ---------------------------------------------------------------------------
 
 export default function activate(letta: any) {
-  if (!letta.capabilities.ui.panels) return;
+  // Sprites are Tamagotchi-like companions for agents, not for a specific UI.
+  // Keep tools/events available in headless channel listeners even when there is
+  // no statusline panel to render.
+  const hasPanels = Boolean(letta.capabilities.ui.panels);
 
   const disposers: Array<() => void> = [];
   const state = loadState();
@@ -961,32 +964,34 @@ export default function activate(letta: any) {
 
   // -- panel ----------------------------------------------------------------
 
-  const panel = letta.ui.openPanel({
-    id: "sprite",
-    order: -1,
-    render: ({ width, agent, row, chalk }: any) => {
-      activeAgentId = (agent && agent.id) || activeAgentId;
-      activeAgentName = (agent && agent.name) || activeAgentName;
-      const sprite = getSprite(activeAgentId);
-      if (!sprite) return "";
-      if (setting(sprite, "visible") !== "on") return "";
+  const panel = hasPanels
+    ? letta.ui.openPanel({
+        id: "sprite",
+        order: -1,
+        render: ({ width, agent, row, chalk }: any) => {
+          activeAgentId = (agent && agent.id) || activeAgentId;
+          activeAgentName = (agent && agent.name) || activeAgentName;
+          const sprite = getSprite(activeAgentId);
+          if (!sprite) return "";
+          if (setting(sprite, "visible") !== "on") return "";
 
-      if (sprite.phase === "egg") {
-        const frame = EGG_FRAMES[tickCount % EGG_FRAMES.length];
-        return row(`${" ".repeat(x)}${frame}`, chalk.dim("something is coming"), width);
-      }
+          if (sprite.phase === "egg") {
+            const frame = EGG_FRAMES[tickCount % EGG_FRAMES.length];
+            return row(`${" ".repeat(x)}${frame}`, chalk.dim("something is coming"), width);
+          }
 
-      const sp = speciesOf(sprite);
-      let face: string = sp.poses[pose] ?? sp.poses.idle;
-      if (sleeping || dozing) face = sp.poses.sleep;
+          const sp = speciesOf(sprite);
+          let face: string = sp.poses[pose] ?? sp.poses.idle;
+          if (sleeping || dozing) face = sp.poses.sleep;
 
-      const shinyMark = sprite.shiny ? chalk.yellowBright("✦") : "";
-      const label = `${chalk.cyan(sprite.name)}${shinyMark} ${chalk.dim(`·Lv.${sprite.level}`)}`;
-      const pad = " ".repeat(Math.max(0, Math.min(x, 16)));
-      const right = bubble && Date.now() < bubbleUntil ? chalk.dim(`“${bubble}”`) : "";
-      return row(`${pad}${face}  ${label}`, right, width);
-    },
-  });
+          const shinyMark = sprite.shiny ? chalk.yellowBright("✦") : "";
+          const label = `${chalk.cyan(sprite.name)}${shinyMark} ${chalk.dim(`·Lv.${sprite.level}`)}`;
+          const pad = " ".repeat(Math.max(0, Math.min(x, 16)));
+          const right = bubble && Date.now() < bubbleUntil ? chalk.dim(`“${bubble}”`) : "";
+          return row(`${pad}${face}  ${label}`, right, width);
+        },
+      })
+    : { update() {}, close() {} };
   disposers.push(() => panel.close());
 
   // -- heartbeat tick (animation + persistence) -----------------------------

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -23,7 +23,8 @@
   "files": [
     "README.md",
     "MOD.md",
-    "mods"
+    "mods",
+    "smoke-test.mjs"
   ],
   "letta": {
     "manifestVersion": 1,
@@ -42,5 +43,8 @@
     "engines": {
       "lettaCodeCli": ">=0.27.18"
     }
+  },
+  "scripts": {
+    "test": "bun smoke-test.mjs"
   }
 }

--- a/packages/sprite/smoke-test.mjs
+++ b/packages/sprite/smoke-test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tempDir = mkdtempSync(join(tmpdir(), "sprite-smoke-"));
+process.env.SPRITE_STATE_PATH = join(tempDir, "sprite.state.json");
+
+const { default: activate } = await import("./mods/sprite.tsx");
+
+const tools = new Map();
+const commands = new Map();
+const events = new Map();
+
+const letta = {
+  capabilities: {
+    tools: true,
+    commands: true,
+    events: {
+      lifecycle: true,
+      tools: true,
+      turns: true,
+      llm: true,
+      compact: true,
+    },
+    ui: { panels: false },
+  },
+  tools: {
+    register(tool) {
+      tools.set(tool.name, tool);
+      return () => tools.delete(tool.name);
+    },
+  },
+  commands: {
+    register(command) {
+      commands.set(command.id, command);
+      return () => commands.delete(command.id);
+    },
+  },
+  events: {
+    on(name, handler) {
+      const handlers = events.get(name) ?? [];
+      handlers.push(handler);
+      events.set(name, handlers);
+      return () => events.set(name, (events.get(name) ?? []).filter((h) => h !== handler));
+    },
+  },
+  ui: {
+    openPanel() {
+      throw new Error("headless smoke test must not open panels");
+    },
+  },
+};
+
+let dispose;
+try {
+  dispose = activate(letta);
+
+  assert.equal(typeof dispose, "function", "activate should return a disposer");
+  assert.ok(commands.has("sprite"), "sprite command should register without panels");
+
+  for (const name of [
+    "sprite_hatch",
+    "sprite_name",
+    "sprite_molt",
+    "sprite_pet",
+    "sprite_status",
+    "sprite_set_voice",
+  ]) {
+    assert.ok(tools.has(name), `${name} should register without panels`);
+  }
+
+  const hatch = tools.get("sprite_hatch").run({
+    args: { species: "duck" },
+    agent: { id: "agent-smoke", name: "Smoke" },
+  });
+  assert.match(String(hatch), /egg appears|already here/);
+
+  const status = tools.get("sprite_status").run({
+    args: {},
+    agent: { id: "agent-smoke", name: "Smoke" },
+  });
+  assert.match(String(status), /egg|duck|companion/i);
+} finally {
+  if (typeof dispose === "function") dispose();
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+console.log("Sprite headless smoke test passed.");


### PR DESCRIPTION
## Summary
- keep sprite activation running when `ui.panels` is unavailable
- use a no-op panel shim in headless/listener contexts instead of returning before tool registration
- preserve the existing statusline panel behavior when panels are available
- document and smoke-test headless channel behavior

## Motivation
Sprites are Tamagotchi-like companions for agents, not for a particular UI surface. The agent should be able to access and care for its companion regardless of whether Cameron messages it through the CLI, Signal, Telegram, Discord, or another channel.

Before this change, sprite activation returned immediately when `letta.capabilities.ui.panels` was false. The channel listener runs headless with no panel UI, so the mod never reached its `letta.tools.register(...)` calls in Signal/channel turns. That meant the sprite existed in CLI but the agent could not call `sprite_status`, `sprite_pet`, etc. through Signal.

This keeps the visual panel optional while preserving the agent-owned tool/event surface everywhere the mod runs.

## Regression coverage
The new `packages/sprite/smoke-test.mjs` activates sprite with `ui.panels: false`, asserts that `openPanel` is not called, verifies `/sprite` plus all `sprite_*` agent tools register, and exercises `sprite_hatch` / `sprite_status` against a temporary `SPRITE_STATE_PATH`.

## Checks
- `bun build packages/sprite/mods/sprite.tsx --target node --outfile /tmp/sprite-pr-test.mjs`
- `npm run validate`
- `npm --prefix packages/sprite test`
