### PR TITLE
feat(muscle-memory): harden passage sync and bundle verification

### DIFF
--- a/packages/muscle-memory/README.md
+++ b/packages/muscle-memory/README.md
@@ -354,6 +354,8 @@ mods/index.ts       Letta mod entrypoint: tools, commands, events, activation
 
 Known boundaries — these are Bounded, not Verified:
 
+- **Canary calibration is validated against the current Letta Cloud embedding model.** The CI-gated eval exercises the decision mechanics on fixtures; the *live* relevance floor depends on the embedder. Any embedding-model change on the Letta side requires re-running the live benchmark (`bench-semantic-live`, needs `LETTA_API_KEY`) to re-verify the canary floor — run it on a cadence and after any Letta embeddings announcement.
+
 - **Distillation quality is shared ground.** We do not claim a stronger skill primitive than Letta. The wedge is autonomy + maintenance, not skill-writing quality.
 - **Routing/dedup is lexical-precision-first.** The opt-in semantic lane catches paraphrase duplicates via canary-calibrated embedding recall (live 15/16 decision quality vs 7/16 lexical-only on the labeled set), but it only parks or corroborates — it never auto-merges — and one known paraphrase class (zero-overlap tool-name evidence, e.g. alembic ↔ "schema changes") still ranks below the calibration floor on the current Letta Cloud embedder.
 - **Canary calibration depends on the current passage embedder.** If Letta changes the passage embedding model or ranking behavior, rerun `scripts/bench-semantic-live.ts`; the canary relevance floor may move even when deterministic fixture tests still pass.

--- a/packages/muscle-memory/mods/engram.ts
+++ b/packages/muscle-memory/mods/engram.ts
@@ -452,41 +452,51 @@ export async function syncSkillPassages(client: unknown, agentId: string | null 
   if (!create) return 0;
   let synced = 0;
   const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
-  for (const m of entries) {
+
+  // BATCHED SYNC (review follow-up): ONE global tag search replaces N per-skill searches.
+  // The reconciliation sweep already fetched every skill passage — so fetch it FIRST, index by
+  // name, and answer every "unchanged?" question locally. A 50-skill shelf goes from ~100+
+  // API calls per close to 1 search + only the writes that are actually needed.
+  // (Depends on search returning passage text — see passageText note; if text is absent the
+  // index yields "" and every entry degrades CORRECTLY to delete+create.)
+  const index = new Map<string, Array<{ id: string; text: string }>>();
+  let indexed = false;
+  if (search) {
     try {
-      let skip = false;
-      if (search && del) {
-        const prior: unknown = await search(agentId, { query: m.name, tags: [skillPassageTag(m.name)], tag_match_mode: "all", top_k: 5 });
-        if (prior && typeof prior === "object" && "results" in prior && Array.isArray(prior.results)) {
-          // review note: this optimization DEPENDS on the search API returning passage text
-          // (passageText reads .text/.content). If the API stops returning text, passageText
-          // yields "" and skip stays false — behavior degrades CORRECTLY but quietly to the
-          // old delete+create round-trip. If sync volume ever spikes, check this first.
-          skip = prior.results.length === 1 && passageText(prior.results[0]) === m.text; // unchanged → no round-trip
-          if (!skip) {
-            for (const r of prior.results) { if (r && typeof r === "object" && "id" in r && typeof r.id === "string") await del(r.id, { agent_id: agentId }); }
-          }
-        }
-      }
-      if (!skip) await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
-      if (!isCanaryName(m.name)) synced++; // canaries are calibration plumbing, not shelf state
-    } catch { /* best-effort per skill — a failed sync never blocks the lifecycle */ }
-  }
-  // Reconcile removals: the shelf is the source of truth; the index must not outlive it.
-  if (search && del) {
-    try {
-      const live = new Set<string>([...managed.map((m) => m.name), ...SKILL_CANARY_NAMES]);
-      const all: unknown = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 500 }); // review note: was 100 — a shelf past the cap would let stale
-      // passages survive reconciliation silently. 500 covers any realistic shelf (~10 passages/skill
-      // headroom); TODO(pagination): page the sweep if shelves ever approach this.
+      const all: unknown = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 500 }); // 500 = headroom; TODO(pagination) if shelves approach this
       if (all && typeof all === "object" && "results" in all && Array.isArray(all.results)) {
+        indexed = true;
         for (const r of all.results) {
           if (!r || typeof r !== "object" || !("id" in r) || typeof r.id !== "string") continue;
           const tags = "tags" in r && Array.isArray(r.tags) ? r.tags : [];
           const named = tags.find((t): t is string => typeof t === "string" && t.startsWith(`${SKILL_PASSAGE_TAG}:`));
           const name = named ? named.slice(SKILL_PASSAGE_TAG.length + 1) : "";
-          if (name && !live.has(name)) await del(r.id, { agent_id: agentId });
+          if (!name) continue;
+          const arr = index.get(name) ?? [];
+          arr.push({ id: r.id, text: passageText(r) });
+          index.set(name, arr);
         }
+      }
+    } catch { /* index unavailable → fall through; entries degrade to create-only below */ }
+  }
+
+  for (const m of entries) {
+    try {
+      const prior = indexed ? (index.get(m.name) ?? []) : [];
+      const skip = indexed && !!del && prior.length === 1 && prior[0].text === m.text; // unchanged → zero round-trips
+      if (!skip && del) { for (const p of prior) await del(p.id, { agent_id: agentId }); }
+      if (!skip) await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
+      if (!isCanaryName(m.name)) synced++; // canaries are calibration plumbing, not shelf state
+    } catch { /* best-effort per skill — a failed sync never blocks the lifecycle */ }
+  }
+
+  // Reconcile removals from the SAME index (no second sweep): the shelf is the source of truth.
+  if (del && indexed) {
+    try {
+      const live = new Set<string>([...managed.map((m) => m.name), ...SKILL_CANARY_NAMES]);
+      for (const [name, ps] of index) {
+        if (live.has(name)) continue;
+        for (const p of ps) await del(p.id, { agent_id: agentId });
       }
     } catch { /* best-effort — reconciliation failure never blocks the lifecycle */ }
   }

--- a/packages/muscle-memory/mods/engram.ts
+++ b/packages/muscle-memory/mods/engram.ts
@@ -293,6 +293,21 @@ export function nativeEnabled(channel: string): boolean {
 }
 
 
+
+// Review concern #7 (2026-07-06): if MM_NATIVE=passages is enabled but the SDK client exposes no
+// passages surface (renamed/restructured API), every semantic function silently no-ops and routing
+// falls back to lexical with NO signal that hybrid is broken. The fallback itself is correct and
+// safe — the silence is the bug. Warn exactly ONCE per process so the operator learns semantic is
+// off; behavior is otherwise byte-identical to the silent path.
+let warnedMissingPassagesSurface = false;
+/** Test hook: reset the once-per-process missing-surface warning latch. */
+export function resetMissingPassagesSurfaceWarning(): void { warnedMissingPassagesSurface = false; }
+function warnMissingPassagesSurface(which: string): void {
+  if (warnedMissingPassagesSurface) return;
+  warnedMissingPassagesSurface = true;
+  try { console.warn(`muscle-memory: MM_NATIVE=passages is enabled but the client has no agents.passages.${which} surface — semantic routing/sync is disabled; falling back to lexical-only (no behavior change, but hybrid routing is NOT active).`); } catch { /* signal is best-effort */ }
+}
+
 // Walk a nested path on an unknown SDK client with typeof narrowing — no fabricated object shape,
 // no inline cast-to-read. Returns the verified callable at the end of the path, BOUND to its
 // receiver, or null. The binding is load-bearing: SDK resource methods (letta-client APIResource)
@@ -420,7 +435,7 @@ export function calibrateSkillHits(raw: SemanticSkillHit[], k: number): Semantic
 export async function semanticSkillCandidates(client: unknown, agentId: string | null | undefined, query: string, k = 3): Promise<SemanticSkillHit[]> {
   if (!agentId || !nativeEnabled("passages") || !query.trim()) return [];
   const search = reachFn(client, ["agents", "passages", "search"]); // client.agents.passages.search(agentId, params)
-  if (!search) return [];
+  if (!search) { warnMissingPassagesSurface("search"); return []; }
   try {
     const resp = await search(agentId, { query: query.slice(0, 4000), tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: k + SKILL_CANARY_NAMES.length });
     return calibrateSkillHits(parseSkillHits(resp), k);
@@ -449,7 +464,7 @@ export async function syncSkillPassages(client: unknown, agentId: string | null 
   const search = reachFn(client, ["agents", "passages", "search"]);
   const create = reachFn(client, ["agents", "passages", "create"]);
   const del = reachFn(client, ["agents", "passages", "delete"]);
-  if (!create) return 0;
+  if (!create) { warnMissingPassagesSurface("create"); return 0; }
   let synced = 0;
   const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
 

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -1960,6 +1960,15 @@ function buildNeocortexBlock(managed, opts = {}) {
 function nativeEnabled(channel) {
   return (process.env.MM_NATIVE ?? "").split(/[,\s]+/).filter(Boolean).includes(channel);
 }
+var warnedMissingPassagesSurface = false;
+function warnMissingPassagesSurface(which) {
+  if (warnedMissingPassagesSurface)
+    return;
+  warnedMissingPassagesSurface = true;
+  try {
+    console.warn(`muscle-memory: MM_NATIVE=passages is enabled but the client has no agents.passages.${which} surface — semantic routing/sync is disabled; falling back to lexical-only (no behavior change, but hybrid routing is NOT active).`);
+  } catch {}
+}
 function reachFn(root, path) {
   let cur = root;
   let receiver = null;
@@ -2032,8 +2041,10 @@ async function semanticSkillCandidates(client, agentId, query, k = 3) {
   if (!agentId || !nativeEnabled("passages") || !query.trim())
     return [];
   const search = reachFn(client, ["agents", "passages", "search"]);
-  if (!search)
+  if (!search) {
+    warnMissingPassagesSurface("search");
     return [];
+  }
   try {
     const resp = await search(agentId, { query: query.slice(0, 4000), tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: k + SKILL_CANARY_NAMES.length });
     return calibrateSkillHits(parseSkillHits(resp), k);
@@ -2056,8 +2067,10 @@ async function syncSkillPassages(client, agentId, managed) {
   const search = reachFn(client, ["agents", "passages", "search"]);
   const create = reachFn(client, ["agents", "passages", "create"]);
   const del = reachFn(client, ["agents", "passages", "delete"]);
-  if (!create)
+  if (!create) {
+    warnMissingPassagesSurface("create");
     return 0;
+  }
   let synced = 0;
   const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
   const index = new Map;

--- a/packages/muscle-memory/mods/index.bundled.mjs
+++ b/packages/muscle-memory/mods/index.bundled.mjs
@@ -2060,20 +2060,35 @@ async function syncSkillPassages(client, agentId, managed) {
     return 0;
   let synced = 0;
   const entries = [...managed.map((m) => ({ name: m.name, text: skillPassageText(m.name, m.description) })), ...canaryPassages()];
+  const index = new Map;
+  let indexed = false;
+  if (search) {
+    try {
+      const all = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 500 });
+      if (all && typeof all === "object" && "results" in all && Array.isArray(all.results)) {
+        indexed = true;
+        for (const r of all.results) {
+          if (!r || typeof r !== "object" || !("id" in r) || typeof r.id !== "string")
+            continue;
+          const tags = "tags" in r && Array.isArray(r.tags) ? r.tags : [];
+          const named = tags.find((t) => typeof t === "string" && t.startsWith(`${SKILL_PASSAGE_TAG}:`));
+          const name = named ? named.slice(SKILL_PASSAGE_TAG.length + 1) : "";
+          if (!name)
+            continue;
+          const arr = index.get(name) ?? [];
+          arr.push({ id: r.id, text: passageText(r) });
+          index.set(name, arr);
+        }
+      }
+    } catch {}
+  }
   for (const m of entries) {
     try {
-      let skip = false;
-      if (search && del) {
-        const prior = await search(agentId, { query: m.name, tags: [skillPassageTag(m.name)], tag_match_mode: "all", top_k: 5 });
-        if (prior && typeof prior === "object" && "results" in prior && Array.isArray(prior.results)) {
-          skip = prior.results.length === 1 && passageText(prior.results[0]) === m.text;
-          if (!skip) {
-            for (const r of prior.results) {
-              if (r && typeof r === "object" && "id" in r && typeof r.id === "string")
-                await del(r.id, { agent_id: agentId });
-            }
-          }
-        }
+      const prior = indexed ? index.get(m.name) ?? [] : [];
+      const skip = indexed && !!del && prior.length === 1 && prior[0].text === m.text;
+      if (!skip && del) {
+        for (const p of prior)
+          await del(p.id, { agent_id: agentId });
       }
       if (!skip)
         await create(agentId, { text: m.text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(m.name)] });
@@ -2081,20 +2096,14 @@ async function syncSkillPassages(client, agentId, managed) {
         synced++;
     } catch {}
   }
-  if (search && del) {
+  if (del && indexed) {
     try {
       const live = new Set([...managed.map((m) => m.name), ...SKILL_CANARY_NAMES]);
-      const all = await search(agentId, { query: SKILL_PASSAGE_TAG, tags: [SKILL_PASSAGE_TAG], tag_match_mode: "all", top_k: 500 });
-      if (all && typeof all === "object" && "results" in all && Array.isArray(all.results)) {
-        for (const r of all.results) {
-          if (!r || typeof r !== "object" || !("id" in r) || typeof r.id !== "string")
-            continue;
-          const tags = "tags" in r && Array.isArray(r.tags) ? r.tags : [];
-          const named = tags.find((t) => typeof t === "string" && t.startsWith(`${SKILL_PASSAGE_TAG}:`));
-          const name = named ? named.slice(SKILL_PASSAGE_TAG.length + 1) : "";
-          if (name && !live.has(name))
-            await del(r.id, { agent_id: agentId });
-        }
+      for (const [name, ps] of index) {
+        if (live.has(name))
+          continue;
+        for (const p of ps)
+          await del(p.id, { agent_id: agentId });
       }
     } catch {}
   }

--- a/packages/muscle-memory/package.json
+++ b/packages/muscle-memory/package.json
@@ -33,7 +33,8 @@
     "transpile": "bun build mods/index.ts --target node --outfile /tmp/muscle-memory.build.js",
     "prepublishOnly": "npm run build",
     "eval:routing": "bun test/routing.eval.ts",
-    "verify": "npm run build && npm run test && npm run eval:routing"
+    "verify": "npm run build && npm run verify:bundle && npm run test && npm run eval:routing",
+    "verify:bundle": "bun build mods/index.ts --target node --outfile /tmp/mm-bundle-drift-check.mjs && cmp -s /tmp/mm-bundle-drift-check.mjs mods/index.bundled.mjs && echo 'bundle matches source' || (echo 'BUNDLE DRIFT: mods/index.bundled.mjs does not match source — run npm run build and commit the bundle' && exit 1)"
   },
   "engines": {
     "node": ">=20"

--- a/packages/muscle-memory/test/semantic-routing.test.ts
+++ b/packages/muscle-memory/test/semantic-routing.test.ts
@@ -13,7 +13,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applySemanticEvidence, pickUpdateTarget, reviewAndAuthor, routeSkill, SEMANTIC_RANK_BONUS } from "../mods/autopilot";
-import { calibrateSkillHits, canaryPassages, parseSkillHits, semanticSkillCandidates, skillPassageTag, skillPassageText, syncSkillPassages, SKILL_CANARY_NAMES, SKILL_PASSAGE_TAG } from "../mods/engram";
+import { calibrateSkillHits, canaryPassages, parseSkillHits, resetMissingPassagesSurfaceWarning, semanticSkillCandidates, skillPassageTag, skillPassageText, syncSkillPassages, SKILL_CANARY_NAMES, SKILL_PASSAGE_TAG } from "../mods/engram";
 
 type Match = { name: string; description: string; dir: string; score: number; matched: number };
 const M = (name: string, score: number, matched: number): Match => ({ name, description: `desc of ${name}`, dir: "/tmp", score, matched });
@@ -291,6 +291,31 @@ test("semanticSkillCandidates: over-fetches top_k = k + canary count and returns
       { name: "merely-nearest", rank: 1, aboveCanary: false }, // dense re-rank after the canary was stripped
     ]);
   } finally {
+    if (prev === undefined) delete process.env.MM_NATIVE; else process.env.MM_NATIVE = prev;
+  }
+});
+
+test("review concern #7: MM_NATIVE=passages with NO passages surface warns ONCE — never silently", async () => {
+  const warns: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...a: unknown[]) => { warns.push(a.map(String).join(" ")); };
+  const prev = process.env.MM_NATIVE;
+  try {
+    // gated off → no warning (nothing is broken; the channel is simply not enabled)
+    delete process.env.MM_NATIVE;
+    resetMissingPassagesSurfaceWarning();
+    expect(await semanticSkillCandidates({}, "agent-1", "q")).toEqual([]);
+    expect(warns.length).toBe(0);
+    // enabled but the client has no passages surface → exactly ONE signal, behavior unchanged
+    process.env.MM_NATIVE = "passages";
+    expect(await semanticSkillCandidates({}, "agent-1", "query")).toEqual([]);      // still lexical-safe
+    expect(await syncSkillPassages({}, "agent-1", [{ name: "a-skill", description: "d" }])).toBe(0);
+    expect(await semanticSkillCandidates({}, "agent-1", "again")).toEqual([]);
+    expect(warns.length).toBe(1);                                                   // once, not spam
+    expect(warns[0]).toContain("MM_NATIVE=passages");
+    expect(warns[0]).toContain("lexical");
+  } finally {
+    console.warn = origWarn;
     if (prev === undefined) delete process.env.MM_NATIVE; else process.env.MM_NATIVE = prev;
   }
 });

--- a/packages/muscle-memory/test/semantic-routing.test.ts
+++ b/packages/muscle-memory/test/semantic-routing.test.ts
@@ -13,7 +13,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applySemanticEvidence, pickUpdateTarget, reviewAndAuthor, routeSkill, SEMANTIC_RANK_BONUS } from "../mods/autopilot";
-import { calibrateSkillHits, parseSkillHits, semanticSkillCandidates, skillPassageTag, skillPassageText, syncSkillPassages, SKILL_CANARY_NAMES, SKILL_PASSAGE_TAG } from "../mods/engram";
+import { calibrateSkillHits, canaryPassages, parseSkillHits, semanticSkillCandidates, skillPassageTag, skillPassageText, syncSkillPassages, SKILL_CANARY_NAMES, SKILL_PASSAGE_TAG } from "../mods/engram";
 
 type Match = { name: string; description: string; dir: string; score: number; matched: number };
 const M = (name: string, score: number, matched: number): Match => ({ name, description: `desc of ${name}`, dir: "/tmp", score, matched });
@@ -135,12 +135,13 @@ test("semanticSkillCandidates + syncSkillPassages: gated off without MM_NATIVE=p
     expect(hits).toEqual([{ name: "a-skill", rank: 0 }]);
     calls.length = 0;
     expect(await syncSkillPassages(client, "agent-1", [{ name: "a-skill", description: "does the thing" }])).toBe(1); // canaries excluded from the count
-    // upsert per entry (stale removed first), managed skill first, then the two canary reference
-    // passages — plus ONE trailing reconciliation search (its only hit, a-skill, is live → no delete).
-    expect(calls.map((c) => c.op)).toEqual(["search", "delete", "create", "search", "delete", "create", "search", "delete", "create", "search"]);
+    // BATCHED contract (review follow-up): ONE global index search up front, then only the
+    // writes that are needed — stale a-skill passage removed + recreated, two canaries created
+    // (no priors). Reconciliation reuses the same index: zero extra searches.
+    expect(calls.map((c) => c.op)).toEqual(["search", "delete", "create", "create", "create"]);
     const created = calls[2].args[1];
     expect(created && typeof created === "object" && "text" in created ? created.text : "").toBe(skillPassageText("a-skill", "does the thing"));
-    const canaryCreate = calls[5].args[1];
+    const canaryCreate = calls[3].args[1];
     expect(canaryCreate && typeof canaryCreate === "object" && "tags" in canaryCreate ? canaryCreate.tags : []).toEqual([SKILL_PASSAGE_TAG, skillPassageTag(SKILL_CANARY_NAMES[0])]);
   } finally {
     if (prev === undefined) delete process.env.MM_NATIVE; else process.env.MM_NATIVE = prev;
@@ -153,21 +154,14 @@ test("sync hygiene: unchanged skills skip the round-trip; removed skills get rec
   const client = { agents: { passages: {
     search: (...args: unknown[]) => {
       calls.push({ op: "search", args });
-      const params = args[1] as { tags?: string[] };
-      const tags = params?.tags ?? [];
-      // per-skill lookup for the kept skill: exactly one prior passage, byte-identical text → skip
-      if (tags[0] === skillPassageTag("kept-skill")) {
-        return Promise.resolve({ results: [{ id: "k1", text: keptText, tags: [SKILL_PASSAGE_TAG, skillPassageTag("kept-skill")] }] });
-      }
-      // reconciliation sweep (bare mm:skill tag): live skill + a ghost + a canary
-      if (tags.length === 1 && tags[0] === SKILL_PASSAGE_TAG) {
-        return Promise.resolve({ results: [
-          { id: "k1", tags: [SKILL_PASSAGE_TAG, skillPassageTag("kept-skill")] },
-          { id: "g1", tags: [SKILL_PASSAGE_TAG, skillPassageTag("ghost-skill")] },   // deleted skill's leftover
-          { id: "c1", tags: [SKILL_PASSAGE_TAG, skillPassageTag(SKILL_CANARY_NAMES[0])] },
-        ] });
-      }
-      return Promise.resolve({ results: [] }); // canary per-entry lookups: nothing prior
+      // BATCHED contract: one global index search serves everything. Results carry tags + text
+      // (as the real API does): the kept skill (byte-identical → skip), a ghost (reconciled),
+      // and canary #0 with its true text (unchanged → skip; canary #1 absent → created).
+      return Promise.resolve({ results: [
+        { id: "k1", text: keptText, tags: [SKILL_PASSAGE_TAG, skillPassageTag("kept-skill")] },
+        { id: "g1", text: "leftover", tags: [SKILL_PASSAGE_TAG, skillPassageTag("ghost-skill")] },
+        { id: "c1", text: canaryPassages()[0].text, tags: [SKILL_PASSAGE_TAG, skillPassageTag(SKILL_CANARY_NAMES[0])] },
+      ] });
     },
     create: (...args: unknown[]) => { calls.push({ op: "create", args }); return Promise.resolve([]); },
     delete: (...args: unknown[]) => { calls.push({ op: "delete", args }); return Promise.resolve({}); },
@@ -180,7 +174,7 @@ test("sync hygiene: unchanged skills skip the round-trip; removed skills get rec
     const deletes = calls.filter((c) => c.op === "delete").map((c) => c.args[0]);
     expect(deletes).toEqual(["g1"]); // ONLY the ghost — kept skill skipped, canary immune
     const creates = calls.filter((c) => c.op === "create");
-    expect(creates.length).toBe(2); // the two canaries; kept-skill's round-trip was skipped entirely
+    expect(creates.length).toBe(1); // only canary #1 (absent); kept-skill AND canary #0 skipped — total API calls: 1 search + 1 delete + 1 create
     for (const c of creates) {
       const body = c.args[1] as { tags?: string[] };
       expect((body.tags ?? []).some((t) => t.includes("mm-canary-"))).toBe(true);


### PR DESCRIPTION
## Summary
- batch managed-skill and canary passage lookup into one index sweep, then reuse it for stale-passage reconciliation
- make package verification fail when the shipped bundle drifts from source
- document when the live canary benchmark must be rerun after embedding-model changes

Follow-up to #45 covering the non-blocking operational notes without expanding routing behavior.

## Test plan
- [x] `npm run verify` — 98 tests passed
- [x] routing decision quality remains 16/16
- [x] source and bundled artifact match
- [x] `npm pack --dry-run --json` contains the intended 15-file distributable surface
- [x] public identity scan contains no private company references

👾 Generated with [Letta Code](https://letta.com)