### PR TITLE
feat(pr-merge-unpin): add Desktop PR merge unpin mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ packages/
 ├── output-compressor/    # Reversibly compresses large tool outputs before the model sees them
 ├── pets/                 # Terminal pets that animate based on turn and tool activity
 ├── plan-mode/            # Plan-mode style workflow
+├── pr-merge-unpin/       # Unpin tracked Desktop conversations after GitHub PR merge
 ├── soft-landing/         # Recovery slash command for drift, compaction, or context overload
 ├── spotify-statusline/   # macOS Spotify now-playing statusline
 ├── sprite/               # Persistent pet that grows stats from real agent work
@@ -115,6 +116,7 @@ scripts/
 - **output-compressor** - Reversibly compresses large tool outputs before the model sees them
 - **pets** - Terminal pets that animate based on turn and tool activity
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
+- **pr-merge-unpin** - Unpin tracked Desktop conversations after their GitHub PR merges
 - **soft-landing** - Recovery slash command for drift, compaction, or context overload
 - **spotify-statusline** - macOS Spotify now-playing statusline
 - **sprite** - Persistent pet that grows stats from real agent work

--- a/packages/pr-merge-unpin/MOD.md
+++ b/packages/pr-merge-unpin/MOD.md
@@ -1,0 +1,55 @@
+---
+name: "@letta-ai/pr-merge-unpin"
+description: "Tracks active PR conversations and unpins them from the Desktop sidebar after their GitHub PR merges"
+---
+
+# PR merge unpin mod semantics
+
+## When to use
+
+Use this mod when pinned Desktop conversations represent active pull-request work and should disappear automatically after the associated PR merges.
+
+## Behavior
+
+On activation, the mod:
+
+1. Starts a 5-minute polling loop.
+2. Registers a `conversation_open` lifecycle handler when lifecycle events are available.
+3. Registers `/pr-merge-unpin` when commands are available.
+
+When a non-default conversation opens in a git repo, the mod runs `gh pr view --json number,url,state,mergedAt` from the repo root. If a PR is found for the current branch, it records:
+
+- `agentId`
+- `conversationId`
+- `repoRoot`
+- PR number and URL
+- latest PR state and `mergedAt`
+
+Tracking state is persisted to:
+
+```text
+~/.letta/mods/pr-merge-unpin.state.json
+```
+
+Each check refreshes tracked PRs with `gh pr view <number> --json number,url,state,mergedAt`. If the PR is merged, the mod removes the conversation id from:
+
+```text
+~/.letta/pinned-conversations.json
+```
+
+Merged entries stay in state until a later check confirms the conversation remains unpinned. This makes the behavior more resilient to Desktop renderer cache races that can briefly rehydrate stale pins.
+
+## Safety invariants
+
+- Default conversations are never tracked.
+- The mod only tracks a conversation when `gh pr view` resolves a PR for the active cwd's current branch.
+- Closed-but-unmerged PRs do not unpin conversations.
+- The mod uses `execFile`, not shell strings.
+- The mod does not import Letta Code internals.
+- Timers and event/command registrations are disposed on reload.
+
+## Limitations
+
+- `gh` must be available and authenticated.
+- Historical conversations are not inferred from cwd maps because worktrees and branches can be reused.
+- Desktop renderer localStorage can race durable JSON writes. This mod retries on later checks but does not call renderer IPC.

--- a/packages/pr-merge-unpin/README.md
+++ b/packages/pr-merge-unpin/README.md
@@ -1,0 +1,60 @@
+# PR merge unpin
+
+A Letta Code mod package that tracks the active conversation's GitHub pull request and removes that conversation from the Desktop pinned sidebar after the PR merges.
+
+This is useful for PR-driven workflows where pinned conversations are a temporary work queue.
+
+## Install
+
+```bash
+letta install npm:@letta-ai/pr-merge-unpin
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## Requirements
+
+- `gh` must be installed and authenticated for the repo.
+- The active conversation cwd must be inside a git repo with a branch that `gh pr view` can resolve.
+- Desktop pins must be stored in `~/.letta/pinned-conversations.json`.
+
+## What it adds
+
+- A `conversation_open` lifecycle handler that records the active conversation's current branch PR.
+- A 5-minute background check for tracked PR merge state.
+- A `/pr-merge-unpin` command that runs a check immediately and prints counts.
+
+Example command output:
+
+```text
+PR merge unpin: checked 2, tracking 1, unpinned 1.
+```
+
+## Behavior
+
+- The mod tracks non-default conversations only.
+- It stores tracking state at `~/.letta/mods/pr-merge-unpin.state.json`.
+- When a tracked PR reports `MERGED` via `gh pr view`, the mod removes that conversation id from `~/.letta/pinned-conversations.json`.
+- Merged entries are retained until a later check confirms the conversation stayed unpinned, which helps with Desktop renderer cache races.
+
+## Limitations
+
+This mod intentionally avoids Letta Code internals and uses the durable Desktop pinned-conversations JSON file. It does not call Desktop renderer IPC APIs, so a stale renderer-local pin cache may briefly rehydrate the pin until the next check removes it again.
+
+## Safety
+
+Mods are trusted local code. Review the source before installing third-party mods.
+
+If a mod breaks startup or command handling, recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/pr-merge-unpin/mods/index.ts
+++ b/packages/pr-merge-unpin/mods/index.ts
@@ -1,0 +1,228 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const LETTA_HOME = join(homedir(), ".letta");
+const PINNED_FILE = join(LETTA_HOME, "pinned-conversations.json");
+const STATE_FILE = join(LETTA_HOME, "mods", "pr-merge-unpin.state.json");
+const CHECK_MS = 5 * 60 * 1000;
+
+function readJson(file, fallback) {
+  try {
+    if (!existsSync(file)) return fallback;
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(file, value) {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function entryKey(agentId, conversationId) {
+  return `${agentId}:${conversationId}`;
+}
+
+function readPinnedAgents() {
+  const parsed = readJson(PINNED_FILE, {});
+  const source = parsed && typeof parsed === "object" && !Array.isArray(parsed) && parsed.agents && typeof parsed.agents === "object"
+    ? parsed.agents
+    : parsed;
+  const agents = {};
+  if (!source || typeof source !== "object" || Array.isArray(source)) return agents;
+  for (const [agentId, ids] of Object.entries(source)) {
+    if (Array.isArray(ids)) {
+      agents[agentId] = [...new Set(ids.filter((id) => typeof id === "string" && id.trim()))];
+    }
+  }
+  return agents;
+}
+
+function removePinnedConversation(agentId, conversationId) {
+  const agents = readPinnedAgents();
+  const current = agents[agentId] ?? [];
+  const next = current.filter((id) => id !== conversationId);
+  if (next.length === current.length) return false;
+  if (next.length > 0) agents[agentId] = next;
+  else delete agents[agentId];
+  writeJson(PINNED_FILE, { version: 1, agents });
+  return true;
+}
+
+function isPinnedConversation(agentId, conversationId) {
+  return (readPinnedAgents()[agentId] ?? []).includes(conversationId);
+}
+
+function readState() {
+  const state = readJson(STATE_FILE, { version: 1, entries: {} });
+  if (!state || typeof state !== "object" || Array.isArray(state)) return { version: 1, entries: {} };
+  if (!state.entries || typeof state.entries !== "object" || Array.isArray(state.entries)) {
+    state.entries = {};
+  }
+  return state;
+}
+
+async function gitRoot(cwd) {
+  if (!cwd || !existsSync(cwd)) return null;
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 2_000 });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function prForCurrentBranch(repoRoot) {
+  try {
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["pr", "view", "--json", "number,url,state,mergedAt"],
+      { cwd: repoRoot, timeout: 5_000, maxBuffer: 1024 * 1024 },
+    );
+    const pr = JSON.parse(stdout);
+    if (typeof pr.number !== "number") return null;
+    return pr;
+  } catch {
+    return null;
+  }
+}
+
+async function prByNumber(repoRoot, prNumber) {
+  try {
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["pr", "view", String(prNumber), "--json", "number,url,state,mergedAt"],
+      { cwd: repoRoot, timeout: 5_000, maxBuffer: 1024 * 1024 },
+    );
+    const pr = JSON.parse(stdout);
+    if (typeof pr.number !== "number") return null;
+    return pr;
+  } catch {
+    return null;
+  }
+}
+
+async function trackConversation(state, agentId, conversationId, cwd) {
+  if (!agentId || !conversationId || conversationId === "default") return null;
+  const repoRoot = await gitRoot(cwd);
+  if (!repoRoot) return null;
+  const pr = await prForCurrentBranch(repoRoot);
+  if (!pr) return null;
+  const key = entryKey(agentId, conversationId);
+  state.entries[key] = {
+    agentId,
+    conversationId,
+    repoRoot,
+    prNumber: pr.number,
+    prUrl: pr.url,
+    state: pr.state,
+    mergedAt: pr.mergedAt || null,
+    updatedAt: new Date().toISOString(),
+  };
+  return state.entries[key];
+}
+
+async function checkTrackedEntries(state) {
+  let checked = 0;
+  let unpinned = 0;
+
+  for (const [key, entry] of Object.entries({ ...state.entries })) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const { agentId, conversationId, repoRoot, prNumber } = entry;
+    if (typeof agentId !== "string" || typeof conversationId !== "string" || typeof repoRoot !== "string") continue;
+    if (typeof prNumber !== "number") continue;
+
+    checked++;
+    const pr = await prByNumber(repoRoot, prNumber);
+    if (!pr) continue;
+    entry.state = pr.state;
+    entry.prUrl = pr.url;
+    entry.mergedAt = pr.mergedAt || null;
+    entry.updatedAt = new Date().toISOString();
+
+    if (pr.state === "MERGED" || pr.mergedAt) {
+      const hadPriorAttempt = Boolean(entry.unpinAttemptedAt);
+      if (removePinnedConversation(agentId, conversationId)) unpinned++;
+      entry.unpinAttemptedAt = new Date().toISOString();
+      entry.unpinAttempts = Number(entry.unpinAttempts ?? 0) + 1;
+      // Desktop renderer localStorage can briefly repopulate the durable pin file
+      // from a stale in-memory snapshot. Keep merged entries until a later check
+      // confirms the conversation stayed unpinned.
+      if (hadPriorAttempt && !isPinnedConversation(agentId, conversationId)) {
+        delete state.entries[key];
+      }
+    }
+  }
+
+  return { checked, unpinned };
+}
+
+async function runCheck(activeContext) {
+  const state = readState();
+
+  if (activeContext?.agentId && activeContext?.conversationId && activeContext?.cwd) {
+    await trackConversation(state, activeContext.agentId, activeContext.conversationId, activeContext.cwd);
+  }
+
+  const result = await checkTrackedEntries(state);
+  writeJson(STATE_FILE, state);
+  return { ...result, tracking: Object.keys(state.entries).length };
+}
+
+export default function activate(letta) {
+  const disposers = [];
+  let running = false;
+
+  const check = async (activeContext) => {
+    if (running) return { skipped: true };
+    running = true;
+    try {
+      return await runCheck(activeContext);
+    } finally {
+      running = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void check().catch((error) => {
+      letta.diagnostics?.report?.({ severity: "warning", message: `pr-merge-unpin check failed: ${error?.message ?? error}` });
+    });
+  }, CHECK_MS);
+  disposers.push(() => clearInterval(timer));
+
+  void check().catch(() => {});
+
+  if (letta.capabilities.events.lifecycle) {
+    disposers.push(letta.events.on("conversation_open", (event, ctx) => {
+      void check({ agentId: event.agentId, conversationId: event.conversationId, cwd: ctx.cwd }).catch(() => {});
+    }));
+  }
+
+  if (letta.capabilities.commands) {
+    disposers.push(letta.commands.register({
+      id: "pr-merge-unpin",
+      description: "Track pinned PR conversations and unpin them after merge",
+      async run(ctx) {
+        const result = await check({
+          agentId: ctx.agent?.id,
+          conversationId: ctx.conversation?.id,
+          cwd: ctx.cwd,
+        });
+        if (result?.skipped) return { type: "output", output: "PR merge unpin check already running." };
+        return {
+          type: "output",
+          output: `PR merge unpin: checked ${result.checked}, tracking ${result.tracking}, unpinned ${result.unpinned}.`,
+        };
+      },
+    }));
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/pr-merge-unpin/package.json
+++ b/packages/pr-merge-unpin/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@letta-ai/pr-merge-unpin",
+  "version": "0.1.0",
+  "description": "Letta Code mod that unpins tracked Desktop conversations after their GitHub PR merges.",
+  "author": "Letta",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "github",
+    "pull-request",
+    "desktop"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/pr-merge-unpin"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["commands", "events.lifecycle"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `@letta-ai/pr-merge-unpin`, a mod package that tracks active PR conversations and unpins them from Desktop after merge.
- Include README/MOD docs covering behavior, state, limitations, and recovery.
- Register the package in the root README package list.

## Test plan
- [x] `node --check packages/pr-merge-unpin/mods/index.ts`
- [x] `npm run validate`