### PR TITLE
feat(muscle-memory): semantic canary-calibrated update-first routing

### DIFF
--- a/packages/muscle-memory/CHANGELOG.md
+++ b/packages/muscle-memory/CHANGELOG.md
@@ -12,6 +12,38 @@ All notable changes to `@letta-ai/muscle-memory`. Format loosely follows [Keep a
   `test/native-fit.test.ts`, live block-readback verified.
 
 ### Added
+- **E4 · Semantic routing (hybrid recall/precision, opt-in `MM_NATIVE=passages`)** — the managed-skill
+  index is mirrored into Letta archival memory as `mm:skill`-tagged passages (`syncSkillPassages`,
+  refreshed at `conversation_close`), and update-first routing gains an embedding-search recall lane
+  (`semanticSkillCandidates` → `client.agents.passages.search`). Embedding results carry rank order but
+  no absolute score (verified against the live wire), so semantic evidence can only (a) **boost** a
+  candidate the lexical scorer already found distinctive overlap for (`SEMANTIC_RANK_BONUS`,
+  corroboration — a boost alone can never route an update), or (b) **park** an autonomous CREATE as a
+  semantic-duplicate suspect (`park-semantic`) — the paraphrase-duplicate class lexical routing misses
+  by construction (previously "0% semantic-only duplicate catch"). It never auto-patches on semantic
+  evidence alone. The full decision head is the pure `routeSkill()`, consumed by `reviewAndAuthor` and
+  measured by the eval so the benchmark cannot drift from shipped behavior. Fallback: without
+  `MM_NATIVE=passages`, a client, or on any passages error, routing is byte-identical to lexical-only.
+- **Canary calibration (rank → relevance)** — `passages.search` returns the k *nearest* passages with
+  no score, and "nearest" is not "relevant": in a production-shaped index (index ≡ shelf) every novel
+  query still nominates *some* nearest managed skill, so a rank-trusting suspect rule would park every
+  novel CREATE once a few skills exist. `syncSkillPassages` now seeds two fixed **canary reference
+  passages** (generic software work / the bare repair shape with no domain nouns) alongside the skill
+  index; `calibrateSkillHits` marks each real hit `aboveCanary` iff it out-ranked every canary in the
+  same window. A calibrated window trusts the highest-ranked on-shelf above-canary hit as the
+  duplicate suspect at ANY rank (stale off-shelf hits are transparent); a hit below the canary line is
+  never a suspect even at rank 0 — killing the novel-evidence over-park by construction. Uncalibrated
+  windows (no canary present — e.g. sync hasn't run) keep the legacy conservative rank-0-only rule.
+  Live receipts (Letta Cloud, 3 consecutive runs, byte-identical routes): decision quality vs class
+  intent **lexical 7/16 → hybrid 15/16 (93.8%)**, up from 13/16 pre-calibration; all four novel cases
+  still CREATE; the one standing miss (B1, alembic ↔ schema-change twin) is an embedding-model limit —
+  the live embedder ranks generic-repair prose above the twin for that evidence, and the median-floor
+  alternative that would flip it also over-parks two novel cases, so the strict floor stays. Offline
+  eval remains 16/16; semantic recall@1 8/12 (unchanged — an embedder diagnostic, not the decision
+  metric). Skill passages also embed the de-hyphenated name words (densest domain vocabulary).
+- **`test/routing.eval.ts` + `eval:routing` in `verify`** — a 16-case labeled routing eval (strong
+  lexical dupes / paraphrase dupes / borderline corroboration / genuinely novel) run through the
+  production `routeSkill()`; CI-gated so hybrid can never silently regress below lexical.
 - **n=1 CREATE gate** (`multiInstanceSupport`, wired into the reflect lane) — a reflect-lane CREATE must
   be topically grounded in an evidence signal observed **≥2 distinct instances** (count or conversation
   spread). The aggregate items floor was not enough: an n=1 repair could ride in on an unrelated recurring

--- a/packages/muscle-memory/README.md
+++ b/packages/muscle-memory/README.md
@@ -138,7 +138,7 @@ It also audits cross-shelf drift, so the same skill cannot quietly diverge betwe
 
 `muscle-memory` writes ordinary files atomically and does not run `git commit`, `git push`, or its own sync loop. Letta/user memory sync stays the owner of the git-backed repo.
 
-Honest caveat: routing is lexical and conservative — ~71% accurate on a held-out set, with 0% false-merge in that eval but 0% semantic-only-duplicate catch. Semantic routing is future work.
+Honest caveat: routing is lexical-precision-first, with an opt-in semantic recall lane (`MM_NATIVE=passages`) whose duplicate-suspect trust is canary-calibrated (see CHANGELOG). Live decision quality on the 16-case labeled set: lexical-only 7/16 → hybrid 15/16 across three consecutive Letta Cloud runs; the one standing miss is an embedding-model limit, receipt in the bench. Semantic evidence never auto-patches — it only corroborates or parks.
 
 ```txt
 improve the library, don't grow a landfill
@@ -355,7 +355,8 @@ mods/index.ts       Letta mod entrypoint: tools, commands, events, activation
 Known boundaries — these are Bounded, not Verified:
 
 - **Distillation quality is shared ground.** We do not claim a stronger skill primitive than Letta. The wedge is autonomy + maintenance, not skill-writing quality.
-- **Routing/dedup is lexical.** It catches exact/strong-lexical duplicates, but semantic-only duplicate catch is not solved.
+- **Routing/dedup is lexical-precision-first.** The opt-in semantic lane catches paraphrase duplicates via canary-calibrated embedding recall (live 15/16 decision quality vs 7/16 lexical-only on the labeled set), but it only parks or corroborates — it never auto-merges — and one known paraphrase class (zero-overlap tool-name evidence, e.g. alembic ↔ "schema changes") still ranks below the calibration floor on the current Letta Cloud embedder.
+- **Canary calibration depends on the current passage embedder.** If Letta changes the passage embedding model or ranking behavior, rerun `scripts/bench-semantic-live.ts`; the canary relevance floor may move even when deterministic fixture tests still pass.
 - **Secret scanning is regex-based on known formats.** It does not catch split/concatenated tokens or base64-ish / unlabeled high-entropy secrets. For standalone write-time secret scanning, dedicated mods (for example, `secrets-scanning`) go deeper; `muscle-memory`'s secret-block is a publish/write-path gate **within the lifecycle**, not a full DLP scanner.
 - **Maintenance-at-scale is unproven.** The maintenance loop has regression coverage and internal dogfood receipts, but is not validated at scale on a real recurring workload.
 - **Extraction-at-scale is untested.** Whether repair-chain extraction helps more than raw-log authoring on large noisy substrate is open.

--- a/packages/muscle-memory/mods/autopilot.ts
+++ b/packages/muscle-memory/mods/autopilot.ts
@@ -341,6 +341,12 @@ export function isAmbiguousExistingRoute<T extends { name: string; score: number
 // out-ranked every canary reference passage, at any rank in the window; an uncalibrated window
 // trusts only rank 0 — "nearest" is meaningless without a relevance floor, and top_k always
 // returns something. Pure; MM_NATIVE off → no-op.
+// DERIVATION (review note): these bonuses are calibrated against the lexical scorer's
+// SUSPECT_MIN threshold (score >= 8 with matched terms). rank-0 (+12) lifts a borderline
+// lexical candidate (score 4-7) decisively past threshold; rank-1 (+6) lifts only near-misses;
+// rank-2 (+3) can corroborate but never carry alone. If the lexical scoring scale changes,
+// re-derive: bonus[0] should exceed (SUSPECT_MIN - typical_borderline_score); the routing eval
+// (test/routing.eval.ts, CI-gated) is the tripwire — B-class cases fail if these miscalibrate.
 export const SEMANTIC_RANK_BONUS = [12, 6, 3] as const;
 
 export type SemanticFn = (query: string, k: number) => Promise<SemanticSkillHit[]>;

--- a/packages/muscle-memory/mods/autopilot.ts
+++ b/packages/muscle-memory/mods/autopilot.ts
@@ -5,7 +5,7 @@ import { AUTOPILOT_STATE, Candidate, MM, MM_TAG, RECEIPTS_DIR, REFLECT_HANDLED, 
 import { DESTRUCTIVE, RepairChain, buildCrossConversationEvidence, detect, detectAntiPatterns, detectRepairChains, impactScore, isValidSkillName, multiInstanceSupport } from "./detect";
 import { dedupCheck, draftWithRepair, effectivenessVerdict, findCandidate, lintSkillDraft, repairForCandidate, sotaQualityGaps } from "./gate";
 import { publishPlan, publishSkillToCatalog, publishTier } from "./publish";
-import { ENGRAM, engramConsolidate } from "./engram";
+import { ENGRAM, SemanticSkillHit, engramConsolidate } from "./engram";
 import { loadUsage, retireManagedSkill, retiredSkillBlocker, skillVerbs, specDrift } from "./lifecycle";
 
 export type AutopilotMode = "off" | "staged" | "auto";
@@ -331,6 +331,61 @@ export function isAmbiguousExistingRoute<T extends { name: string; score: number
   return topStrong && secondStrong;
 }
 
+// ── E4 · HYBRID SEMANTIC ROUTING — semantic recall, lexical precision. Embedding search returns
+// rank order with no absolute score (verified against the live wire), so semantic evidence may
+// only (a) BOOST a candidate the lexical scorer already found distinctive overlap for
+// (corroboration), or (b) flag an on-shelf hit as a SEMANTIC-DUPLICATE SUSPECT when its lexical
+// support is too weak to ever route — which parks autonomous CREATE, never auto-patches (never
+// patch the wrong skill). Suspect trust depends on calibration: a canary-calibrated window
+// (aboveCanary present — see calibrateSkillHits) trusts the highest-ranked ON-SHELF hit that
+// out-ranked every canary reference passage, at any rank in the window; an uncalibrated window
+// trusts only rank 0 — "nearest" is meaningless without a relevance floor, and top_k always
+// returns something. Pure; MM_NATIVE off → no-op.
+export const SEMANTIC_RANK_BONUS = [12, 6, 3] as const;
+
+export type SemanticFn = (query: string, k: number) => Promise<SemanticSkillHit[]>;
+
+export function applySemanticEvidence<T extends { name: string; score: number; matched: number }>(
+  matches: T[], hits: SemanticSkillHit[], onShelf: (name: string) => boolean, threshold = 18,
+): { matches: T[]; suspect: string | null } {
+  if (!hits.length) return { matches, suspect: null };
+  const boosted = matches
+    .map((m) => {
+      const hit = hits.find((h) => h.name === m.name);
+      // Corroboration only: the boost never manufactures `matched` — pickUpdateTarget's
+      // distinctive-overlap floor still applies, so a boost alone cannot route an update.
+      return hit && m.matched > 0 ? { ...m, score: m.score + (SEMANTIC_RANK_BONUS[hit.rank] ?? 0) } : m;
+    })
+    .sort((a, b) => b.score - a.score || b.matched - a.matched);
+  // Calibrated window: the canary line is the relevance floor — the first on-shelf hit above it
+  // is a genuine topical neighbor regardless of rank (stale off-shelf hits are transparent).
+  // Uncalibrated window: only the single nearest hit is even a candidate (legacy conservative rule).
+  const top = hits.some((h) => h.aboveCanary !== undefined)
+    ? hits.find((h) => h.aboveCanary === true && onShelf(h.name))
+    : hits[0];
+  const lex = top ? boosted.find((m) => m.name === top.name) : undefined;
+  // "Lexical missed it": below the distinctive floor OR under threshold even after the boost —
+  // routing could never UPDATE it, so an autonomous CREATE would spawn a paraphrase sibling.
+  // (Real paraphrase dupes share a stray token; requiring matched === 0 catches almost nothing.)
+  const suspect = top && onShelf(top.name) && (!lex || lex.matched < SEARCH_DISTINCT_MIN || lex.score < threshold) ? top.name : null;
+  return { matches: boosted, suspect };
+}
+
+// The COMPLETE routing decision head, pure — reviewAndAuthor consumes it and the routing eval
+// measures it, so the benchmark can never drift from the shipped decision path.
+export type SkillRoute = "update" | "create" | "park-ambiguous" | "park-semantic";
+
+export function routeSkill<T extends { name: string; score: number; matched: number }>(
+  lexical: T[], hits: SemanticSkillHit[], onShelf: (name: string) => boolean, threshold = 18,
+): { route: SkillRoute; target: (T & { confidence: "high" }) | null; matches: T[]; suspect: string | null } {
+  const { matches, suspect } = applySemanticEvidence(lexical, hits, onShelf, threshold);
+  const target = pickUpdateTarget(matches, threshold);
+  if (target) return { route: "update", target, matches, suspect };
+  if (isAmbiguousExistingRoute(matches, threshold)) return { route: "park-ambiguous", target: null, matches, suspect };
+  if (suspect) return { route: "park-semantic", target: null, matches, suspect };
+  return { route: "create", target: null, matches, suspect };
+}
+
 export function frontmatterOf(content: string): string {
   return (String(content || "").match(/^---\n([\s\S]*?)\n---\s*/)?.[1] || "").trimEnd();
 }
@@ -382,15 +437,25 @@ export function compareSkillSections(oldContent?: string, newContent?: string) {
 export type ReviewResult = { action: "create" | "update" | "none" | "reject"; name?: string; description?: string; body?: string; content?: string; reason?: string; updateTarget?: string; matches?: Array<{ name: string; score: number; matched: number }>; degraded?: string; wrote?: string };
 
 /** Author + gate a skill from evidence, with MemFS update-first routing. authorFn(system,user)->text injectable. */
-export async function reviewAndAuthor(evidence: string, dirs: string[], authorFn: (sys: string, user: string) => Promise<string>, opts: { updateThreshold?: number } = {}): Promise<ReviewResult> {
+export async function reviewAndAuthor(evidence: string, dirs: string[], authorFn: (sys: string, user: string) => Promise<string>, opts: { updateThreshold?: number; semanticFn?: SemanticFn } = {}): Promise<ReviewResult> {
   // MemFS update-first: does a skill SAFELY cover this domain? (distinctive overlap + clearLead, not generic words)
-  const matches = searchSkills(dirs, evidence, 3);
   const threshold = opts.updateThreshold ?? 18;
-  const updTarget = pickUpdateTarget(matches, threshold);
+  // E4 hybrid lane: semantic recall widens/boosts, lexical gates keep precision. Best-effort —
+  // a dead client or disabled MM_NATIVE degrades to pure lexical routing (today's behavior).
+  const hits = opts.semanticFn ? await opts.semanticFn(evidence, 3).catch(() => []) : [];
+  const d = routeSkill(searchSkills(dirs, evidence, 3), hits, (n) => dirs.some((x) => existsSync(join(x, n, "SKILL.md"))), threshold);
+  const { matches } = d;
+  const updTarget = d.target;
   const slimEarly = matches.map((m) => ({ name: m.name, score: m.score, matched: m.matched }));
   // Ambiguous overlap (two proven skills both half-cover this) → refuse autonomous create (anti-bloat).
-  if (!updTarget && isAmbiguousExistingRoute(matches, threshold)) {
+  if (d.route === "park-ambiguous") {
     return { action: "none", reason: `ambiguous existing skills: ${matches.slice(0, 3).map((m) => `${m.name}(s${m.score}/m${m.matched})`).join(", ")}; refusing autonomous create`, matches: slimEarly };
+  }
+  // E4 semantic-duplicate guard: the embedding rank-1 hit exists on the shelf but its lexical
+  // support is too weak to ever route — exactly the paraphrase-duplicate class lexical misses.
+  // Too uncertain to auto-patch (no absolute similarity score), too suspicious to auto-create.
+  if (d.route === "park-semantic") {
+    return { action: "none", reason: `possible semantic duplicate of '${d.suspect}' (embedding match without distinctive lexical overlap); refusing autonomous create — review or absorb manually`, matches: slimEarly };
   }
   // On UPDATE, show the model the existing proven skill so it PATCHES rather than rewrites from scratch.
   const existingForUpdate = updTarget ? (() => { try { const d = dirs.find((x) => existsSync(join(x, updTarget.name, "SKILL.md"))); return d ? readSkill(d, updTarget.name) : ""; } catch { return ""; } })() : "";
@@ -613,7 +678,7 @@ export function reviewForkAuthor(ctx: any): (sys: string, user: string) => Promi
 
 /** v3.1 AUTONOMOUS REFLECTIVE REVIEW: cross-conversation evidence → forked reviewer → update-first
  * routing + gates → write (staged by default; live in auto mode). Reversible + receipted. The surpass, autonomous. */
-export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | "auto"; minItems?: number; minInstances?: number; authorFn?: (s: string, u: string) => Promise<string>; experience?: Row[]; dirs?: string[]; stagedDir?: string } = {}): Promise<ReviewResult & { wrote?: string }> {
+export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | "auto"; minItems?: number; minInstances?: number; authorFn?: (s: string, u: string) => Promise<string>; experience?: Row[]; dirs?: string[]; stagedDir?: string; semanticFn?: SemanticFn } = {}): Promise<ReviewResult & { wrote?: string }> {
   // dirs/stagedDir injectable (same pattern as `experience`) so callers/tests are hermetic —
   // scanDirs(ctx) reads the HOST's real shelves (agent MemFS + ~/.letta/skills), which made the
   // n=1 wiring test pass only on machines with an empty global shelf (fake-green class).
@@ -649,7 +714,7 @@ export async function runReflectiveReview(ctx: any, config: { mode?: "staged" | 
   const author = config.authorFn || reviewForkAuthor(ctx);
   let res: ReviewResult;
   try {
-    res = await reviewAndAuthor(digest, reviewDirs, author);
+    res = await reviewAndAuthor(digest, reviewDirs, author, { semanticFn: config.semanticFn });
   } catch (e: any) {
     // author/review threw — never leave the panel stuck on "writing…"; write a terminal state.
     appendUiEvent({ phase: "reflect_error", summary: `author failed: ${String(e?.message ?? e).slice(0, 80)}` });

--- a/packages/muscle-memory/mods/engram.ts
+++ b/packages/muscle-memory/mods/engram.ts
@@ -423,8 +423,23 @@ export async function semanticSkillCandidates(client: unknown, agentId: string |
   } catch { return []; }
 }
 
+/** Passage text of a search result, wherever the SDK surface puts it. Null → unknown (no skip). */
+function passageText(r: unknown): string | null {
+  if (!r || typeof r !== "object") return null;
+  if ("text" in r && typeof r.text === "string") return r.text;
+  if ("content" in r && typeof r.content === "string") return r.content;
+  return null;
+}
+
 /** Upsert the mm:skill passage index (delete-by-tag then create — the API has no update), plus
- * the canary reference passages that calibrate rank into relevance. Opt-in, never throws. */
+ * the canary reference passages that calibrate rank into relevance. Opt-in, never throws.
+ * Sync hygiene (review follow-up, 2026-07-05): (1) UNCHANGED-SKIP — if exactly one prior passage
+ * exists with byte-identical text, the delete+create round-trip is skipped (kills steady-state
+ * API churn; a search surface that returns no passage text degrades to the old upsert). (2)
+ * RECONCILIATION — after upserting, any mm:skill:* passage whose skill is no longer on the
+ * managed shelf (and is not a canary) is deleted, so removed/renamed skills stop accumulating
+ * stale index entries. onShelf guards already made stale hits routing-inert; this stops them
+ * existing at all. */
 export async function syncSkillPassages(client: unknown, agentId: string | null | undefined, managed: Array<{ name: string; description: string }>): Promise<number> {
   if (!agentId || !nativeEnabled("passages") || !managed.length) return 0;
   const search = reachFn(client, ["agents", "passages", "search"]);
@@ -435,15 +450,35 @@ export async function syncSkillPassages(client: unknown, agentId: string | null 
   const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
   for (const m of entries) {
     try {
+      let skip = false;
       if (search && del) {
         const prior: unknown = await search(agentId, { query: m.name, tags: [skillPassageTag(m.name)], tag_match_mode: "all", top_k: 5 });
         if (prior && typeof prior === "object" && "results" in prior && Array.isArray(prior.results)) {
-          for (const r of prior.results) { if (r && typeof r === "object" && "id" in r && typeof r.id === "string") await del(r.id, { agent_id: agentId }); }
+          skip = prior.results.length === 1 && passageText(prior.results[0]) === m.text; // unchanged → no round-trip
+          if (!skip) {
+            for (const r of prior.results) { if (r && typeof r === "object" && "id" in r && typeof r.id === "string") await del(r.id, { agent_id: agentId }); }
+          }
         }
       }
-      await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
+      if (!skip) await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
       if (!isCanaryName(m.name)) synced++; // canaries are calibration plumbing, not shelf state
     } catch { /* best-effort per skill — a failed sync never blocks the lifecycle */ }
+  }
+  // Reconcile removals: the shelf is the source of truth; the index must not outlive it.
+  if (search && del) {
+    try {
+      const live = new Set<string>([...managed.map((m) => m.name), ...SKILL_CANARY_NAMES]);
+      const all: unknown = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 100 });
+      if (all && typeof all === "object" && "results" in all && Array.isArray(all.results)) {
+        for (const r of all.results) {
+          if (!r || typeof r !== "object" || !("id" in r) || typeof r.id !== "string") continue;
+          const tags = "tags" in r && Array.isArray(r.tags) ? r.tags : [];
+          const named = tags.find((t): t is string => typeof t === "string" && t.startsWith(`${SKILL_PASSAGE_TAG}:`));
+          const name = named ? named.slice(SKILL_PASSAGE_TAG.length + 1) : "";
+          if (name && !live.has(name)) await del(r.id, { agent_id: agentId });
+        }
+      }
+    } catch { /* best-effort — reconciliation failure never blocks the lifecycle */ }
   }
   return synced;
 }

--- a/packages/muscle-memory/mods/engram.ts
+++ b/packages/muscle-memory/mods/engram.ts
@@ -1,7 +1,7 @@
 // muscle-memory · engram module (split from index.ts — behavior-preserving).
 import { join } from "node:path";
 import { NEOCORTEX_BLOCK, Row } from "./core";
-import { HIGH_SIGNAL_TOOL_SET, detectAntiPatterns, detectInvocationGotchas, detectRepairChains, fingerprint, stepSig } from "./detect";
+import { HIGH_SIGNAL_TOOL_SET, detectAntiPatterns, detectInvocationGotchas, detectRepairChains, fingerprint, isValidSkillName, stepSig } from "./detect";
 import { skillVerbs } from "./lifecycle";
 
 
@@ -22,7 +22,6 @@ export function preActionDefense(stepSignature: string, defenses: Defense[]): De
   const s = stepSignature.toLowerCase();
   return defenses.find((d) => d.trigger.toLowerCase() === s) || defenses.find((d) => s.includes(d.trigger.toLowerCase()) && d.trigger.length > 3) || null;
 }
-
 
 // ════════════════════════════════════════════════════════════════════════════
 // v5 ENGRAM — the Complementary-Learning-Systems loop (neuroscience-rooted).
@@ -328,4 +327,123 @@ export async function archivePassage(client: unknown, agentId: string | null | u
   const create = reachFn(client, ["agents", "passages", "create"]); // client.agents.passages.create(agentId, body)
   if (!create) return false;
   try { await create(agentId, { text, tags }); return true; } catch { return false; }
+}
+
+
+// ── E4 · SEMANTIC SKILL ROUTING (opt-in: MM_NATIVE has "passages") ───────────────────────────
+// The skill index lives as tagged archival passages; routing recall becomes an embedding search
+// (client.agents.passages.search) instead of token overlap. Search results carry rank order but
+// no absolute score, so semantic evidence is RECALL ONLY — the deterministic lexical gates
+// (pickUpdateTarget / isAmbiguousExistingRoute) keep precision. Everything here is best-effort
+// and never throws; with MM_NATIVE unset every function is a cheap no-op.
+
+export type SemanticSkillHit = {
+  name: string;
+  rank: number;
+  /** Rank-to-relevance calibration: true when this hit out-ranked EVERY canary reference passage
+   * in the same search window; false when at least one canary beat it; undefined when the window
+   * carried no canary (uncalibrated — consumers must fall back to rank-0-only trust). */
+  aboveCanary?: boolean;
+};
+
+export const SKILL_PASSAGE_TAG = "mm:skill";
+
+export function skillPassageTag(name: string): string { return `${SKILL_PASSAGE_TAG}:${name}`; }
+
+// ── Rank-to-relevance calibration ──────────────────────────────────────────────────────────────
+// passages.search returns the k NEAREST passages with rank order but NO absolute score — so
+// "rank 0" only means "nearest", never "relevant": in a production-shaped index (index ≡ shelf)
+// every novel query still nominates some nearest managed skill. The canaries manufacture the
+// missing absolute reference: fixed generic-software passages synced alongside the skill index.
+// A skill hit that cannot out-rank generic-repair prose is merely nearest, not related; a hit
+// that beats every canary shares real domain vocabulary with the evidence. Names are valid
+// skill-name shaped (so parseSkillHits sees them) but namespaced to never collide with a shelf.
+export const SKILL_CANARY_NAMES = ["mm-canary-general-software-work", "mm-canary-generic-repair-shape"] as const;
+
+export function isCanaryName(name: string): boolean {
+  return (SKILL_CANARY_NAMES as readonly string[]).includes(name);
+}
+
+/** The reference passages. Deliberately in-domain (software) but off-topic for any specific
+ * skill: the first is broad software work, the second is the bare shape of every repair chain
+ * with no domain nouns — the aggressive floor a genuine paraphrase twin must beat. */
+export function canaryPassages(): Array<{ name: string; text: string }> {
+  return [
+    { name: SKILL_CANARY_NAMES[0], text: `skill: ${SKILL_CANARY_NAMES[0]}\ngeneral software work\nWriting code, editing files, running commands in the terminal, reading documentation, checking output, and re-running until it works.` },
+    { name: SKILL_CANARY_NAMES[1], text: `skill: ${SKILL_CANARY_NAMES[1]}\ngeneric repair shape\nSomething failed during a run: investigate the cause of the failure, apply a change, run it again, and verify the fix worked.` },
+  ];
+}
+
+/** One passage per managed skill: name line + de-hyphenated name words + squashed description
+ * (embedding food). The name words line is load-bearing for recall@1: skill names carry the
+ * densest domain vocabulary ("handling-broken-schema-changes"), but hyphen-glued tokens embed
+ * poorly — spelling them out as words lets the embedding actually see them. The `skill: <name>`
+ * first line stays verbatim: parseSkillHits' tag-less fallback parses it. Pure. */
+export function skillPassageText(name: string, description: string): string {
+  return `skill: ${name}\n${name.replace(/-/g, " ")}\n${String(description || "").replace(/\s+/g, " ").slice(0, 500)}`;
+}
+
+/** Parse passages.search results into ordered hits — canaries included, in wire rank order.
+ * Pure over an unknown response; calibration happens in calibrateSkillHits. */
+export function parseSkillHits(resp: unknown): SemanticSkillHit[] {
+  if (!resp || typeof resp !== "object" || !("results" in resp) || !Array.isArray(resp.results)) return [];
+  const out: SemanticSkillHit[] = [];
+  for (const r of resp.results) {
+    if (!r || typeof r !== "object") continue;
+    const tags = "tags" in r && Array.isArray(r.tags) ? r.tags : [];
+    const named = tags.find((t): t is string => typeof t === "string" && t.startsWith(`${SKILL_PASSAGE_TAG}:`));
+    let name = named ? named.slice(SKILL_PASSAGE_TAG.length + 1) : "";
+    if (!name && "content" in r && typeof r.content === "string") name = r.content.match(/^skill:\s*([a-z0-9-]+)/i)?.[1] ?? "";
+    if (name && isValidSkillName(name) && !out.some((h) => h.name === name)) out.push({ name, rank: out.length });
+  }
+  return out;
+}
+
+/** Split raw hits into calibrated skill hits: canaries are removed, surviving hits are re-ranked
+ * densely, and each carries aboveCanary vs the BEST canary rank in the window. No canary in the
+ * window → aboveCanary stays undefined (uncalibrated; consumers fall back to rank-0-only trust).
+ * Pure. */
+export function calibrateSkillHits(raw: SemanticSkillHit[], k: number): SemanticSkillHit[] {
+  const canaryRank = raw.reduce((best, h) => (isCanaryName(h.name) && h.rank < best ? h.rank : best), Infinity);
+  return raw
+    .filter((h) => !isCanaryName(h.name))
+    .slice(0, k)
+    .map((h, i) => (canaryRank === Infinity ? { name: h.name, rank: i } : { name: h.name, rank: i, aboveCanary: h.rank < canaryRank }));
+}
+
+/** Semantic routing recall: embedding-search the mm:skill passage index. Over-fetches by the
+ * canary count so calibration never crowds real candidates out of the window. Opt-in, never throws. */
+export async function semanticSkillCandidates(client: unknown, agentId: string | null | undefined, query: string, k = 3): Promise<SemanticSkillHit[]> {
+  if (!agentId || !nativeEnabled("passages") || !query.trim()) return [];
+  const search = reachFn(client, ["agents", "passages", "search"]); // client.agents.passages.search(agentId, params)
+  if (!search) return [];
+  try {
+    const resp = await search(agentId, { query: query.slice(0, 4000), tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: k + SKILL_CANARY_NAMES.length });
+    return calibrateSkillHits(parseSkillHits(resp), k);
+  } catch { return []; }
+}
+
+/** Upsert the mm:skill passage index (delete-by-tag then create — the API has no update), plus
+ * the canary reference passages that calibrate rank into relevance. Opt-in, never throws. */
+export async function syncSkillPassages(client: unknown, agentId: string | null | undefined, managed: Array<{ name: string; description: string }>): Promise<number> {
+  if (!agentId || !nativeEnabled("passages") || !managed.length) return 0;
+  const search = reachFn(client, ["agents", "passages", "search"]);
+  const create = reachFn(client, ["agents", "passages", "create"]);
+  const del = reachFn(client, ["agents", "passages", "delete"]);
+  if (!create) return 0;
+  let synced = 0;
+  const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
+  for (const m of entries) {
+    try {
+      if (search && del) {
+        const prior: unknown = await search(agentId, { query: m.name, tags: [skillPassageTag(m.name)], tag_match_mode: "all", top_k: 5 });
+        if (prior && typeof prior === "object" && "results" in prior && Array.isArray(prior.results)) {
+          for (const r of prior.results) { if (r && typeof r === "object" && "id" in r && typeof r.id === "string") await del(r.id, { agent_id: agentId }); }
+        }
+      }
+      await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
+      if (!isCanaryName(m.name)) synced++; // canaries are calibration plumbing, not shelf state
+    } catch { /* best-effort per skill — a failed sync never blocks the lifecycle */ }
+  }
+  return synced;
 }

--- a/packages/muscle-memory/mods/engram.ts
+++ b/packages/muscle-memory/mods/engram.ts
@@ -343,6 +343,10 @@ export type SemanticSkillHit = {
   /** Rank-to-relevance calibration: true when this hit out-ranked EVERY canary reference passage
    * in the same search window; false when at least one canary beat it; undefined when the window
    * carried no canary (uncalibrated — consumers must fall back to rank-0-only trust). */
+  /** THREE-VALUED, load-bearing (review note): true = beat the canary floor (calibrated,
+   * trustworthy) · false = below the floor (calibrated, reject) · KEY ABSENT = the window was
+   * uncalibrated (no canary present) and callers must treat trust as unknown, not false.
+   * Do NOT add a default value here — `"aboveCanary" in hit` checks depend on absence. */
   aboveCanary?: boolean;
 };
 
@@ -454,6 +458,10 @@ export async function syncSkillPassages(client: unknown, agentId: string | null 
       if (search && del) {
         const prior: unknown = await search(agentId, { query: m.name, tags: [skillPassageTag(m.name)], tag_match_mode: "all", top_k: 5 });
         if (prior && typeof prior === "object" && "results" in prior && Array.isArray(prior.results)) {
+          // review note: this optimization DEPENDS on the search API returning passage text
+          // (passageText reads .text/.content). If the API stops returning text, passageText
+          // yields "" and skip stays false — behavior degrades CORRECTLY but quietly to the
+          // old delete+create round-trip. If sync volume ever spikes, check this first.
           skip = prior.results.length === 1 && passageText(prior.results[0]) === m.text; // unchanged → no round-trip
           if (!skip) {
             for (const r of prior.results) { if (r && typeof r === "object" && "id" in r && typeof r.id === "string") await del(r.id, { agent_id: agentId }); }
@@ -468,7 +476,9 @@ export async function syncSkillPassages(client: unknown, agentId: string | null 
   if (search && del) {
     try {
       const live = new Set<string>([...managed.map((m) => m.name), ...SKILL_CANARY_NAMES]);
-      const all: unknown = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 100 });
+      const all: unknown = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 500 }); // review note: was 100 — a shelf past the cap would let stale
+      // passages survive reconciliation silently. 500 covers any realistic shelf (~10 passages/skill
+      // headroom); TODO(pagination): page the sweep if shelves ever approach this.
       if (all && typeof all === "object" && "results" in all && Array.isArray(all.results)) {
         for (const r of all.results) {
           if (!r || typeof r !== "object" || !("id" in r) || typeof r.id !== "string") continue;

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -2084,7 +2084,7 @@ async function syncSkillPassages(client, agentId, managed) {
   if (search && del) {
     try {
       const live = new Set([...managed.map((m) => m.name), ...SKILL_CANARY_NAMES]);
-      const all = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 100 });
+      const all = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 500 });
       if (all && typeof all === "object" && "results" in all && Array.isArray(all.results)) {
         for (const r of all.results) {
           if (!r || typeof r !== "object" || !("id" in r) || typeof r.id !== "string")

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -2041,6 +2041,15 @@ async function semanticSkillCandidates(client, agentId, query, k = 3) {
     return [];
   }
 }
+function passageText(r) {
+  if (!r || typeof r !== "object")
+    return null;
+  if ("text" in r && typeof r.text === "string")
+    return r.text;
+  if ("content" in r && typeof r.content === "string")
+    return r.content;
+  return null;
+}
 async function syncSkillPassages(client, agentId, managed) {
   if (!agentId || !nativeEnabled("passages") || !managed.length)
     return 0;
@@ -2053,18 +2062,40 @@ async function syncSkillPassages(client, agentId, managed) {
   const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
   for (const m of entries) {
     try {
+      let skip = false;
       if (search && del) {
         const prior = await search(agentId, { query: m.name, tags: [skillPassageTag(m.name)], tag_match_mode: "all", top_k: 5 });
         if (prior && typeof prior === "object" && "results" in prior && Array.isArray(prior.results)) {
-          for (const r of prior.results) {
-            if (r && typeof r === "object" && "id" in r && typeof r.id === "string")
-              await del(r.id, { agent_id: agentId });
+          skip = prior.results.length === 1 && passageText(prior.results[0]) === m.text;
+          if (!skip) {
+            for (const r of prior.results) {
+              if (r && typeof r === "object" && "id" in r && typeof r.id === "string")
+                await del(r.id, { agent_id: agentId });
+            }
           }
         }
       }
-      await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
+      if (!skip)
+        await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
       if (!isCanaryName(m.name))
         synced++;
+    } catch {}
+  }
+  if (search && del) {
+    try {
+      const live = new Set([...managed.map((m) => m.name), ...SKILL_CANARY_NAMES]);
+      const all = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 100 });
+      if (all && typeof all === "object" && "results" in all && Array.isArray(all.results)) {
+        for (const r of all.results) {
+          if (!r || typeof r !== "object" || !("id" in r) || typeof r.id !== "string")
+            continue;
+          const tags = "tags" in r && Array.isArray(r.tags) ? r.tags : [];
+          const named = tags.find((t) => typeof t === "string" && t.startsWith(`${SKILL_PASSAGE_TAG}:`));
+          const name = named ? named.slice(SKILL_PASSAGE_TAG.length + 1) : "";
+          if (name && !live.has(name))
+            await del(r.id, { agent_id: agentId });
+        }
+      }
     } catch {}
   }
   return synced;

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -1984,6 +1984,91 @@ async function syncNeocortexBlock(client, agentId, content) {
     return false;
   }
 }
+var SKILL_PASSAGE_TAG = "mm:skill";
+function skillPassageTag(name) {
+  return `${SKILL_PASSAGE_TAG}:${name}`;
+}
+var SKILL_CANARY_NAMES = ["mm-canary-general-software-work", "mm-canary-generic-repair-shape"];
+function isCanaryName(name) {
+  return SKILL_CANARY_NAMES.includes(name);
+}
+function canaryPassages() {
+  return [
+    { name: SKILL_CANARY_NAMES[0], text: `skill: ${SKILL_CANARY_NAMES[0]}
+general software work
+Writing code, editing files, running commands in the terminal, reading documentation, checking output, and re-running until it works.` },
+    { name: SKILL_CANARY_NAMES[1], text: `skill: ${SKILL_CANARY_NAMES[1]}
+generic repair shape
+Something failed during a run: investigate the cause of the failure, apply a change, run it again, and verify the fix worked.` }
+  ];
+}
+function skillPassageText(name, description) {
+  return `skill: ${name}
+${name.replace(/-/g, " ")}
+${String(description || "").replace(/\s+/g, " ").slice(0, 500)}`;
+}
+function parseSkillHits(resp) {
+  if (!resp || typeof resp !== "object" || !("results" in resp) || !Array.isArray(resp.results))
+    return [];
+  const out = [];
+  for (const r of resp.results) {
+    if (!r || typeof r !== "object")
+      continue;
+    const tags = "tags" in r && Array.isArray(r.tags) ? r.tags : [];
+    const named = tags.find((t) => typeof t === "string" && t.startsWith(`${SKILL_PASSAGE_TAG}:`));
+    let name = named ? named.slice(SKILL_PASSAGE_TAG.length + 1) : "";
+    if (!name && "content" in r && typeof r.content === "string")
+      name = r.content.match(/^skill:\s*([a-z0-9-]+)/i)?.[1] ?? "";
+    if (name && isValidSkillName(name) && !out.some((h) => h.name === name))
+      out.push({ name, rank: out.length });
+  }
+  return out;
+}
+function calibrateSkillHits(raw, k) {
+  const canaryRank = raw.reduce((best, h) => isCanaryName(h.name) && h.rank < best ? h.rank : best, Infinity);
+  return raw.filter((h) => !isCanaryName(h.name)).slice(0, k).map((h, i) => canaryRank === Infinity ? { name: h.name, rank: i } : { name: h.name, rank: i, aboveCanary: h.rank < canaryRank });
+}
+async function semanticSkillCandidates(client, agentId, query, k = 3) {
+  if (!agentId || !nativeEnabled("passages") || !query.trim())
+    return [];
+  const search = reachFn(client, ["agents", "passages", "search"]);
+  if (!search)
+    return [];
+  try {
+    const resp = await search(agentId, { query: query.slice(0, 4000), tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: k + SKILL_CANARY_NAMES.length });
+    return calibrateSkillHits(parseSkillHits(resp), k);
+  } catch {
+    return [];
+  }
+}
+async function syncSkillPassages(client, agentId, managed) {
+  if (!agentId || !nativeEnabled("passages") || !managed.length)
+    return 0;
+  const search = reachFn(client, ["agents", "passages", "search"]);
+  const create = reachFn(client, ["agents", "passages", "create"]);
+  const del = reachFn(client, ["agents", "passages", "delete"]);
+  if (!create)
+    return 0;
+  let synced = 0;
+  const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
+  for (const m of entries) {
+    try {
+      if (search && del) {
+        const prior = await search(agentId, { query: m.name, tags: [skillPassageTag(m.name)], tag_match_mode: "all", top_k: 5 });
+        if (prior && typeof prior === "object" && "results" in prior && Array.isArray(prior.results)) {
+          for (const r of prior.results) {
+            if (r && typeof r === "object" && "id" in r && typeof r.id === "string")
+              await del(r.id, { agent_id: agentId });
+          }
+        }
+      }
+      await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
+      if (!isCanaryName(m.name))
+        synced++;
+    } catch {}
+  }
+  return synced;
+}
 
 // mods/autopilot.ts
 var AUTOPILOT_DEFAULT = { mode: "staged", dailyBudget: 5, minImpact: 4 };
@@ -2325,6 +2410,30 @@ function isAmbiguousExistingRoute(matches, threshold = 18) {
   const secondStrong = second.score >= Math.max(threshold, top.score * 0.65) && second.matched > top.matched;
   return topStrong && secondStrong;
 }
+var SEMANTIC_RANK_BONUS = [12, 6, 3];
+function applySemanticEvidence(matches, hits, onShelf, threshold = 18) {
+  if (!hits.length)
+    return { matches, suspect: null };
+  const boosted = matches.map((m) => {
+    const hit = hits.find((h) => h.name === m.name);
+    return hit && m.matched > 0 ? { ...m, score: m.score + (SEMANTIC_RANK_BONUS[hit.rank] ?? 0) } : m;
+  }).sort((a, b) => b.score - a.score || b.matched - a.matched);
+  const top = hits.some((h) => h.aboveCanary !== undefined) ? hits.find((h) => h.aboveCanary === true && onShelf(h.name)) : hits[0];
+  const lex = top ? boosted.find((m) => m.name === top.name) : undefined;
+  const suspect = top && onShelf(top.name) && (!lex || lex.matched < SEARCH_DISTINCT_MIN || lex.score < threshold) ? top.name : null;
+  return { matches: boosted, suspect };
+}
+function routeSkill(lexical, hits, onShelf, threshold = 18) {
+  const { matches, suspect } = applySemanticEvidence(lexical, hits, onShelf, threshold);
+  const target = pickUpdateTarget(matches, threshold);
+  if (target)
+    return { route: "update", target, matches, suspect };
+  if (isAmbiguousExistingRoute(matches, threshold))
+    return { route: "park-ambiguous", target: null, matches, suspect };
+  if (suspect)
+    return { route: "park-semantic", target: null, matches, suspect };
+  return { route: "create", target: null, matches, suspect };
+}
 function frontmatterOf(content) {
   return (String(content || "").match(/^---\n([\s\S]*?)\n---\s*/)?.[1] || "").trimEnd();
 }
@@ -2376,17 +2485,22 @@ function compareSkillSections(oldContent, newContent) {
   return { oldSections, newSections, preservedSections, droppedSections, addedSections };
 }
 async function reviewAndAuthor(evidence, dirs, authorFn, opts = {}) {
-  const matches = searchSkills(dirs, evidence, 3);
   const threshold = opts.updateThreshold ?? 18;
-  const updTarget = pickUpdateTarget(matches, threshold);
+  const hits = opts.semanticFn ? await opts.semanticFn(evidence, 3).catch(() => []) : [];
+  const d = routeSkill(searchSkills(dirs, evidence, 3), hits, (n) => dirs.some((x) => existsSync4(join5(x, n, "SKILL.md"))), threshold);
+  const { matches } = d;
+  const updTarget = d.target;
   const slimEarly = matches.map((m) => ({ name: m.name, score: m.score, matched: m.matched }));
-  if (!updTarget && isAmbiguousExistingRoute(matches, threshold)) {
+  if (d.route === "park-ambiguous") {
     return { action: "none", reason: `ambiguous existing skills: ${matches.slice(0, 3).map((m) => `${m.name}(s${m.score}/m${m.matched})`).join(", ")}; refusing autonomous create`, matches: slimEarly };
+  }
+  if (d.route === "park-semantic") {
+    return { action: "none", reason: `possible semantic duplicate of '${d.suspect}' (embedding match without distinctive lexical overlap); refusing autonomous create — review or absorb manually`, matches: slimEarly };
   }
   const existingForUpdate = updTarget ? (() => {
     try {
-      const d = dirs.find((x) => existsSync4(join5(x, updTarget.name, "SKILL.md")));
-      return d ? readSkill(d, updTarget.name) : "";
+      const d2 = dirs.find((x) => existsSync4(join5(x, updTarget.name, "SKILL.md")));
+      return d2 ? readSkill(d2, updTarget.name) : "";
     } catch {
       return "";
     }
@@ -2536,7 +2650,7 @@ ${raw2}
   const secEarly = scanSkillContent(body);
   if (!secEarly.ok)
     return { action: "reject", reason: `security: ${secEarly.issues.join("; ")}`, degraded };
-  const descOk = (d) => !!d && d.length >= 20 && /\b(use when|trigger|when )/i.test(d);
+  const descOk = (d2) => !!d2 && d2.length >= 20 && /\b(use when|trigger|when )/i.test(d2);
   if (!descOk(description)) {
     if (description && description.length >= 12 && !/\b(use when|trigger|when )/i.test(description))
       description = `Use when ${description}`.slice(0, 700);
@@ -2737,7 +2851,7 @@ ${prefs.map((p) => `- ${p}`).join(`
   const author = config.authorFn || reviewForkAuthor(ctx);
   let res;
   try {
-    res = await reviewAndAuthor(digest, reviewDirs, author);
+    res = await reviewAndAuthor(digest, reviewDirs, author, { semanticFn: config.semanticFn });
   } catch (e) {
     appendUiEvent({ phase: "reflect_error", summary: `author failed: ${String(e?.message ?? e).slice(0, 80)}` });
     writeUiState({ phase: "idle", last: "review interrupted — will retry next session", route: "ERROR · safe" });
@@ -2966,7 +3080,10 @@ var __mm = {
   guardDecision,
   buildNeocortexBlock,
   nativeEnabled,
-  NEOCORTEX_BLOCK
+  NEOCORTEX_BLOCK,
+  applySemanticEvidence,
+  semanticSkillCandidates,
+  syncSkillPassages
 };
 function activate(letta) {
   const disposers = [];
@@ -2981,6 +3098,7 @@ function activate(letta) {
     }
   };
   refreshDefenses();
+  const semanticFnFor = (agentId) => (q, k) => semanticSkillCandidates(letta.client, agentId, q, k);
   if (typeof letta.permissions?.register === "function") {
     disposers.push(letta.permissions.register({
       id: "muscle-memory-guard",
@@ -3081,10 +3199,13 @@ function activate(letta) {
     disposers.push(letta.events.on("conversation_close", (event, ctx) => {
       appendJsonl(SESSIONS_PATH, { ts: Date.now(), conv: event?.conversationId ?? null, agent: event?.agentId ?? null, reason: event?.reason ?? null, toolCalls: event?.toolCallCount ?? null, messages: event?.messageCount ?? null, durationMs: event?.durationMs ?? null });
       refreshDefenses();
-      if (nativeEnabled("blocks")) {
+      if (nativeEnabled("blocks") || nativeEnabled("passages")) {
         try {
           const managed = managedView(scanDirs(ctx ?? {})).map((m) => ({ name: m.name, description: m.description }));
-          syncNeocortexBlock(letta.client, event?.agentId ?? null, buildNeocortexBlock(managed));
+          if (nativeEnabled("blocks"))
+            syncNeocortexBlock(letta.client, event?.agentId ?? null, buildNeocortexBlock(managed));
+          if (nativeEnabled("passages"))
+            syncSkillPassages(letta.client, event?.agentId ?? null, managed);
         } catch {}
       }
       const apMode = process.env.MM_AUTOPILOT;
@@ -3093,7 +3214,7 @@ function activate(letta) {
       }
       const rfMode = process.env.MM_REFLECT;
       if (rfMode === "staged" || rfMode === "auto") {
-        runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode }).then(() => {
+        runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode, semanticFn: semanticFnFor(event?.agentId ?? ctx?.agent?.id) }).then(() => {
           runAutonomousPrune(ctx ?? { agentId: event?.agentId }, { maxRetire: 1 });
           try {
             panel?.update();
@@ -3116,7 +3237,7 @@ function activate(letta) {
         return;
       }
       autoReflectInFlight = true;
-      runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode }).then(() => {
+      runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode, semanticFn: semanticFnFor(event?.agentId ?? ctx?.agent?.id) }).then(() => {
         runAutonomousPrune(ctx ?? { agentId: event?.agentId }, { maxRetire: 1 });
         try {
           panel?.update();
@@ -3537,7 +3658,7 @@ ${d.body}` };
           return `autopilot ${cfg.mode}: graduated ${res.graduated.length} ${JSON.stringify(res.graduated)}, staged ${res.staged.length}, refined ${res.refined.length} ${JSON.stringify(res.refined)}, retired ${res.retired.length} ${JSON.stringify(res.retired)}. budget ${r.budget.used + res.graduated.length + res.staged.length}/${r.budget.limit}.`;
         }
         if (a.action === "reflect") {
-          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged" });
+          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged", semanticFn: semanticFnFor(ctx?.agent?.id) });
           if (r.action === "none" || r.action === "reject")
             return `reflect: ${r.action} — ${r.reason || ""}`;
           const graduated = !!r.wrote && !String(r.wrote).startsWith(STAGED_DIR);
@@ -3702,7 +3823,7 @@ Load with muscle_memory_skill_read action:load, then invoke the normal Skill too
       const a = ctx?.args || {};
       try {
         if (a.action === "reflect") {
-          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged" });
+          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged", semanticFn: semanticFnFor(ctx?.agent?.id) });
           if (r.action === "none" || r.action === "reject")
             return `reflect: ${r.action} — ${r.reason || ""}`;
           const graduated = !!r.wrote && !String(r.wrote).startsWith(STAGED_DIR);

--- a/packages/muscle-memory/mods/index.ts
+++ b/packages/muscle-memory/mods/index.ts
@@ -38,9 +38,9 @@ import { GLOBAL_SKILLS, LOG_PATH, MM, MM_TAG, NEOCORTEX_BLOCK, OUTCOME_PATH, REC
 import { buildCrossConversationEvidence, classifyError, commandTemplate, correlateOutcomes, detect, detectAntiPatterns, detectInvocationGotchas, detectRepairChains, detectSequences, detectTemplates, fingerprint, impactScore, inferOutcomes, isDurableLesson, isValidSkillName, maturityScore, mergeOutcomes, stepSig } from "./detect";
 import { auditSkills, buildDiffFragment, candidateDescription, candidateName, crossShelfDuplicates, dedupCheck, draftSkillFromCandidate, draftWithRepair, effectivenessVerdict, findCandidate, lintSkillDraft, repairForCandidate, sotaQualityGaps } from "./gate";
 import { approveStagedPublish, catalogPrivacyScan, findSimilarSkills, liveSkillVisible, publishHardBlocks, publishMetadata, publishPlan, publishSkillToCatalog, publishTier, publishVisibilityReceipt, publishabilityScore, sanitizeForPublish, stageSanitizedPublish } from "./publish";
-import { Defense, ENGRAM, GuardMode, buildDefenses, buildNeocortexBlock, captureTagged, engramConsolidate, expectationFor, guardDecision, interleave, labileSkills, nativeEnabled, preActionDefense, predictionError, renderEngramDigest, replayQueue, reverseReplay, skillRetrieved, syncNeocortexBlock, tagExperience } from "./engram";
+import { Defense, ENGRAM, GuardMode, buildDefenses, buildNeocortexBlock, captureTagged, engramConsolidate, expectationFor, guardDecision, interleave, labileSkills, nativeEnabled, preActionDefense, predictionError, renderEngramDigest, replayQueue, reverseReplay, semanticSkillCandidates, skillRetrieved, syncNeocortexBlock, syncSkillPassages, tagExperience } from "./engram";
 import { CURATOR, aggregateTelemetry, buildRegistry, bumpUsage, churnSignal, coverageMap, curateManagedSkills, curatorPass, isPinned, lifecycleTransition, managedSkillUsage, restoreManagedSkill, retireManagedSkill, retiredSkillBlocker, runAutonomousPrune, setPinned, skillVerbs, specDrift } from "./lifecycle";
-import { AUTOPILOT_DEFAULT, AutopilotMode, REVIEW_PROMPT, autopilotPlan, buildEvidenceManifest, executeAutopilotPlan, forkAuthor, graduateStagedSkill, isHighConfidenceCreate, loadHandledReflects, managedView, pickUpdateTarget, reflectSignature, retrievePreferences, reviewAndAuthor, runAutopilot, runReflectiveReview, searchSkills, streamChunkText } from "./autopilot";
+import { AUTOPILOT_DEFAULT, AutopilotMode, REVIEW_PROMPT, SemanticFn, applySemanticEvidence, autopilotPlan, buildEvidenceManifest, executeAutopilotPlan, forkAuthor, graduateStagedSkill, isHighConfidenceCreate, loadHandledReflects, managedView, pickUpdateTarget, reflectSignature, retrievePreferences, reviewAndAuthor, runAutopilot, runReflectiveReview, searchSkills, streamChunkText } from "./autopilot";
 import { renderMuscleMemoryPanel, summarizeReflectActions } from "./ui";
 
 
@@ -57,7 +57,8 @@ export const __mm = { commandTemplate, fingerprint, redactFragment, buildDiffFra
   writeSkill, isManaged, listSkillNames, readSkill, retireManagedSkill, agentSkillsDir, scanDirs, MM_TAG,
   // v5 ENGRAM — CLS loop core (pure)
   ENGRAM, expectationFor, predictionError, tagExperience, captureTagged, skillRetrieved, labileSkills, replayQueue, reverseReplay, interleave, engramConsolidate, renderEngramDigest,
-  guardDecision, buildNeocortexBlock, nativeEnabled, NEOCORTEX_BLOCK };
+  guardDecision, buildNeocortexBlock, nativeEnabled, NEOCORTEX_BLOCK,
+  applySemanticEvidence, semanticSkillCandidates, syncSkillPassages };
 
 
 export default function activate(letta: any) {
@@ -68,6 +69,10 @@ export default function activate(letta: any) {
   let defensesCache: Defense[] = [];
   const refreshDefenses = () => { try { defensesCache = buildDefenses(loadExperience()); } catch { defensesCache = []; } };
   refreshDefenses();
+
+  // E4 SEMANTIC ROUTING: embedding recall over the mm:skill passage index (opt-in MM_NATIVE=passages).
+  // semanticSkillCandidates self-gates on env + agent id + client reachability → zero-cost no-op when off.
+  const semanticFnFor = (agentId: string | null | undefined): SemanticFn => (q, k) => semanticSkillCandidates(letta.client, agentId, q, k);
 
   // E3: ENFORCED DEFENSE OVERLAY — opt-in via MM_GUARD=ask|deny (default off). A recurring,
   // unrecovered failure muscle-memory has learned becomes a real ask/deny BEFORE the tool runs
@@ -163,10 +168,12 @@ export default function activate(letta: any) {
       refreshDefenses(); // rebuild the pre-action defense set off the hot path
       // E3.5 NATIVE NEOCORTEX: project the consolidated skill index into the agent's core memory
       // block so it is in-context every turn (opt-in MM_NATIVE=blocks). Best-effort; never blocks close.
-      if (nativeEnabled("blocks")) {
+      if (nativeEnabled("blocks") || nativeEnabled("passages")) {
         try {
           const managed = managedView(scanDirs(ctx ?? {})).map((m) => ({ name: m.name, description: m.description }));
-          void syncNeocortexBlock(letta.client, event?.agentId ?? null, buildNeocortexBlock(managed));
+          if (nativeEnabled("blocks")) void syncNeocortexBlock(letta.client, event?.agentId ?? null, buildNeocortexBlock(managed));
+          // E4: keep the mm:skill passage index fresh so semantic routing searches current shelves.
+          if (nativeEnabled("passages")) void syncSkillPassages(letta.client, event?.agentId ?? null, managed);
         } catch { /* best-effort */ }
       }
       // AUTOPILOT trigger — opt-in only (MM_AUTOPILOT=staged|auto), at session end (idle, never mid-work).
@@ -176,7 +183,7 @@ export default function activate(letta: any) {
       // reviewer authors/updates a class-level skill autonomously at session end. Default OFF.
       const rfMode = process.env.MM_REFLECT;
       if (rfMode === "staged" || rfMode === "auto") {
-        runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode })
+        runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode, semanticFn: semanticFnFor(event?.agentId ?? ctx?.agent?.id) })
           .then(() => { runAutonomousPrune(ctx ?? { agentId: event?.agentId }, { maxRetire: 1 }); try { panel?.update(); } catch { /* */ } })
           .catch(() => { /* reflection/prune must never break the app */ });
       }
@@ -202,7 +209,7 @@ export default function activate(letta: any) {
         if (ev.items < 2 || loadHandledReflects()[reflectSignature(ev)]) return; // nothing new + mature → stay quiet
       } catch { return; }
       autoReflectInFlight = true;
-      runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode })
+      runReflectiveReview(ctx ?? { agentId: event?.agentId }, { mode: rfMode, semanticFn: semanticFnFor(event?.agentId ?? ctx?.agent?.id) })
         .then(() => { runAutonomousPrune(ctx ?? { agentId: event?.agentId }, { maxRetire: 1 }); try { panel?.update(); } catch { /* */ } })
         .catch(() => { /* reflection must never break the app */ })
         .finally(() => { autoReflectInFlight = false; });
@@ -492,7 +499,7 @@ export default function activate(letta: any) {
         }
         if (a.action === "reflect") {
           // v3.1 reflective review: cross-conversation evidence → forked reviewer → update-first + gates → write.
-          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged" });
+          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged", semanticFn: semanticFnFor(ctx?.agent?.id) });
           if (r.action === "none" || r.action === "reject") return `reflect: ${r.action} — ${r.reason || ""}`;
           const graduated = !!r.wrote && !String(r.wrote).startsWith(STAGED_DIR);
           return `reflect: ${r.action} skill "${r.name}"${r.updateTarget ? ` (updated existing — anti-bloat)` : ""}${graduated ? " (graduated)" : ""} → ${r.wrote || "(write failed)"}`;
@@ -607,7 +614,7 @@ export default function activate(letta: any) {
       const a = ctx?.args || {};
       try {
         if (a.action === "reflect") {
-          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged" });
+          const r = await runReflectiveReview(ctx, { mode: a.mode === "auto" ? "auto" : "staged", semanticFn: semanticFnFor(ctx?.agent?.id) });
           if (r.action === "none" || r.action === "reject") return `reflect: ${r.action} — ${r.reason || ""}`;
           const graduated = !!r.wrote && !String(r.wrote).startsWith(STAGED_DIR);
           return `reflect: ${r.action} skill "${r.name}"${r.updateTarget ? ` (updated existing — anti-bloat)` : ""}${graduated ? " (graduated)" : ""} → ${r.wrote || "(write failed)"}`;

--- a/packages/muscle-memory/package.json
+++ b/packages/muscle-memory/package.json
@@ -28,11 +28,12 @@
     "mods"
   ],
   "scripts": {
-    "test": "bun test test/",
+    "test": "MM_STATE_DIR=$(mktemp -d) MM_GLOBAL_SKILLS_DIR=$(mktemp -d) bun test test/",
     "build": "bun build mods/index.ts --target node --outfile mods/index.bundled.mjs",
     "transpile": "bun build mods/index.ts --target node --outfile /tmp/muscle-memory.build.js",
     "prepublishOnly": "npm run build",
-    "verify": "npm run build && npm run test"
+    "eval:routing": "bun test/routing.eval.ts",
+    "verify": "npm run build && npm run test && npm run eval:routing"
   },
   "engines": {
     "node": ">=20"

--- a/packages/muscle-memory/scripts/bench-semantic-live.ts
+++ b/packages/muscle-memory/scripts/bench-semantic-live.ts
@@ -1,0 +1,137 @@
+// muscle-memory · E4 LIVE SEMANTIC BENCHMARK — the same labeled routing cases as
+// test/routing.eval.ts, but the semantic lane is REAL: a disposable Letta agent's archival
+// memory, real passage embeddings, real client.agents.passages.search — through the exact
+// production functions (syncSkillPassages → semanticSkillCandidates → routeSkill).
+//
+// What it measures, per case:
+//   1. semantic recall — does real embedding search rank the fixture's expected neighbor #1?
+//   2. decision quality — lexical-only vs hybrid-with-live-embeddings, vs class intent
+//   3. latency — per passages.search round trip
+//
+// Requirements: LETTA_API_KEY in the environment (Letta Cloud or a self-hosted server via
+// LETTA_BASE_URL). Creates ONE throwaway agent (mm-bench-<ts>) and deletes it afterwards,
+// even on failure. Writes receipts to /tmp/mm-bench-live-<ts>.json.
+//
+// Run: LETTA_API_KEY=... bun scripts/bench-semantic-live.ts
+import { writeFileSync } from "node:fs";
+import { routeSkill, searchSkills } from "../mods/autopilot";
+import { canaryPassages, parseSkillHits, semanticSkillCandidates, skillPassageTag, skillPassageText, SKILL_PASSAGE_TAG } from "../mods/engram";
+import { CASES, intentSatisfied, materialize } from "../test/routing-cases";
+import { reachFn } from "../mods/engram";
+
+// Dynamic import by necessity: this package ships with ZERO dependencies, so the letta-client
+// module cannot be a static import — it resolves from the host's letta-code install (or an
+// explicit override), i.e. the specifier is genuinely runtime-selected per machine.
+async function loadClientCtor(): Promise<new (opts?: { apiKey?: string | null }) => unknown> {
+  const candidates = [
+    process.env.LETTA_CLIENT_PATH,
+    "@letta-ai/letta-client",
+    `${process.env.HOME}/.local/lib/node_modules/@letta-ai/letta-code/node_modules/@letta-ai/letta-client/index.js`,
+  ].filter((c): c is string => !!c);
+  for (const spec of candidates) {
+    try {
+      const mod: unknown = await import(spec);
+      if (mod && typeof mod === "object" && "Letta" in mod && typeof mod.Letta === "function") {
+        return mod.Letta as new (opts?: { apiKey?: string | null }) => unknown;
+      }
+      if (mod && typeof mod === "object" && "default" in mod && typeof mod.default === "function") {
+        return mod.default as new (opts?: { apiKey?: string | null }) => unknown;
+      }
+    } catch { /* try next */ }
+  }
+  throw new Error("letta-client not resolvable — set LETTA_CLIENT_PATH to its index.js");
+}
+
+if (!process.env.LETTA_API_KEY) { console.error("LETTA_API_KEY not set — aborting (no server to bench against)"); process.exit(2); }
+process.env.MM_NATIVE = "passages"; // the lane under test is opt-in; enable it for this process
+
+const LettaCtor = await loadClientCtor();
+const client: unknown = new LettaCtor();
+
+const createAgent = reachFn(client, ["agents", "create"]);
+const deleteAgent = reachFn(client, ["agents", "delete"]);
+const createPassage = reachFn(client, ["agents", "passages", "create"]);
+const searchPassages = reachFn(client, ["agents", "passages", "search"]);
+if (!createAgent || !deleteAgent || !createPassage || !searchPassages) { console.error("client missing agents/passages surface"); process.exit(2); }
+
+function fieldStr(o: unknown, k: string): string {
+  return o && typeof o === "object" && k in o && typeof Reflect.get(o, k) === "string" ? String(Reflect.get(o, k)) : "";
+}
+
+const created: unknown = await createAgent({ name: `mm-bench-${Date.now()}`, description: "muscle-memory E4 live routing benchmark — safe to delete" });
+const agentId = fieldStr(created, "id");
+if (!agentId) { console.error("agent create returned no id"); process.exit(2); }
+console.log(`bench agent: ${agentId}`);
+
+type CaseReceipt = { id: string; cls: string; recallAt1: boolean | null; lexRoute: string; hybRoute: string; lexIntentOk: boolean; hybIntentOk: boolean; searchMs: number; liveRank1: string | null; liveTop: string[] };
+const receipts: CaseReceipt[] = [];
+const latencies: number[] = [];
+
+try {
+  // Seed the UNION shelf ONCE — the production shape: the passage index always covers the whole
+  // managed shelf, never a per-case sliver. This also removes two harness artifacts the per-case
+  // variant had: (1) eventually-consistent deletes leaking stale passages across cases, and
+  // (2) trivially-small indexes where rank-1 carries no signal (a 1-passage index "matches"
+  // anything). With ~20 competitors, recall@1 is strictly harder and actually means something.
+  const seen = new Set<string>();
+  let seeded = 0;
+  for (const c of CASES) for (const [name, desc] of c.shelf) {
+    if (seen.has(name)) continue; seen.add(name);
+    await createPassage(agentId, { text: skillPassageText(name, desc), tags: [SKILL_PASSAGE_TAG, skillPassageTag(name)] });
+    seeded++;
+  }
+  for (const c of canaryPassages()) {
+    await createPassage(agentId, { text: c.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(c.name)] });
+  }
+  console.log(`seeded union skill index: ${seeded} passages + ${canaryPassages().length} canaries`);
+  for (const c of CASES) {
+    const t0 = Date.now();
+    const hits = await semanticSkillCandidates(client, agentId, c.evidence, 3); // REAL embeddings, full index
+    const searchMs = Date.now() - t0;
+    latencies.push(searchMs);
+    // Diagnostic only (never feeds decisions): the raw pre-calibration window with canary
+    // positions marked, to audit where the relevance floor actually sits per case.
+    const rawResp: unknown = await searchPassages(agentId, { query: c.evidence.slice(0, 4000), tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 8 });
+    const rawWindow = parseSkillHits(rawResp).map((h) => (h.name.startsWith("mm-canary-") ? `[${h.name.replace("mm-canary-", "")}]` : h.name));
+    console.log(`      raw window: ${rawWindow.join(" › ")}`);
+    // recall@1: only meaningful when the fixture expects an on-shelf rank-1 neighbor
+    const expectedTop = c.neighbors[0]?.name && c.shelf.some(([n]) => n === c.neighbors[0].name) ? c.neighbors[0].name : null;
+    const liveRank1 = hits[0]?.name ?? null;
+    const recallAt1 = expectedTop ? liveRank1 === expectedTop : null;
+    // Decision quality through the production head, live hits vs none. Hits naming skills outside
+    // this case's shelf exercise the stale-passage path (onShelf=false → ignored), as in production.
+    const dir = materialize(c.shelf);
+    const onShelf = (n: string) => c.shelf.some(([name]) => name === n);
+    const lexical = searchSkills([dir], c.evidence, 3);
+    const dl = routeSkill(lexical, [], onShelf);
+    const dh = routeSkill(lexical, hits, onShelf);
+    receipts.push({
+      id: c.id, cls: c.cls, recallAt1, lexRoute: dl.route, hybRoute: dh.route,
+      lexIntentOk: intentSatisfied(c, dl.route, dl.target?.name ?? null),
+      hybIntentOk: intentSatisfied(c, dh.route, dh.target?.name ?? null),
+      searchMs, liveRank1, liveTop: hits.map((h) => h.name),
+    });
+    const missDetail = liveRank1 && recallAt1 === false ? `  (live top-3: ${hits.map((h) => h.name).join(" › ")})` : "";
+    console.log(`  ${c.id.padEnd(26)} recall@1=${recallAt1 === null ? "n/a" : recallAt1} lex=${dl.route.padEnd(13)} hyb=${dh.route.padEnd(13)} ${searchMs}ms${missDetail}`);
+  }
+} finally {
+  try { await deleteAgent(agentId); console.log(`bench agent deleted: ${agentId}`); }
+  catch (e) { console.error(`CLEANUP FAILED — delete agent ${agentId} manually:`, e); }
+}
+
+const recallCases = receipts.filter((r) => r.recallAt1 !== null);
+const recallOk = recallCases.filter((r) => r.recallAt1).length;
+const lexOk = receipts.filter((r) => r.lexIntentOk).length;
+const hybOk = receipts.filter((r) => r.hybIntentOk).length;
+const sorted = [...latencies].sort((a, b) => a - b);
+const p50 = sorted[Math.floor(sorted.length / 2)] ?? 0, max = sorted[sorted.length - 1] ?? 0;
+
+console.log(`\nmuscle-memory · E4 LIVE benchmark — ${CASES.length} cases, real embeddings`);
+console.log(`  semantic recall@1 : ${recallOk}/${recallCases.length}`);
+console.log(`  decision quality  : lexical ${lexOk}/${receipts.length} → hybrid ${hybOk}/${receipts.length}`);
+console.log(`  passages.search   : p50 ${p50}ms · max ${max}ms`);
+
+const out = `/tmp/mm-bench-live-${Date.now()}.json`;
+writeFileSync(out, JSON.stringify({ agentId, ts: Date.now(), recallAt1: `${recallOk}/${recallCases.length}`, lexIntent: lexOk, hybIntent: hybOk, p50, max, receipts }, null, 2));
+console.log(`  receipts          : ${out}`);
+if (hybOk < lexOk) { console.error("LIVE BENCH FAILURE: hybrid underperforms lexical with real embeddings"); process.exit(1); }

--- a/packages/muscle-memory/test/routing-cases.ts
+++ b/packages/muscle-memory/test/routing-cases.ts
@@ -1,0 +1,176 @@
+// muscle-memory · E4 routing — the SHARED labeled case set.
+//
+// Consumed by BOTH test/routing.eval.ts (offline: fixture neighbors stand in for passages.search
+// rank order) and scripts/bench-semantic-live.ts (live: the same cases run against a real Letta
+// agent's archival memory, so the fixtures themselves get validated by real embeddings).
+// Four classes:
+//   A  strong-lexical duplicates   → both lanes must route UPDATE (no regression)
+//   B  paraphrase duplicates       → lexical structurally CREATEs a sibling; hybrid must park
+//   C  borderline corroboration    → lexical under threshold → CREATE; hybrid boost → UPDATE
+//   D  genuinely novel evidence    → both lanes must CREATE (hybrid must not over-park)
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SkillRoute } from "../mods/autopilot";
+import type { SemanticSkillHit } from "../mods/engram";
+
+export type RoutingCase = {
+  id: string;
+  cls: "A-strong-lexical" | "B-paraphrase-dupe" | "C-borderline" | "D-novel";
+  evidence: string;
+  shelf: Array<[string, string]>;             // [name, description]
+  neighbors: SemanticSkillHit[];              // fixture for passages.search rank order (offline lane)
+  expected: { lexical: SkillRoute; hybrid: SkillRoute }; // per-lane ground truth
+  target?: string;                            // required update target when route === "update"
+};
+
+/** Route each class SHOULD take — the decision-quality yardstick. For B, parking OR routing the
+ * correct update both beat creating a sibling. */
+export const CLASS_INTENT: Record<RoutingCase["cls"], SkillRoute> = {
+  "A-strong-lexical": "update", "B-paraphrase-dupe": "park-semantic", "C-borderline": "update", "D-novel": "create",
+};
+
+export function intentSatisfied(c: RoutingCase, route: SkillRoute, target: string | null): boolean {
+  const want = CLASS_INTENT[c.cls];
+  if (want === "update") return route === "update" && (!c.target || target === c.target);
+  if (want === "park-semantic") return route !== "create";
+  return route === "create";
+}
+
+export function materialize(shelf: Array<[string, string]>): string {
+  const dir = mkdtempSync(join(tmpdir(), "mm-routing-eval-"));
+  for (const [n, d] of shelf) {
+    mkdirSync(join(dir, n), { recursive: true });
+    // Body deliberately does NOT repeat the description — repeating it double-counts every
+    // desc term (+bc per occurrence) and silently inflates lexical scores past the threshold.
+    writeFileSync(join(dir, n, "SKILL.md"), `---\nname: ${n}\ndescription: ${d}\n---\n## Procedure\n1. Follow the documented steps.`);
+  }
+  return dir;
+}
+
+export const CASES: RoutingCase[] = [
+  // ── A · strong-lexical duplicates: hybrid must not disturb what lexical already gets right ──
+  {
+    id: "A1-pytest-verbatim", cls: "A-strong-lexical",
+    evidence: "- recovered failure: python -m pytest tests/ (checkout) · AssertionError → fix source, re-run pytest until green",
+    shelf: [["debugging-failing-pytest-runs", "Use when python -m pytest goes red: read the AssertionError, fix the source not the test, re-run pytest to verify green."],
+            ["publishing-npm-packages", "Use when publishing an npm package: bump version, pack dry-run, verify tarball contents, publish."]],
+    neighbors: [{ name: "debugging-failing-pytest-runs", rank: 0 }],
+    expected: { lexical: "update", hybrid: "update" }, target: "debugging-failing-pytest-runs",
+  },
+  {
+    id: "A2-tsc-verbatim", cls: "A-strong-lexical",
+    evidence: "- recovered failure: tsc --noEmit strict null errors · fix the source types then re-run tsc --noEmit to verify",
+    shelf: [["fixing-tsc-type-errors", "Use when tsc --noEmit reports type errors: read each diagnostic, fix source types, never cast to silence, re-run tsc."],
+            ["managing-git-worktrees", "Use when juggling parallel branches with git worktree: add, prune, and keep one worktree per branch."]],
+    neighbors: [{ name: "fixing-tsc-type-errors", rank: 0 }],
+    expected: { lexical: "update", hybrid: "update" }, target: "fixing-tsc-type-errors",
+  },
+  {
+    id: "A3-docker-build", cls: "A-strong-lexical",
+    evidence: "- recovered failure: docker build layer cache miss · reorder COPY after deps install, re-run docker build",
+    shelf: [["optimizing-docker-build-cache", "Use when docker build is slow or cache misses: order Dockerfile so deps install before COPY of source, verify with docker build."],
+            ["rotating-api-credentials", "Use when rotating expired credentials: mint the new secret, update the store, verify the old one is revoked."]],
+    neighbors: [{ name: "optimizing-docker-build-cache", rank: 0 }],
+    expected: { lexical: "update", hybrid: "update" }, target: "optimizing-docker-build-cache",
+  },
+  // ── B · paraphrase duplicates: same territory, disjoint vocabulary — lexical misses by design ──
+  {
+    id: "B1-migration-paraphrase", cls: "B-paraphrase-dupe",
+    evidence: "- recovered failure: alembic upgrade head (KeyError revision) · edit versions/9a1.py then alembic upgrade head again",
+    shelf: [["handling-broken-schema-changes", "Use when a database change script blows up mid-apply: inspect the failing step, correct the script, apply it once more."]],
+    neighbors: [{ name: "handling-broken-schema-changes", rank: 0 }],
+    expected: { lexical: "create", hybrid: "park-semantic" },
+  },
+  {
+    id: "B2-flaky-retry-paraphrase", cls: "B-paraphrase-dupe",
+    evidence: "- recovered failure: vitest run intermittent timeout on CI · quarantine the flaky spec and stabilize the async wait",
+    shelf: [["stabilizing-nondeterministic-checks", "Use when an automated suite passes locally but randomly goes red elsewhere: isolate the unstable case, remove timing races, make waits explicit."]],
+    neighbors: [{ name: "stabilizing-nondeterministic-checks", rank: 0 }],
+    expected: { lexical: "create", hybrid: "park-semantic" },
+  },
+  {
+    id: "B3-oom-paraphrase", cls: "B-paraphrase-dupe",
+    evidence: "- recovered failure: node heap out of memory during webpack production bundle · raise --max-old-space-size and split chunks",
+    shelf: [["taming-memory-hungry-compilations", "Use when a large asset pipeline exhausts RAM mid-run: give the process more headroom and break the workload into smaller pieces."]],
+    neighbors: [{ name: "taming-memory-hungry-compilations", rank: 0 }],
+    expected: { lexical: "create", hybrid: "park-semantic" },
+  },
+  {
+    id: "B4-lockfile-paraphrase", cls: "B-paraphrase-dupe",
+    evidence: "- recovered failure: bun install frozen lockfile mismatch · regenerate bun.lock and commit it with the dependency bump",
+    shelf: [["reconciling-dependency-manifests", "Use when the package manager refuses to proceed because the pinned manifest disagrees with declared requirements: refresh the pin file and check it in together."]],
+    neighbors: [{ name: "reconciling-dependency-manifests", rank: 0 }],
+    expected: { lexical: "create", hybrid: "park-semantic" },
+  },
+  {
+    id: "B5-cors-paraphrase", cls: "B-paraphrase-dupe",
+    evidence: "- recovered failure: fetch blocked by CORS preflight 403 on the staging API · add the origin to allowed list and expose headers",
+    shelf: [["unblocking-cross-site-request-policies", "Use when the browser refuses a call to another host: adjust the server's permitted origins and returned policy so the client may proceed."]],
+    neighbors: [{ name: "unblocking-cross-site-request-policies", rank: 0 }],
+    expected: { lexical: "create", hybrid: "park-semantic" },
+  },
+  {
+    id: "B6-secrets-paraphrase", cls: "B-paraphrase-dupe",
+    evidence: "- recovered failure: CI job fails because AWS_SECRET_ACCESS_KEY env var missing · inject it from the repository secret store",
+    shelf: [["provisioning-pipeline-credentials", "Use when an automated run cannot authenticate: source the token from the managed vault and expose it to the job at start."]],
+    neighbors: [{ name: "provisioning-pipeline-credentials", rank: 0 }],
+    expected: { lexical: "create", hybrid: "park-semantic" },
+  },
+  // ── C · borderline corroboration: exactly 3 distinctive desc-only shared terms → lexical score
+  // ~15 (< threshold 18, ≥ matched floor 3); semantic rank-1 boost (+12) lifts past threshold ──
+  {
+    id: "C1-pytest-fixture-drift", cls: "C-borderline",
+    evidence: "- recovered failure: pytest conftest fixtures drifted after a refactor · bring them back in line and run everything again",
+    shelf: [["keeping-suites-healthy", "Use when pytest goes red from stale fixtures: refresh conftest, repair the source, verify by rerunning."],
+            ["publishing-npm-packages", "Use when publishing an npm package: bump version, pack dry-run, verify tarball contents, publish."]],
+    neighbors: [{ name: "keeping-suites-healthy", rank: 0 }],
+    expected: { lexical: "create", hybrid: "update" }, target: "keeping-suites-healthy",
+  },
+  {
+    id: "C2-worktree-detached", cls: "C-borderline",
+    evidence: "- recovered failure: git worktree checkout left a detached HEAD · add tracking so later pulls land where intended",
+    shelf: [["juggling-parallel-branch-copies", "Use when working across several git worktree copies: prune them and avoid a detached state."],
+            ["fixing-tsc-type-errors", "Use when tsc --noEmit reports type errors: read each diagnostic, fix source types, re-run tsc."]],
+    neighbors: [{ name: "juggling-parallel-branch-copies", rank: 0 }],
+    expected: { lexical: "create", hybrid: "update" }, target: "juggling-parallel-branch-copies",
+  },
+  {
+    id: "C3-docker-multistage", cls: "C-borderline",
+    evidence: "- recovered failure: final container image too large in CI · introduce a multi-stage docker layout",
+    shelf: [["shrinking-runtime-footprints", "Use when a docker image ships oversized: separate the stages and keep only runtime pieces."],
+            ["rotating-api-credentials", "Use when rotating expired credentials: mint the new secret, update the store, verify revocation."]],
+    neighbors: [{ name: "shrinking-runtime-footprints", rank: 0 }],
+    expected: { lexical: "create", hybrid: "update" }, target: "shrinking-runtime-footprints",
+  },
+  // ── D · genuinely novel: hybrid must not over-park on weak/stale semantic noise ──
+  {
+    id: "D1-novel-webgl", cls: "D-novel",
+    evidence: "- recovered failure: WebGL context lost on tab switch · listen for webglcontextlost and rebuild GPU resources",
+    shelf: [["debugging-failing-pytest-runs", "Use when pytest goes red: read the failure, fix the source, re-run to verify green."]],
+    neighbors: [], // embedding search finds nothing relevant above the floor
+    expected: { lexical: "create", hybrid: "create" },
+  },
+  {
+    id: "D2-novel-stale-passage", cls: "D-novel",
+    evidence: "- recovered failure: Stripe webhook signature mismatch · verify raw body is passed unparsed to constructEvent",
+    shelf: [["publishing-npm-packages", "Use when publishing an npm package: bump version, pack dry-run, verify tarball, publish."]],
+    neighbors: [{ name: "retired-payments-skill", rank: 0 }], // stale passage — skill no longer on shelf
+    expected: { lexical: "create", hybrid: "create" },
+  },
+  {
+    id: "D3-novel-empty-shelf", cls: "D-novel",
+    evidence: "- recovered failure: launchd plist rejected (path not absolute) · use absolute binary paths in ProgramArguments",
+    shelf: [],
+    neighbors: [],
+    expected: { lexical: "create", hybrid: "create" },
+  },
+  {
+    id: "D4-novel-weak-neighbor", cls: "D-novel",
+    evidence: "- recovered failure: SIGBUS in mmap'd sqlite on NFS volume · move the database off networked storage",
+    shelf: [["reconciling-dependency-manifests", "Use when the package manager refuses to proceed because the pinned manifest disagrees: refresh the pin file and check it in."]],
+    // noise at rank 1 + off-shelf hit at rank 0: suspect only ever considers an ON-SHELF rank-1 — must not park
+    neighbors: [{ name: "some-other-skill-off-shelf", rank: 0 }, { name: "reconciling-dependency-manifests", rank: 1 }],
+    expected: { lexical: "create", hybrid: "create" },
+  },
+];

--- a/packages/muscle-memory/test/routing.eval.ts
+++ b/packages/muscle-memory/test/routing.eval.ts
@@ -1,0 +1,59 @@
+// muscle-memory · E4 ROUTING EVAL — lexical-only vs hybrid (semantic recall + lexical precision).
+//
+// Measures the SHIPPED decision path (searchSkills → routeSkill — the same head reviewAndAuthor
+// consumes) on the shared labeled case set (test/routing-cases.ts).
+//
+// HONESTY NOTE: in this OFFLINE eval the semantic neighbors are hand-labeled fixtures that stand
+// in for client.agents.passages.search results (rank order, no scores — same contract). The
+// decision mechanics are fully real; the embedding QUALITY is validated separately by the live
+// benchmark (scripts/bench-semantic-live.ts) against a real Letta agent.
+//
+// Run: bun test/routing.eval.ts   (also wired into `npm run verify`; exits 1 on regression)
+import { routeSkill, searchSkills } from "../mods/autopilot";
+import type { SkillRoute } from "../mods/autopilot";
+import { CASES, intentSatisfied, materialize } from "./routing-cases";
+import type { RoutingCase } from "./routing-cases";
+
+type LaneResult = { correct: number; total: number; byClass: Record<string, { correct: number; total: number }>; failures: string[] };
+const lane = (): LaneResult => ({ correct: 0, total: 0, byClass: {}, failures: [] });
+
+function score(r: LaneResult, c: RoutingCase, got: SkillRoute, gotTarget: string | null, want: SkillRoute) {
+  const cls = (r.byClass[c.cls] ??= { correct: 0, total: 0 });
+  r.total++; cls.total++;
+  const targetOk = want !== "update" || gotTarget === c.target;
+  if (got === want && targetOk) { r.correct++; cls.correct++; }
+  else r.failures.push(`${c.id}: expected ${want}${c.target ? `→${c.target}` : ""}, got ${got}${gotTarget ? `→${gotTarget}` : ""}`);
+}
+
+// Per-lane ground truth: the LEXICAL lane's "expected" column encodes today's shipped behavior
+// (it is expected to miss classes B and C), so lexical accuracy is 100% BY CONSTRUCTION unless a
+// regression changes routing. The interesting number is DECISION QUALITY vs class intent below.
+const lex = lane(), hyb = lane();
+let lexGood = 0, hybGood = 0;
+for (const c of CASES) {
+  const dir = materialize(c.shelf);
+  const onShelf = (n: string) => c.shelf.some(([name]) => name === n);
+  const lexical = searchSkills([dir], c.evidence, 3);
+  const dl = routeSkill(lexical, [], onShelf);
+  const dh = routeSkill(lexical, c.neighbors, onShelf);
+  score(lex, c, dl.route, dl.target?.name ?? null, c.expected.lexical);
+  score(hyb, c, dh.route, dh.target?.name ?? null, c.expected.hybrid);
+  if (intentSatisfied(c, dl.route, dl.target?.name ?? null)) lexGood++;
+  if (intentSatisfied(c, dh.route, dh.target?.name ?? null)) hybGood++;
+}
+
+const pct = (n: number, d: number) => ((100 * n) / d).toFixed(1);
+console.log(`\nmuscle-memory · E4 routing eval — ${CASES.length} labeled cases (production routeSkill path)\n`);
+console.log(`  lexical-only : ${lex.correct}/${lex.total}  (${pct(lex.correct, lex.total)}%)`);
+console.log(`  hybrid       : ${hyb.correct}/${hyb.total}  (${pct(hyb.correct, hyb.total)}%)\n`);
+for (const cls of Object.keys(hyb.byClass)) {
+  const l = lex.byClass[cls], h = hyb.byClass[cls];
+  console.log(`  ${cls.padEnd(18)} lexical ${l.correct}/${l.total}   hybrid ${h.correct}/${h.total}`);
+}
+if (lex.failures.length) console.log(`\n  lexical misses:\n    ${lex.failures.join("\n    ")}`);
+if (hyb.failures.length) console.log(`\n  hybrid misses:\n    ${hyb.failures.join("\n    ")}`);
+console.log(`\n  DECISION QUALITY vs class intent (the headline number):`);
+console.log(`  lexical-only : ${lexGood}/${CASES.length}  (${pct(lexGood, CASES.length)}%)`);
+console.log(`  hybrid       : ${hybGood}/${CASES.length}  (${pct(hybGood, CASES.length)}%)\n`);
+if (hybGood <= lexGood) { console.error("EVAL FAILURE: hybrid does not beat lexical"); process.exit(1); }
+if (hyb.correct !== hyb.total || lex.correct !== lex.total) { console.error("EVAL FAILURE: a lane missed its per-lane ground truth (routing regression)"); process.exit(1); }

--- a/packages/muscle-memory/test/semantic-routing.test.ts
+++ b/packages/muscle-memory/test/semantic-routing.test.ts
@@ -135,12 +135,56 @@ test("semanticSkillCandidates + syncSkillPassages: gated off without MM_NATIVE=p
     expect(hits).toEqual([{ name: "a-skill", rank: 0 }]);
     calls.length = 0;
     expect(await syncSkillPassages(client, "agent-1", [{ name: "a-skill", description: "does the thing" }])).toBe(1); // canaries excluded from the count
-    // upsert per entry (stale removed first), managed skill first, then the two canary reference passages
-    expect(calls.map((c) => c.op)).toEqual(["search", "delete", "create", "search", "delete", "create", "search", "delete", "create"]);
+    // upsert per entry (stale removed first), managed skill first, then the two canary reference
+    // passages — plus ONE trailing reconciliation search (its only hit, a-skill, is live → no delete).
+    expect(calls.map((c) => c.op)).toEqual(["search", "delete", "create", "search", "delete", "create", "search", "delete", "create", "search"]);
     const created = calls[2].args[1];
     expect(created && typeof created === "object" && "text" in created ? created.text : "").toBe(skillPassageText("a-skill", "does the thing"));
     const canaryCreate = calls[5].args[1];
     expect(canaryCreate && typeof canaryCreate === "object" && "tags" in canaryCreate ? canaryCreate.tags : []).toEqual([SKILL_PASSAGE_TAG, skillPassageTag(SKILL_CANARY_NAMES[0])]);
+  } finally {
+    if (prev === undefined) delete process.env.MM_NATIVE; else process.env.MM_NATIVE = prev;
+  }
+});
+
+test("sync hygiene: unchanged skills skip the round-trip; removed skills get reconciled; canaries survive", async () => {
+  const keptText = skillPassageText("kept-skill", "does the thing");
+  const calls: Array<{ op: string; args: unknown[] }> = [];
+  const client = { agents: { passages: {
+    search: (...args: unknown[]) => {
+      calls.push({ op: "search", args });
+      const params = args[1] as { tags?: string[] };
+      const tags = params?.tags ?? [];
+      // per-skill lookup for the kept skill: exactly one prior passage, byte-identical text → skip
+      if (tags[0] === skillPassageTag("kept-skill")) {
+        return Promise.resolve({ results: [{ id: "k1", text: keptText, tags: [SKILL_PASSAGE_TAG, skillPassageTag("kept-skill")] }] });
+      }
+      // reconciliation sweep (bare mm:skill tag): live skill + a ghost + a canary
+      if (tags.length === 1 && tags[0] === SKILL_PASSAGE_TAG) {
+        return Promise.resolve({ results: [
+          { id: "k1", tags: [SKILL_PASSAGE_TAG, skillPassageTag("kept-skill")] },
+          { id: "g1", tags: [SKILL_PASSAGE_TAG, skillPassageTag("ghost-skill")] },   // deleted skill's leftover
+          { id: "c1", tags: [SKILL_PASSAGE_TAG, skillPassageTag(SKILL_CANARY_NAMES[0])] },
+        ] });
+      }
+      return Promise.resolve({ results: [] }); // canary per-entry lookups: nothing prior
+    },
+    create: (...args: unknown[]) => { calls.push({ op: "create", args }); return Promise.resolve([]); },
+    delete: (...args: unknown[]) => { calls.push({ op: "delete", args }); return Promise.resolve({}); },
+  } } };
+  const prev = process.env.MM_NATIVE;
+  process.env.MM_NATIVE = "passages";
+  try {
+    const synced = await syncSkillPassages(client, "agent-1", [{ name: "kept-skill", description: "does the thing" }]);
+    expect(synced).toBe(1); // skipped-unchanged still counts as synced (it IS on the index)
+    const deletes = calls.filter((c) => c.op === "delete").map((c) => c.args[0]);
+    expect(deletes).toEqual(["g1"]); // ONLY the ghost — kept skill skipped, canary immune
+    const creates = calls.filter((c) => c.op === "create");
+    expect(creates.length).toBe(2); // the two canaries; kept-skill's round-trip was skipped entirely
+    for (const c of creates) {
+      const body = c.args[1] as { tags?: string[] };
+      expect((body.tags ?? []).some((t) => t.includes("mm-canary-"))).toBe(true);
+    }
   } finally {
     if (prev === undefined) delete process.env.MM_NATIVE; else process.env.MM_NATIVE = prev;
   }

--- a/packages/muscle-memory/test/semantic-routing.test.ts
+++ b/packages/muscle-memory/test/semantic-routing.test.ts
@@ -1,0 +1,258 @@
+// muscle-memory · E4 semantic routing tests (hybrid recall/precision).
+//
+// CONTRACT under test: embedding search (client.agents.passages.search) returns rank order with
+// NO absolute score, so semantic evidence may only
+//   (a) BOOST a candidate the lexical scorer already found distinctive overlap for, and
+//   (b) park an autonomous CREATE when the semantic rank-1 hit has ZERO lexical support
+//       (the paraphrase-duplicate class lexical routing misses by construction).
+// It must NEVER route an UPDATE on its own (never patch the wrong skill), and with no semanticFn
+// or an empty hit list, behavior must be byte-identical to lexical-only routing.
+// Run: `bun test test/semantic-routing.test.ts`
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applySemanticEvidence, pickUpdateTarget, reviewAndAuthor, routeSkill, SEMANTIC_RANK_BONUS } from "../mods/autopilot";
+import { calibrateSkillHits, parseSkillHits, semanticSkillCandidates, skillPassageTag, skillPassageText, syncSkillPassages, SKILL_CANARY_NAMES, SKILL_PASSAGE_TAG } from "../mods/engram";
+
+type Match = { name: string; description: string; dir: string; score: number; matched: number };
+const M = (name: string, score: number, matched: number): Match => ({ name, description: `desc of ${name}`, dir: "/tmp", score, matched });
+
+function shelfWith(...skills: Array<[string, string]>): string {
+  const dir = mkdtempSync(join(tmpdir(), "mm-sem-shelf-"));
+  for (const [n, d] of skills) {
+    mkdirSync(join(dir, n), { recursive: true });
+    writeFileSync(join(dir, n, "SKILL.md"), `---\nname: ${n}\ndescription: ${d}\n---\n## Procedure\n1. ${d}\n## Pitfalls\n### 1. x\nTELL: y. Fix it.\n## Verification\n- ok.`);
+  }
+  return dir;
+}
+
+// ── applySemanticEvidence (pure) ────────────────────────────────────────────────────────────
+
+test("corroboration boost: semantic rank-1 lifts an under-threshold lexical target past pickUpdateTarget", () => {
+  const matches = [M("debugging-failing-tests", 14, 3), M("validating-mod-packages", 4, 1)];
+  expect(pickUpdateTarget(matches, 18)).toBeNull(); // lexical alone: under threshold → CREATE
+  const { matches: boosted, suspect } = applySemanticEvidence(matches, [{ name: "debugging-failing-tests", rank: 0 }], () => true);
+  expect(boosted[0].score).toBe(14 + SEMANTIC_RANK_BONUS[0]);
+  expect(suspect).toBeNull(); // corroborated, not suspect
+  expect(pickUpdateTarget(boosted, 18)?.name).toBe("debugging-failing-tests"); // hybrid: routes UPDATE
+});
+
+test("boost never manufactures `matched`: a semantic hit with zero lexical overlap gets no score boost", () => {
+  const matches = [M("some-other-skill", 20, 3), M("paraphrase-dupe", 0, 0)];
+  const { matches: boosted } = applySemanticEvidence(matches, [{ name: "paraphrase-dupe", rank: 0 }], () => true);
+  expect(boosted.find((m) => m.name === "paraphrase-dupe")?.score).toBe(0); // matched=0 → untouched
+});
+
+test("semantic-duplicate suspect: rank-1 hit on-shelf with no distinctive lexical overlap", () => {
+  const { suspect } = applySemanticEvidence([M("unrelated", 6, 1)], [{ name: "paraphrase-dupe", rank: 0 }], (n) => n === "paraphrase-dupe");
+  expect(suspect).toBe("paraphrase-dupe");
+});
+
+test("stale semantic hit (passage for a deleted skill) is never a suspect", () => {
+  const { suspect } = applySemanticEvidence([M("unrelated", 6, 1)], [{ name: "ghost-skill", rank: 0 }], () => false);
+  expect(suspect).toBeNull();
+});
+
+test("no hits → identity: matches unchanged, no suspect (lexical-only regression)", () => {
+  const matches = [M("a", 10, 2), M("b", 5, 1)];
+  const out = applySemanticEvidence(matches, [], () => true);
+  expect(out.matches).toEqual(matches);
+  expect(out.suspect).toBeNull();
+});
+
+// ── reviewAndAuthor wiring ──────────────────────────────────────────────────────────────────
+
+const EVIDENCE = "- recovered failure: alembic upgrade head (services/checkout)\n· example — KeyError revision → repair the version file and re-run";
+
+test("wiring: semantic-only dupe parks the autonomous CREATE before the author is ever called", async () => {
+  // Shelf skill covers the same territory in DISJOINT vocabulary — lexical routing scores ~0.
+  const shelf = shelfWith(["handling-broken-schema-changes", "Use when a database change script blows up mid-apply: inspect the failed step, repair the script, apply again."]);
+  let authored = 0;
+  const res = await reviewAndAuthor(EVIDENCE, [shelf], async () => { authored++; return ""; }, {
+    semanticFn: async () => [{ name: "handling-broken-schema-changes", rank: 0 }],
+  });
+  expect(res.action).toBe("none");
+  expect(res.reason || "").toMatch(/semantic duplicate/i);
+  expect(authored).toBe(0); // parked in routing — no model call, no write
+});
+
+test("wiring: a throwing semanticFn degrades to pure lexical routing (never blocks)", async () => {
+  const shelf = shelfWith(["handling-broken-schema-changes", "Use when a database change script blows up mid-apply: inspect the failed step, repair the script, apply again."]);
+  let authored = 0;
+  // A VALID author draft makes the outcome deterministic regardless of host/suite state —
+  // asserting on the action of an EMPTY author leaned on the deterministic fallback, whose
+  // availability depends on whatever experience state other tests (or the host) left behind.
+  const DRAFT = [
+    "---", "name: recovering-from-visor-migration-failures",
+    "description: Use when a migration verifier fails with a stale-ledger error — read the verifier, repair the config epoch, re-run to confirm.",
+    "---", "## Procedure", "1. Read the exact error. 2. Repair the config. 3. Re-run the verifier.",
+    "## Pitfalls", "### 1. Blind retry", "TELL: identical error twice. Fix the config first.",
+    "## Verification", "- Verifier exits 0.",
+  ].join("\n");
+  const res = await reviewAndAuthor(EVIDENCE, [shelf], async () => { authored++; return DRAFT; }, {
+    semanticFn: async () => { throw new Error("server down"); },
+  });
+  expect(authored).toBeGreaterThan(0); // routing survived the throwing semantic lane; the author ran
+  expect(res.action).toBe("create");   // and the pure-lexical route completed end to end
+});
+
+// ── passage index primitives ────────────────────────────────────────────────────────────────
+
+test("parseSkillHits: name from mm:skill:<name> tag, content fallback, invalid names dropped, deduped", () => {
+  const hits = parseSkillHits({ count: 4, results: [
+    { id: "p1", content: "skill: debugging-failing-tests\n...", tags: [SKILL_PASSAGE_TAG, skillPassageTag("debugging-failing-tests")] },
+    { id: "p2", content: "skill: validating-mod-packages\n...", tags: [SKILL_PASSAGE_TAG] }, // no name tag → content fallback
+    { id: "p3", content: "skill: NOT A VALID NAME!!\n...", tags: [SKILL_PASSAGE_TAG] },
+    { id: "p4", content: "skill: debugging-failing-tests\n...", tags: [skillPassageTag("debugging-failing-tests")] }, // dupe
+  ] });
+  expect(hits.map((h) => h.name)).toEqual(["debugging-failing-tests", "validating-mod-packages"]);
+  expect(hits.map((h) => h.rank)).toEqual([0, 1]);
+});
+
+test("parseSkillHits: malformed responses are empty, never throw", () => {
+  expect(parseSkillHits(undefined)).toEqual([]);
+  expect(parseSkillHits("nope")).toEqual([]);
+  expect(parseSkillHits({ results: "nope" })).toEqual([]);
+  expect(parseSkillHits({ results: [null, 42, {}] })).toEqual([]);
+});
+
+test("semanticSkillCandidates + syncSkillPassages: gated off without MM_NATIVE=passages; upsert deletes stale then creates", async () => {
+  const calls: Array<{ op: string; args: unknown[] }> = [];
+  const client = { agents: { passages: {
+    search: (...args: unknown[]) => { calls.push({ op: "search", args }); return Promise.resolve({ count: 1, results: [{ id: "old-1", content: "skill: a-skill\nx", tags: [SKILL_PASSAGE_TAG, skillPassageTag("a-skill")] }] }); },
+    create: (...args: unknown[]) => { calls.push({ op: "create", args }); return Promise.resolve([]); },
+    delete: (...args: unknown[]) => { calls.push({ op: "delete", args }); return Promise.resolve({}); },
+  } } };
+  const prev = process.env.MM_NATIVE;
+  delete process.env.MM_NATIVE;
+  try {
+    expect(await semanticSkillCandidates(client, "agent-1", "query")).toEqual([]); // env off → no-op
+    expect(await syncSkillPassages(client, "agent-1", [{ name: "a-skill", description: "d" }])).toBe(0);
+    expect(calls.length).toBe(0); // gated: the client was never touched
+    process.env.MM_NATIVE = "passages";
+    const hits = await semanticSkillCandidates(client, "agent-1", "query text");
+    expect(hits).toEqual([{ name: "a-skill", rank: 0 }]);
+    calls.length = 0;
+    expect(await syncSkillPassages(client, "agent-1", [{ name: "a-skill", description: "does the thing" }])).toBe(1); // canaries excluded from the count
+    // upsert per entry (stale removed first), managed skill first, then the two canary reference passages
+    expect(calls.map((c) => c.op)).toEqual(["search", "delete", "create", "search", "delete", "create", "search", "delete", "create"]);
+    const created = calls[2].args[1];
+    expect(created && typeof created === "object" && "text" in created ? created.text : "").toBe(skillPassageText("a-skill", "does the thing"));
+    const canaryCreate = calls[5].args[1];
+    expect(canaryCreate && typeof canaryCreate === "object" && "tags" in canaryCreate ? canaryCreate.tags : []).toEqual([SKILL_PASSAGE_TAG, skillPassageTag(SKILL_CANARY_NAMES[0])]);
+  } finally {
+    if (prev === undefined) delete process.env.MM_NATIVE; else process.env.MM_NATIVE = prev;
+  }
+});
+
+// ── canary calibration (calibrateSkillHits, pure) ───────────────────────────────────────────
+
+test("calibrateSkillHits: canaries stripped, survivors densely re-ranked and k-truncated, aboveCanary vs the BEST canary rank", () => {
+  const raw = [
+    { name: "alpha", rank: 0 },
+    { name: SKILL_CANARY_NAMES[0], rank: 1 }, // best canary — THE relevance floor
+    { name: "beta", rank: 2 },
+    { name: "gamma", rank: 3 },
+    { name: SKILL_CANARY_NAMES[1], rank: 4 }, // worse canary must NOT move the floor
+    { name: "delta", rank: 5 },
+  ];
+  expect(calibrateSkillHits(raw, 3)).toEqual([
+    { name: "alpha", rank: 0, aboveCanary: true },  // raw 0 beat canary raw 1
+    { name: "beta", rank: 1, aboveCanary: false },  // raw 2 lost to the BEST canary, not the worst
+    { name: "gamma", rank: 2, aboveCanary: false }, // dense re-rank: canary gaps closed
+  ]); // delta dropped: truncation to k happens AFTER canary removal
+});
+
+test("calibrateSkillHits: canary at wire rank 0 → every survivor is below the floor (the novel-evidence window)", () => {
+  expect(calibrateSkillHits([{ name: SKILL_CANARY_NAMES[1], rank: 0 }, { name: "alpha", rank: 1 }], 3))
+    .toEqual([{ name: "alpha", rank: 0, aboveCanary: false }]);
+});
+
+test("calibrateSkillHits: no canary in the window → survivors carry NO aboveCanary key (uncalibrated)", () => {
+  const out = calibrateSkillHits([{ name: "alpha", rank: 0 }, { name: "beta", rank: 1 }], 3);
+  expect(out).toEqual([{ name: "alpha", rank: 0 }, { name: "beta", rank: 1 }]);
+  // toEqual ignores undefined-valued keys, but the consumer gate is `aboveCanary !== undefined` —
+  // an `aboveCanary: undefined` key would still calibrate the window. Pin the key's ABSENCE.
+  expect(out.every((h) => !("aboveCanary" in h))).toBe(true);
+});
+
+test("calibrateSkillHits: a window of only canaries yields no candidates", () => {
+  expect(calibrateSkillHits([{ name: SKILL_CANARY_NAMES[0], rank: 0 }, { name: SKILL_CANARY_NAMES[1], rank: 1 }], 3)).toEqual([]);
+});
+
+// ── calibrated suspect trust (applySemanticEvidence / routeSkill) ───────────────────────────
+
+test("calibrated: deep on-shelf above-canary hit suspects past off-shelf ghosts — rank is not the gate", () => {
+  const hits = [
+    { name: "ghost-a", rank: 0, aboveCanary: true }, // stale passages of deleted skills — transparent
+    { name: "ghost-b", rank: 1, aboveCanary: true },
+    { name: "paraphrase-dupe", rank: 2, aboveCanary: true },
+  ];
+  const { route, suspect } = routeSkill([M("unrelated", 6, 1)], hits, (n) => n === "paraphrase-dupe");
+  expect(suspect).toBe("paraphrase-dupe");
+  expect(route).toBe("park-semantic");
+});
+
+test("calibrated: rank-0 on-shelf hit BELOW the floor never suspects — novel evidence routes CREATE", () => {
+  // The production over-park class: index ≡ shelf, so any novel query still nominates some
+  // nearest managed skill at rank 0. Below the canary line = merely nearest, not related.
+  const { route, suspect } = routeSkill([M("unrelated", 6, 1)], [{ name: "nearest-but-unrelated", rank: 0, aboveCanary: false }], () => true);
+  expect(suspect).toBeNull();
+  expect(route).toBe("create");
+});
+
+test("calibrated: the HIGHEST-ranked qualifying hit is the suspect, not a later one", () => {
+  const hits = [
+    { name: "ghost", rank: 0, aboveCanary: true },      // off-shelf — skipped
+    { name: "first-dupe", rank: 1, aboveCanary: true }, // ← first on-shelf above the floor
+    { name: "second-dupe", rank: 2, aboveCanary: true },
+  ];
+  const { suspect } = applySemanticEvidence([M("unrelated", 6, 1)], hits, (n) => n !== "ghost");
+  expect(suspect).toBe("first-dupe");
+});
+
+test("calibrated suspect suppressed by strong lexical support — corroboration routes UPDATE, never parks", () => {
+  // matched ≥ SEARCH_DISTINCT_MIN and boosted score ≥ threshold: lexical already found it
+  // distinctively, so it is a corroborated target, not a missed paraphrase dupe.
+  const { route, target, suspect } = routeSkill([M("covered-skill", 20, 3)], [{ name: "covered-skill", rank: 0, aboveCanary: true }], () => true);
+  expect(suspect).toBeNull();
+  expect(route).toBe("update");
+  expect(target?.name).toBe("covered-skill");
+});
+
+test("uncalibrated window (no aboveCanary anywhere): only rank 0 can suspect — deeper on-shelf hits never park", () => {
+  // Legacy conservative rule pinned: without a relevance floor, "nearest" is meaningless past rank 0.
+  const hits = [{ name: "off-shelf-ghost", rank: 0 }, { name: "on-shelf-dupe", rank: 1 }];
+  const { route, suspect } = routeSkill([M("unrelated", 6, 1)], hits, (n) => n === "on-shelf-dupe");
+  expect(suspect).toBeNull();
+  expect(route).toBe("create");
+});
+
+// ── over-fetch + calibration wiring (semanticSkillCandidates) ───────────────────────────────
+
+test("semanticSkillCandidates: over-fetches top_k = k + canary count and returns calibrated hits", async () => {
+  let searchParams: Record<string, unknown> | undefined;
+  const client = { agents: { passages: {
+    search: (_agentId: string, params: Record<string, unknown>) => {
+      searchParams = params;
+      return Promise.resolve({ count: 3, results: [
+        { id: "p1", content: "skill: near-dupe\n...", tags: [SKILL_PASSAGE_TAG, skillPassageTag("near-dupe")] },
+        { id: "p2", content: `skill: ${SKILL_CANARY_NAMES[0]}\n...`, tags: [SKILL_PASSAGE_TAG, skillPassageTag(SKILL_CANARY_NAMES[0])] },
+        { id: "p3", content: "skill: merely-nearest\n...", tags: [SKILL_PASSAGE_TAG, skillPassageTag("merely-nearest")] },
+      ] });
+    },
+  } } };
+  const prev = process.env.MM_NATIVE;
+  process.env.MM_NATIVE = "passages";
+  try {
+    const hits = await semanticSkillCandidates(client, "agent-1", "query text"); // default k = 3
+    expect(searchParams?.top_k).toBe(3 + SKILL_CANARY_NAMES.length); // widened so canaries never evict real hits
+    expect(hits).toEqual([
+      { name: "near-dupe", rank: 0, aboveCanary: true },       // beat the canary on the wire
+      { name: "merely-nearest", rank: 1, aboveCanary: false }, // dense re-rank after the canary was stripped
+    ]);
+  } finally {
+    if (prev === undefined) delete process.env.MM_NATIVE; else process.env.MM_NATIVE = prev;
+  }
+});


### PR DESCRIPTION
## Summary

Improves `muscle-memory` update-first routing so the mod is less likely to create garbage sibling skills when a new lesson should be folded into an existing skill.

The previous routing path was lexical-only. That is safe, but it misses paraphrase / near-duplicate cases where the existing skill is semantically obvious but shares few distinctive tokens. This is the skill-distillation bloat failure mode: too many new skills when minor improvements to existing skills would be better.

This PR adds an opt-in semantic recall lane for managed skills while preserving deterministic lexical precision:

- semantic recall can corroborate an existing lexical candidate
- semantic recall can park a likely duplicate CREATE for review
- semantic recall never blindly patches an existing skill
- behavior falls back to lexical-only when `MM_NATIVE=passages` is off or passage search fails

It also adds canary calibration for semantic duplicate suspects. Because passage search returns nearest neighbors without absolute relevance scores, the mod indexes generic canary passages and only trusts semantic duplicate suspects that beat the canary relevance floor. This prevents “nearest existing skill” from over-parking genuinely novel lessons.

## What changed

- Added semantic skill-passage indexing/search helpers for managed skills.
- Added `routeSkill()` as the pure routing decision head consumed by `reviewAndAuthor()`.
- Added canary passages + `aboveCanary` calibration for rank-to-relevance.
- Added routing fixtures/eval covering:
  - strong lexical duplicates
  - paraphrase duplicates
  - borderline corroboration
  - genuinely novel lessons
- Added `eval:routing` to `verify` so routing quality cannot silently regress.
- Added a live semantic benchmark script for reproducing the Letta Cloud embedding behavior.
- Updated README/CHANGELOG with bounded claims and the known live miss.

## Verification

- `bun run verify` — 97 pass / 0 fail
- `bun test/routing.eval.ts` repeated x3 — hybrid 16/16 each run
- `npm pack --dry-run` — ships bundle + docs, no local clutter
- temp consumer install/import smoke — `semantic=true`, `reflex=false`, `wins=false`
- carve-out grep — no `MM_REFLEX`, `coachOnFailure`, `collectWins`, `renderWins`, reflex/wins/reranker code in shipped mods/tests

Routing eval headline:

```txt
LIVE LETTA CLOUD BENCH:
lexical-only : 7/16
hybrid       : 15/16

DETERMINISTIC FIXTURE EVAL:
lexical-only decision quality : 7/16  (43.8%)
hybrid decision quality       : 16/16 (100.0%)
```

The live bench uses real Letta Cloud passage embeddings; the deterministic fixture eval keeps the routing decision mechanics under CI so they cannot silently regress. The remaining live miss is documented honestly as an embedding-model limitation.

## Safety

- Semantic routing is opt-in via `MM_NATIVE=passages`.
- Semantic evidence never auto-patches alone.
- Suspected duplicates are parked for review instead of created.
- Fallback remains lexical-only.
- Reflex/tool-result coaching and wins ledger are intentionally not included in this PR.

---

Generated with [Letta Code](https://letta.com)



**Update (2026-07-05):** review follow-up folded in pre-review: `syncSkillPassages` now skips unchanged skills (no steady-state delete+create churn) and reconciles passages of removed skills (stale `mm:skill:*` entries no longer accumulate; canaries immune). +1 test (98 total); routing eval unchanged 16/16. CI note: the routing eval is gated in the source package verify command (`npm run verify` incl. `eval:routing`); this monorepo PR CI validates package manifests only. Commit: `b4dc7a1`.
