### PR TITLE
Add code outline enforce

### DIFF
--- a/packages/code-outline-enforce/MOD.md
+++ b/packages/code-outline-enforce/MOD.md
@@ -1,0 +1,77 @@
+---
+name: "@letta-ai/code-outline-enforce"
+description: "Permission overlay + outline tool that forces agents to structure large code files before reading them."
+---
+
+# Code-Outline Enforce mod semantics
+
+## When to use
+
+Use this mod when working with large source code files where full-file reads waste context tokens. The mod is especially valuable in codebases with files over 500 lines where an agent might otherwise read entire files to find a single function or class.
+
+This package provides a permission overlay and a model-callable outline tool. The overlay blocks `Read` on large code files unless offset/limit is specified, and auto-injects the outline into the denial message. The `code_outline` tool is available for explicit use.
+
+## Behavioral contract
+
+When a `Read` call on a code file is denied, the agent should:
+
+1. Read the auto-injected outline from the denial reason.
+2. Use `Read` with offset/limit to target specific sections identified in the outline.
+3. Optionally call `code_outline` directly on files that haven't been blocked yet.
+
+The agent should never attempt to bypass the permission overlay by reading without offset/limit on files above the threshold.
+
+## Tools
+
+### `code_outline`
+
+Model-callable structural outline tool. Accepts a `file_path` parameter and returns functions, classes, methods, and other structural elements with line numbers.
+
+Backends tried in order:
+- Python `ast` for `.py` files (accurate start+end lines)
+- Universal Ctags (optional, 50+ languages)
+- Regex patterns (25+ languages, zero dependencies)
+- Fallback (line count + first 15 lines)
+
+## Permission invariants
+
+The permission overlay:
+
+- **Blocks** `Read`-family tools (Read, read_file, ReadFile, ReadFileGemini, ReadLSP, ReadFileCodex) on code files (extensions listed in CODE_EXTS) above LINE_THRESHOLD (default 500) or BYTE_THRESHOLD (default 512 KB) when:
+  - No offset or limit is provided (blind full-file read)
+  - A tiny unanchored limit (< MIN_UNANCHORED_LIMIT, default 50) is provided without an offset (sequential crawl from the top)
+- **Allows** reads with a valid positive offset (anchored to an outline location) even with a small limit — the agent knows where it's going.
+- **Allows** unanchored reads with limit >= MIN_UNANCHORED_LIMIT.
+- **Allows** reads on files below both thresholds.
+- **Allows** reads on memory files (`.letta/.../memory/`).
+- **Resolves relative paths** against the event's `workingDirectory` or `cwd`.
+- **Auto-injects** a capped outline (max 40 entries, 3000 chars) into the denial reason. Truncated outlines include a hint directing the agent to use the shown symbols for targeted reads. The overlay uses regex/fallback only (start lines, no end ranges) — it must work synchronously with zero external dependencies. The explicit `code_outline` tool additionally uses Python AST and ctags for end ranges.
+- **Caches** outline results by resolved path + mtime + size for performance (max 100 entries).
+
+## Supported languages (regex backend, zero dependencies)
+
+Python, JavaScript, TypeScript, Go, Rust, C, C++, Java, C#, Ruby, PHP, Swift, Kotlin, Scala, Lua, HTML, CSS/SCSS, Shell, PowerShell, SQL, Dart, Vue, Svelte, Dockerfile.
+
+Python regex patterns cover `class`, `def`, and `async def`. For accurate start+end lines, the `code_outline` tool prefers Python AST when available.
+
+## Configuration
+
+No persistent state. Configuration via environment variables (values clamped to minimum 1):
+
+- `LETTA_OUTLINE_THRESHOLD` — line count threshold (default: 500)
+- `LETTA_OUTLINE_BYTE_THRESHOLD` — byte size backstop for minified files (default: 524288 / 512 KB)
+- `LETTA_OUTLINE_MIN_UNANCHORED_LIMIT` — minimum limit for unanchored reads without offset (default: 50)
+
+## Outline capping
+
+All outline output — including denial auto-injections and explicit `code_outline` results — is capped at 40 entries and 3000 characters. This prevents the very token blowback the mod is designed to solve. When either limit is hit, the outline is truncated and a hint directs the agent to use the shown symbols to choose a targeted Read range.
+
+Fallback output (first 15 lines) is also character-capped, with individual lines truncated at 200 characters before joining.
+
+## Adaptation notes for agents
+
+- Do not import Letta Code internals. Use the public mod API and Node built-ins.
+- The permission check is synchronous and uses `readFileSync` — keep it fast.
+- The regex patterns are line-by-line. Multi-line signatures or deeply nested structures may be missed.
+- For Python files, the `ast` backend gives the most accurate results (start+end lines). For all other languages, regex gives start lines only.
+- The `code_outline` tool and the permission overlay share the same regex patterns — they are always in sync.

--- a/packages/code-outline-enforce/README.md
+++ b/packages/code-outline-enforce/README.md
@@ -1,0 +1,106 @@
+# Code-Outline Enforcement Mod
+
+**The Problem**
+Agents waste context by reading entire large source files when they only need a few functions. A 5,000-line file burns ~15k tokens in a single Read call. System prompt reminders like "use code-outline first" don't work — the agent ignores them.
+
+**The Solution**
+Structural enforcement, not advisory. Two parts:
+
+**1. Permission Overlay (the gate)**
+Blocks Read-family tools (Read, read_file, ReadFile, ReadFileGemini, ReadLSP, ReadFileCodex) on code files over 500 lines (configurable) or 512 KB in two cases:
+
+- **No offset/limit at all** — agent would read the entire file blind
+- **Tiny unanchored limit (< 50 lines, no offset)** — agent would crawl from the top in small slices
+
+With a valid offset (anchored to an outline location), even a small limit is allowed — the agent knows where it's going. Larger unanchored limits (>= 50) are also allowed for direct access to known sections.
+
+When a read is blocked, a **capped outline** (max 40 entries, 3000 chars) is auto-injected into the denial message — the agent gets the structure immediately without needing to call `code_outline` separately. Relative paths are resolved against the event's working directory.
+
+Uses `letta.permissions.register`, not `tool_start`. Runs before the approval UI so the user never sees a confusing prompt for a denied tool.
+
+**2. Mod Tool: `code_outline` (the outline)**
+Gives the agent a structural outline (functions, classes, methods with line numbers) so it knows where to target its reads. Four backends tried in order:
+
+- **Python ast** — accurate start+end lines for `.py` files (requires Python, usually already installed)
+- **Ctags** (optional) — 50+ languages, best accuracy
+- **Regex patterns** — zero-dependency, covers 25+ languages
+- **Fallback** — line count + first 15 lines
+
+**No dependencies required.** Works out of the box. Python and ctags are optional enhancements.
+
+The permission overlay uses **regex/fallback only** (start lines, no end ranges) for its auto-injected denial outlines — it must work synchronously with zero external dependencies. The explicit `code_outline` tool uses all four backends including AST and ctags.
+
+## Supported Languages (zero dependencies)
+
+| Language | Extensions | What it outlines |
+|---|---|---|
+| Python | `.py` | classes, functions (start+end lines via ast) |
+| JavaScript | `.js`, `.jsx`, `.mjs`, `.cjs` | functions, classes, interfaces, arrow functions, methods |
+| TypeScript | `.ts`, `.tsx` | functions, classes, interfaces, enums, type aliases, methods |
+| Go | `.go` | functions, structs, interfaces, type aliases |
+| Rust | `.rs` | functions, structs, enums, traits, impl blocks, consts |
+| C | `.c`, `.h` | functions, structs, enums, macros |
+| C++ | `.cpp`, `.cc`, `.hpp` | functions, classes, enums, templates, macros |
+| Java | `.java` | classes, interfaces, enums, methods, fields |
+| C# | `.cs` | classes, interfaces, structs, enums, methods, fields |
+| Ruby | `.rb` | methods, classes, modules, attributes |
+| PHP | `.php` | functions, classes, interfaces, traits, consts |
+| Swift | `.swift` | functions, classes, structs, enums, protocols, vars |
+| Kotlin | `.kt` | functions, classes, interfaces, objects, properties |
+| Scala | `.scala` | functions, classes, traits, objects, vals |
+| Lua | `.lua` | functions, methods, tables |
+| **HTML** | `.html`, `.htm` | structural tags (section, nav, etc.), elements with IDs, comments, script/style blocks |
+| **CSS** | `.css`, `.less` | at-rules (@media, @keyframes), rulesets, comment sections |
+| **SCSS/Sass** | `.scss`, `.sass` | at-rules (@mixin, @include), rulesets, comment sections |
+| **Shell** | `.sh`, `.bash`, `.zsh` | functions, comment sections |
+| **PowerShell** | `.ps1`, `.psm1` | functions, classes, enums, filters, comment sections |
+| **SQL** | `.sql` | CREATE/ALTER/DROP statements, INSERT INTO, SELECT...FROM, comment sections |
+| **Dart** | `.dart` | classes, enums, mixins, typedefs, functions, getters, setters, comment sections |
+| **Vue** | `.vue` | template/script/style blocks, comment sections |
+| **Svelte** | `.svelte` | script/style blocks, comment sections |
+| **Dockerfile** | `Dockerfile`, `Dockerfile.*` | FROM, RUN, CMD, ENTRYPOINT, COPY, ADD, ENV, ARG, WORKDIR, EXPOSE, etc. |
+
+### Optional enhancements
+
+| Tool | What it adds | Install |
+|---|---|---|
+| Python | Accurate start+end lines for `.py` files (vs. just start lines) | Usually pre-installed |
+| Universal Ctags | 50+ language coverage with better accuracy | `winget install UniversalCtags.Ctags` / `brew install universal-ctags` / `apt install universal-ctags` |
+
+## How It Works
+
+```
+Agent: [Read on camera_panel.py — 5,958 lines]
+Mod: DENIED. "File has 5958 lines. Outline:
+  L137: class VolumeControl
+  L245: class MainVideoView
+  L2826: class CameraPanel
+  ... (90+ methods)
+
+Use Read with offset/limit for targeted reads (offset for anchored reads, or limit >= 50 without offset)."
+Agent: [Read with offset=2838, limit=260]
+Mod: ALLOWED
+```
+
+The outline is auto-injected into the denial. The agent reads exactly the 260 lines it needs. (The example shows regex/fallback output with start-only lines; the explicit `code_outline` tool additionally produces end ranges via Python AST or ctags.)
+
+## Installation
+
+### Standalone mod file
+1. Copy `mods/index.mjs` to `~/.letta/mods/code-outline-enforce.mjs`
+2. Run `/reload`
+
+### As a package (via letta-ai/mods repo)
+```
+letta install npm:@letta-ai/code-outline-enforce
+/reload
+```
+
+### Recovery
+
+If the mod blocks a read you need to perform, provide a positive `offset` for an anchored read, or an unanchored `limit` at or above the configured minimum (default 50). If the mod prevents Letta from loading entirely, start with `letta --no-mods` or set `LETTA_DISABLE_MODS=1` in your environment.
+
+### Configuration
+- `LETTA_OUTLINE_THRESHOLD` — line count threshold (default: 500)
+- `LETTA_OUTLINE_BYTE_THRESHOLD` — byte size backstop for minified files (default: 524288 / 512 KB)
+- `LETTA_OUTLINE_MIN_UNANCHORED_LIMIT` — minimum limit for unanchored reads without offset (default: 50). Prevents the "crawl 15 lines at a time" pattern.

--- a/packages/code-outline-enforce/mods/index.mjs
+++ b/packages/code-outline-enforce/mods/index.mjs
@@ -1,0 +1,778 @@
+/**
+ * Code-Outline Enforcement Mod v4
+ *
+ * Two capabilities:
+ * 1. Permission overlay: blocks large reads on code files without offset/limit
+ * 2. Mod tool "code_outline": multi-language structural outline
+ *
+ * Outline backends (tried in order):
+ *   - Python ast for .py files (accurate start+end lines, requires Python)
+ *   - Universal Ctags for 50+ languages (start line only, optional)
+ *   - Regex patterns for 25+ languages (start line only, zero dependencies)
+ *   - Fallback: line count + first 15 lines
+ *
+ * For installation, configuration, and supported-language tables see README.md.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// --- Configuration (validated) ---
+
+const LINE_THRESHOLD = Math.max(1, parseInt(process.env.LETTA_OUTLINE_THRESHOLD)) || 500;
+const BYTE_THRESHOLD = Math.max(1, parseInt(process.env.LETTA_OUTLINE_BYTE_THRESHOLD)) || 512 * 1024; // 512 KiB
+const MAX_OUTLINE_ENTRIES = 40;
+const MAX_OUTLINE_CHARS = 3000;
+const MIN_UNANCHORED_LIMIT = Math.max(1, parseInt(process.env.LETTA_OUTLINE_MIN_UNANCHORED_LIMIT)) || 50;
+
+// --- Read-tool family normalization ---
+
+/**
+ * Normalize a tool name by stripping non-alphanumeric characters and lowercasing.
+ * This handles Read, read_file, ReadFile, ReadFileGemini, read-file, ReadLSP,
+ * ReadFileCodex, and any other variant the runtime may produce.
+ */
+const normalizeToolName = (name) =>
+  String(name).replace(/[^a-z0-9]/gi, "").toLowerCase();
+
+const READ_TOOL_NAMES = new Set([
+  "read",
+  "readfile",
+  "readfilegemini",
+  "readfilecodex",
+  "readlsp",
+]);
+
+// --- Supported code file extensions ---
+
+const CODE_EXTS = new Set([
+  ".py", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx",
+  ".go", ".rs", ".c", ".cpp", ".cc", ".h", ".hpp",
+  ".java", ".cs", ".rb", ".php", ".swift", ".kt", ".scala", ".lua",
+  ".html", ".htm", ".css", ".scss", ".sass", ".less",
+  ".sh", ".bash", ".zsh", ".ps1", ".psm1",
+  ".sql", ".dart", ".vue", ".svelte",
+  "dockerfile",
+]);
+
+// --- Caches ---
+
+let ctagsPath = null;
+let pythonExe = null;
+
+// Outline cache: map<resolvedPath_mtime_size, { outline, lineCount, bytes }>
+const outlineCache = new Map();
+const OUTLINE_CACHE_MAX = 100;
+
+// --- Regex outline patterns (zero dependencies) ---
+
+const CONTROL_FLOW = new Set([
+  "if", "for", "while", "switch", "catch", "return",
+  "else", "do", "try", "finally", "throw", "assert",
+]);
+const isControlFlow = (name) => CONTROL_FLOW.has(name);
+
+const REGEX_PATTERNS = {
+  ".py": [
+    [/^\s*(?:class)\s+(\w+)/, "class"],
+    [/^\s*(?:async\s+)?def\s+(\w+)/, "def"],
+  ],
+  ".js": [
+    [/^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+(\w+)/, "function"],
+    [/^\s*(?:export\s+)?(?:default\s+)?class\s+(\w+)/, "class"],
+    [/^\s*(?:export\s+)?interface\s+(\w+)/, "interface"],
+    [/^\s*(?:export\s+)?enum\s+(\w+)/, "enum"],
+    [/^\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(?[^=]*=>/, "arrowFn"],
+    [/^\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*function/, "function"],
+    [/^\s*(?:static\s+)?(?:async\s+)?(\w+)\s*\([^)]*\)\s*\{/, "method", true],
+  ],
+  ".jsx": null,
+  ".mjs": null,
+  ".cjs": null,
+  ".ts": [
+    [/^\s*(?:export\s+)?(?:default\s+)?(?:abstract\s+)?(?:async\s+)?function\s+(\w+)/, "function"],
+    [/^\s*(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+(\w+)/, "class"],
+    [/^\s*(?:export\s+)?interface\s+(\w+)/, "interface"],
+    [/^\s*(?:export\s+)?enum\s+(\w+)/, "enum"],
+    [/^\s*(?:export\s+)?type\s+(\w+)\s*=/, "type"],
+    [/^\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(?[^=]*=>/, "arrowFn"],
+    [/^\s*(?:static\s+)?(?:async\s+)?(?:get\s+|set\s+)?(\w+)\s*\([^)]*\)\s*[:{]/, "method", true],
+  ],
+  ".tsx": null,
+
+  ".go": [
+    [/^\s*func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(/, "func"],
+    [/^\s*type\s+(\w+)\s+struct/, "struct"],
+    [/^\s*type\s+(\w+)\s+interface/, "interface"],
+    [/^\s*type\s+(\w+)\s+func/, "type"],
+    [/^\s*var\s+(\w+)\s*=\s*func/, "varFunc"],
+  ],
+
+  ".rs": [
+    [/^\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/, "fn"],
+    [/^\s*(?:pub\s+)?struct\s+(\w+)/, "struct"],
+    [/^\s*(?:pub\s+)?enum\s+(\w+)/, "enum"],
+    [/^\s*(?:pub\s+)?trait\s+(\w+)/, "trait"],
+    [/^\s*impl\s+(?:<[^>]*>\s+)?(\w+)/, "impl"],
+    [/^\s*(?:pub\s+)?(?:const|static)\s+(\w+)/, "const"],
+  ],
+
+  ".c": [
+    [/^\s*(?:static\s+)?(?:inline\s+)?[\w\s\*]+?\s+(\w+)\s*\([^)]*\)\s*\{/, "function", true],
+    [/^\s*(?:typedef\s+)?struct\s+(\w+)/, "struct"],
+    [/^\s*(?:typedef\s+)?enum\s+(\w+)/, "enum"],
+    [/^\s*#define\s+(\w+)/, "macro"],
+  ],
+  ".cpp": [
+    [/^\s*(?:static\s+)?(?:inline\s+)?(?:virtual\s+)?[\w\s\*&:]+?\s+(\w+)\s*\([^)]*\)\s*(?:const\s*)?(?:override\s*)?\{/, "function", true],
+    [/^\s*(?:class|struct)\s+(\w+)/, "class"],
+    [/^\s*(?:typedef\s+)?enum\s+(?:class\s+)?(\w+)/, "enum"],
+    [/^\s*template\s*<[^>]*>\s*[\w\s\*&:]+?\s+(\w+)\s*\(/, "template"],
+    [/^\s*#define\s+(\w+)/, "macro"],
+  ],
+  ".cc": null,
+  ".h": null,
+  ".hpp": null,
+
+  ".java": [
+    [/^\s*(?:public|private|protected|static|final|abstract|\s)*\s+(?:class|interface|enum)\s+(\w+)/, "class"],
+    [/^\s*(?:public|private|protected|static|final|abstract|synchronized|native|\s)*\s+[\w<>\[\],\s]+\s+(\w+)\s*\([^)]*\)\s*\{/, "method", true],
+    [/^\s*(?:public|private|protected|static|final|\s)*\s+[\w<>\[\],\s]+\s+(\w+)\s*=\s*[^;]+;/, "field"],
+  ],
+
+  ".cs": [
+    [/^\s*(?:public|private|protected|internal|static|sealed|abstract|partial|async|\s)*\s+(?:class|interface|struct|enum)\s+(\w+)/, "class"],
+    [/^\s*(?:public|private|protected|internal|static|async|override|virtual|abstract|sealed|\s)*\s+[\w<>\[\],\s]+\s+(\w+)\s*\([^)]*\)\s*\{/, "method", true],
+    [/^\s*(?:public|private|protected|internal|static|readonly|\s)*\s+[\w<>\[\],\s]+\s+(\w+)\s*=\s*[^;]+;/, "field"],
+  ],
+
+  ".rb": [
+    [/^\s*(?:private|protected|public)?\s*def\s+(?:self\.)?(\w+)/, "def"],
+    [/^\s*class\s+(\w+)/, "class"],
+    [/^\s*module\s+(\w+)/, "module"],
+    [/^\s*attr_(?:accessor|reader|writer)\s*:(\w+)/, "attr"],
+  ],
+
+  ".php": [
+    [/^\s*(?:public|private|protected|static|final|abstract|\s)*\s*function\s+(\w+)/, "function"],
+    [/^\s*(?:final\s+|abstract\s+)?class\s+(\w+)/, "class"],
+    [/^\s*interface\s+(\w+)/, "interface"],
+    [/^\s*trait\s+(\w+)/, "trait"],
+    [/^\s*(?:public|private|protected|static|\s)*\s+(?:const|static)\s+(\w+)/, "const"],
+  ],
+
+  ".swift": [
+    [/^\s*(?:public|private|fileprivate|internal|open|static|final|override|mutating|\s)*\s*func\s+(\w+)/, "func"],
+    [/^\s*(?:public|private|fileprivate|internal|open|final|\s)*\s*(?:class|struct|enum|protocol)\s+(\w+)/, "type"],
+    [/^\s*(?:public|private|fileprivate|internal|open|static|\s)*\s*var\s+(\w+)/, "var"],
+    [/^\s*(?:public|private|fileprivate|internal|open|static|let|\s)*\s*let\s+(\w+)/, "let"],
+  ],
+
+  ".kt": [
+    [/^\s*(?:public|private|protected|internal|open|override|operator|inline|suspend|\s)*\s*fun\s+(\w+)/, "fun"],
+    [/^\s*(?:public|private|protected|internal|final|open|abstract|data|\s)*\s*(?:class|interface|object|enum\s+class)\s+(\w+)/, "class"],
+    [/^\s*(?:public|private|protected|internal|const|\s)*\s*(?:val|var)\s+(\w+)/, "property"],
+  ],
+
+  ".scala": [
+    [/^\s*(?:private|protected|override|final|implicit|\s)*\s*def\s+(\w+)/, "def"],
+    [/^\s*(?:private|protected|final|sealed|abstract|case|\s)*\s*(?:class|trait|object|case\s+class)\s+(\w+)/, "class"],
+    [/^\s*(?:private|protected|val|var|\s)*\s*(?:val|var)\s+(\w+)/, "val"],
+  ],
+
+  ".lua": [
+    [/^\s*function\s+(\w+)/, "function"],
+    [/^\s*local\s+function\s+(\w+)/, "function"],
+    [/^\s*function\s+(\w+)\.(\w+)/, "method"],
+    [/^\s*function\s+(\w+):(\w+)/, "method"],
+    [/^\s*local\s+(\w+)\s*=\s*\{/, "table"],
+  ],
+
+  ".html": [
+    [/^\s*<!--\s*(.+?)\s*-->/, "section"],
+    [/^\s*<[a-z]+\b[^>]*\bid\s*=\s*["']([^"']+)["'][^>]*>/, "id"],
+    [/^\s*<(section|nav|header|footer|main|article|aside|template|form|table)\b[^>]*>/, "tag"],
+    [/^\s*<(script|style)\b[^>]*>/, "block"],
+  ],
+  ".htm": null,
+
+  ".css": [
+    [/^\s*@(media|keyframes|font-face|import|supports)\b/, "at-rule"],
+    [/^\s*\/\*\s*(.+?)\s*\*\//, "section"],
+    [/^\s*([.#]?[a-zA-Z][a-zA-Z0-9_-]*)\s*\{/, "rule"],
+  ],
+  ".scss": [
+    [/^\s*@(media|keyframes|font-face|import|supports|mixin|include|function)\b/, "at-rule"],
+    [/^\s*\/\/\s*(.+)$/, "comment"],
+    [/^\s*\/\*\s*(.+?)\s*\*\//, "section"],
+    [/^\s*([.#]?[a-zA-Z][a-zA-Z0-9_-]*)\s*\{/, "rule"],
+  ],
+  ".sass": null,
+  ".less": null,
+
+  ".sh": [
+    [/^\s*function\s+(\w+)\s*\(/, "function"],
+    [/^\s*(\w+)\s*\(\s*\)\s*\{/, "function"],
+    [/^\s*#\s*(.+)$/, "comment"],
+  ],
+  ".bash": null,
+  ".zsh": null,
+
+  ".ps1": [
+    [/^\s*function\s+(\w+)/, "function"],
+    [/^\s*class\s+(\w+)/, "class"],
+    [/^\s*enum\s+(\w+)/, "enum"],
+    [/^\s*filter\s+(\w+)/, "filter"],
+    [/^\s*#\s*(.+)$/, "comment"],
+  ],
+  ".psm1": null,
+
+  ".sql": [
+    [/^\s*CREATE\s+(?:TABLE|VIEW|INDEX|PROCEDURE|FUNCTION|TRIGGER)\s+(\w+)/i, "create"],
+    [/^\s*ALTER\s+(?:TABLE|VIEW|INDEX|PROCEDURE|FUNCTION)\s+(\w+)/i, "alter"],
+    [/^\s*DROP\s+(?:TABLE|VIEW|INDEX|PROCEDURE|FUNCTION)\s+(\w+)/i, "drop"],
+    [/^\s*INSERT\s+INTO\s+(\w+)/i, "insert"],
+    [/^\s*SELECT\b.*?\bFROM\s+(\w+)/is, "select"],
+    [/^\s*--\s*(.+)$/, "comment"],
+  ],
+
+  ".dart": [
+    [/^\s*(?:abstract\s+)?(?:class|enum|mixin|typedef)\s+(\w+)/, "type"],
+    [/^\s*(?:static\s+)?\w+\s+(\w+)\s*\(/, "function"],
+    [/^\s*(?:static\s+)?\w+\s+get\s+(\w+)/, "getter"],
+    [/^\s*set\s+(\w+)\s*\(/, "setter"],
+    [/^\s*\/\/\/?\s*(.+)$/, "comment"],
+  ],
+
+  ".vue": [
+    [/^\s*<template>/, "template"],
+    [/^\s*<script[^>]*>/, "script"],
+    [/^\s*<style[^>]*>/, "style"],
+    [/^\s*<!--\s*(.+?)\s*-->/, "comment"],
+  ],
+
+  ".svelte": [
+    [/^\s*<script[^>]*>/, "script"],
+    [/^\s*<style[^>]*>/, "style"],
+    [/^\s*<!--\s*(.+?)\s*-->/, "comment"],
+  ],
+
+  "dockerfile": [
+    [/^\s*(FROM)\s+\S+/, "from"],
+    [/^\s*(RUN)\s/, "run"],
+    [/^\s*(CMD)\s/, "cmd"],
+    [/^\s*(ENTRYPOINT)\s/, "entrypoint"],
+    [/^\s*(COPY)\s/, "copy"],
+    [/^\s*(ADD)\s/, "add"],
+    [/^\s*(ENV)\s/, "env"],
+    [/^\s*(ARG)\s/, "arg"],
+    [/^\s*(WORKDIR)\s/, "workdir"],
+    [/^\s*(EXPOSE)\s/, "expose"],
+    [/^\s*(VOLUME)\s/, "volume"],
+    [/^\s*(LABEL)\s/, "label"],
+    [/^\s*(HEALTHCHECK)\s/, "healthcheck"],
+    [/^\s*(SHELL)\s/, "shell"],
+  ],
+};
+
+// Extension alias map
+const EXT_ALIASES = {
+  ".jsx": ".js", ".mjs": ".js", ".cjs": ".js",
+  ".tsx": ".ts",
+  ".cc": ".cpp", ".h": ".c", ".hpp": ".cpp",
+  ".htm": ".html",
+  ".sass": ".scss",
+  ".bash": ".sh", ".zsh": ".sh",
+  ".psm1": ".ps1",
+  ".less": ".css",
+};
+
+// --- Helpers ---
+
+function n(path) {
+  return path.replace(/\\/g, "/");
+}
+
+function getExt(filePath) {
+  const normalized = n(filePath);
+  const basename = normalized.split("/").pop() || "";
+  // Dockerfile (case-insensitive, with optional .suffix)
+  if (/^dockerfile(?:\.|$)/i.test(basename)) return "dockerfile";
+  const dot = basename.lastIndexOf(".");
+  if (dot === -1) return "";
+  return basename.slice(dot).toLowerCase();
+}
+
+function getRegexPatterns(ext) {
+  let patterns = REGEX_PATTERNS[ext];
+  if (patterns === null) {
+    const base = EXT_ALIASES[ext];
+    patterns = base ? REGEX_PATTERNS[base] : null;
+  }
+  return patterns;
+}
+
+function isMemoryFile(filePath) {
+  const normalized = n(filePath);
+  return normalized.includes(".letta/") && normalized.includes("/memory/");
+}
+
+/**
+ * Resolve a possibly-relative file_path against the event's working directory.
+ * Returns absolute path or null if unable to resolve.
+ */
+function resolvePath(filePath, event) {
+  if (!filePath) return null;
+  const normalized = n(filePath);
+
+  // Already absolute (Windows drive letter or Unix root)
+  if (/^[A-Za-z]:[/\\]/i.test(normalized) || normalized.startsWith("/")) {
+    return normalized;
+  }
+
+  // Relative — resolve against workingDirectory or cwd
+  const cwd = event.workingDirectory || event.cwd || process.cwd();
+  return n(cwd).replace(/\/+$/, "") + "/" + normalized;
+}
+
+/**
+ * True when the agent provided a valid offset (anchored read).
+ * An anchored read means the agent already has a target location
+ * (e.g. from the outline) and knows where it's going.
+ *   - Positive number bypasses the block.
+ *   - 0 / null / undefined do NOT bypass (full-file read).
+ *   - Negative numbers do NOT bypass (invalid).
+ */
+function hasAnchoredOffset(args) {
+  const offset = args?.offset;
+  return typeof offset === "number" && offset > 0;
+}
+
+/**
+ * Count lines in a UTF-8 buffer by counting LF (0x0A) bytes.
+ */
+function countLinesFromBuffer(buf) {
+  let count = 1;
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] === 10) count++;
+  }
+  return count;
+}
+
+/**
+ * Shared regex outline backend.
+ * Returns an array of "L{line}: {kind} {name}" strings, or null.
+ */
+function regexOutlineLines(filePath, ext) {
+  const patterns = getRegexPatterns(ext);
+  if (!patterns) return null;
+
+  let content;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const lines = content.split("\n");
+  const tags = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    for (const [regex, kind, excludeControlFlow] of patterns) {
+      const match = lines[i].match(regex);
+      if (match) {
+        if (excludeControlFlow && isControlFlow(match[1])) continue;
+        tags.push(`  L${i + 1}: ${kind} ${match[1]}`);
+        break;
+      }
+    }
+  }
+
+  return tags.length > 0 ? tags : null;
+}
+
+/**
+ * Build outline string from raw lines, capped by entry count and total characters.
+ * Reserves room for the truncation hint so the final result stays within MAX_OUTLINE_CHARS.
+ * Also accepts a pre-built string (for fallback paths) and caps that too.
+ */
+function buildCappedOutline(outlineLines, lineCount) {
+  let result;
+  let trimmed = false;
+
+  if (Array.isArray(outlineLines)) {
+    // Cap by entry count
+    if (outlineLines.length > MAX_OUTLINE_ENTRIES) {
+      outlineLines = outlineLines.slice(0, MAX_OUTLINE_ENTRIES);
+      trimmed = true;
+    }
+    result = outlineLines.join("\n");
+  } else {
+    // Already a string (fallback output)
+    result = String(outlineLines);
+  }
+
+  // Build hint now so we know its length when capping
+  const TRUNCATION_HINT = `\n  ... (${lineCount} total lines, outline truncated — use the shown symbols to choose a targeted Read range)`;
+
+  // Character cap — reserve room for the hint if we might append it
+  if (result.length > MAX_OUTLINE_CHARS - TRUNCATION_HINT.length) {
+    const effectiveLimit = MAX_OUTLINE_CHARS - TRUNCATION_HINT.length;
+    const truncated = result.slice(0, effectiveLimit);
+    const lastNewline = truncated.lastIndexOf("\n");
+    result = lastNewline > 0 ? truncated.slice(0, lastNewline) : truncated;
+    trimmed = true;
+  }
+
+  if (trimmed) {
+    result += TRUNCATION_HINT;
+  }
+
+  return result;
+}
+
+/**
+ * Get or generate a cached outline for a file path.
+ * Reads the file once per cache miss: stats for mtime+size, reads buffer,
+ * counts lines from buffer, decodes for regex.
+ * Cache key = resolvedPath_mtime_size.
+ * Returns { outline, lineCount, bytes }.
+ */
+function getOutline(filePath, ext) {
+  // Stat once for mtime + size
+  let stat;
+  try {
+    stat = statSync(filePath);
+  } catch {
+    return { outline: null, lineCount: 0, bytes: 0 };
+  }
+
+  const cacheKey = `${filePath}_${stat.mtimeMs}_${stat.size}`;
+
+  // Cache key includes mtime and size so file changes produce a new entry
+  const cached = outlineCache.get(cacheKey);
+  if (cached) return cached;
+
+  // Read file buffer once
+  let buf;
+  try {
+    buf = readFileSync(filePath);
+  } catch {
+    return { outline: null, lineCount: 0, bytes: 0 };
+  }
+
+  const lineCount = countLinesFromBuffer(buf);
+  const bytes = stat.size;
+
+  let outline = null;
+
+  // Try regex patterns first (synchronous, zero dependencies)
+  const regexPatterns = getRegexPatterns(ext);
+  if (regexPatterns) {
+    try {
+      const content = buf.toString("utf-8");
+      const lines = content.split("\n");
+      const rawLines = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        for (const [regex, kind, excludeControlFlow] of regexPatterns) {
+          const match = lines[i].match(regex);
+          if (match) {
+            if (excludeControlFlow && isControlFlow(match[1])) continue;
+            rawLines.push(`  L${i + 1}: ${kind} ${match[1]}`);
+            break;
+          }
+        }
+      }
+
+      if (rawLines.length > 0) {
+        outline = buildCappedOutline(rawLines, lineCount);
+      }
+    } catch {
+      // regex parse error — fall through to fallback
+    }
+  }
+
+  if (!outline) {
+    // Fallback — capped
+    try {
+      const content = buf.toString("utf-8");
+      const lines = content.split("\n");
+      const head = lines.slice(0, 15).map((l, i) => {
+        const line = l.length > 200 ? l.slice(0, 200) + "..." : l;
+        return `  L${i + 1}: ${line}`;
+      }).join("\n");
+      const fallbackText = `File has ${lineCount} lines (no outline backend available).\nFirst 15 lines:\n${head}`;
+      outline = buildCappedOutline(fallbackText, lineCount);
+    } catch {
+      outline = buildCappedOutline(`File has ${lineCount} lines. No outline backend available.`, lineCount);
+    }
+  }
+
+  const result = { outline, lineCount, bytes };
+
+  // Cache (evict oldest if over max)
+  if (outlineCache.size >= OUTLINE_CACHE_MAX) {
+    const firstKey = outlineCache.keys().next().value;
+    outlineCache.delete(firstKey);
+  }
+  outlineCache.set(cacheKey, result);
+
+  return result;
+}
+
+// --- Ctags / Python detection ---
+
+async function checkCtags() {
+  try {
+    await execFileAsync("ctags", ["--version"], { timeout: 2000 });
+    ctagsPath = "ctags";
+    return true;
+  } catch {
+    // check fallback paths
+  }
+
+  const home = process.env.USERPROFILE || process.env.HOME || "";
+  const fallbackPaths = [
+    `${home}\\AppData\\Local\\Microsoft\\WinGet\\Packages\\UniversalCtags.Ctags_Microsoft.Winget.Source_8wekyb3d8bbwe\\ctags.exe`,
+    `${home}\\scoop\\apps\\universal-ctags\\current\\ctags.exe`,
+    "/opt/homebrew/bin/ctags",
+    "/usr/local/bin/ctags",
+    "/usr/bin/ctags",
+  ];
+
+  for (const p of fallbackPaths) {
+    try {
+      await execFileAsync(p, ["--version"], { timeout: 2000 });
+      ctagsPath = p;
+      return true;
+    } catch {
+      // try next
+    }
+  }
+
+  ctagsPath = false;
+  return false;
+}
+
+async function findPython() {
+  if (pythonExe !== null) return pythonExe;
+  for (const cmd of ["python", "python3"]) {
+    try {
+      await execFileAsync(cmd, ["--version"], { timeout: 2000 });
+      pythonExe = cmd;
+      return cmd;
+    } catch {
+      // try next
+    }
+  }
+  pythonExe = false;
+  return false;
+}
+
+async function outlineWithPython(filePath) {
+  const py = await findPython();
+  if (!py) throw new Error("python not found");
+
+  const script =
+    "import ast,sys;f=open(sys.argv[1],encoding='utf-8');src=f.read();f.close();tree=ast.parse(src);out=[];[out.append('  L{}-{}: {} {}'.format(n.lineno,getattr(n,'end_lineno',n.lineno),'class' if isinstance(n,ast.ClassDef) else 'def',n.name)) for n in ast.walk(tree) if isinstance(n,(ast.FunctionDef,ast.AsyncFunctionDef,ast.ClassDef))];print(chr(10).join(out))";
+
+  const { stdout } = await execFileAsync(py, ["-c", script, filePath], {
+    timeout: 5000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+async function outlineWithCtags(filePath) {
+  const exe = ctagsPath || "ctags";
+  const { stdout } = await execFileAsync(
+    exe,
+    ["--output-format=json", "--fields=+lnK", filePath],
+    { timeout: 5000, maxBuffer: 2 * 1024 * 1024 },
+  );
+
+  const USEFUL_KINDS = new Set([
+    "class", "method", "function", "interface", "struct", "enum",
+    "typedef", "namespace", "module", "constructor", "property",
+  ]);
+
+  const tags = stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((t) => t.line && t.name && USEFUL_KINDS.has(t.kind))
+    .sort((a, b) => a.line - b.line);
+
+  return tags.map((t) => `  L${t.line}: ${t.kind} ${t.name}`).join("\n");
+}
+
+// --- Mod activation ---
+
+export default function activate(letta) {
+  const disposers = [];
+
+  // 1) Permission overlay: block full-file reads on large code files
+  if (letta.capabilities.permissions) {
+    disposers.push(
+      letta.permissions.register({
+        id: "code-outline-enforce",
+        description:
+          `Block Read-family tools on code files over ${LINE_THRESHOLD} lines ` +
+          `or ${(BYTE_THRESHOLD / 1024).toFixed(0)} KB. Tiny unanchored reads (< ${MIN_UNANCHORED_LIMIT} lines, no offset) are also blocked.`,
+        check(event) {
+          // Normalize read-tool family (case-insensitive, strip non-alnum)
+          if (!READ_TOOL_NAMES.has(normalizeToolName(event.toolName))) return;
+
+          // Resolve file path (handle relative paths)
+          const filePath = resolvePath(event.args?.file_path, event);
+          if (!filePath) return;
+
+          const ext = getExt(filePath);
+          if (!CODE_EXTS.has(ext)) return;
+
+          // Don't block memory files (markdown, not source code)
+          if (isMemoryFile(filePath)) return;
+
+          // Allow anchored reads — agent has a target offset (from outline)
+          if (hasAnchoredOffset(event.args)) return;
+
+          // Allow unanchored reads with sufficient limit (not tiny crawl)
+          const limit = event.args?.limit;
+          if (typeof limit === "number" && limit > 0 && limit >= MIN_UNANCHORED_LIMIT) return;
+
+          // Generate (cached, capped) outline — also gets line count and bytes
+          const cached = getOutline(filePath, ext);
+          if (!cached.outline) return; // unreadable file — let it through
+
+          const { outline, lineCount, bytes } = cached;
+
+          // Check thresholds
+          if (lineCount <= LINE_THRESHOLD && bytes <= BYTE_THRESHOLD) return;
+
+          return {
+            decision: "deny",
+            reason:
+              `File has ${lineCount} lines (${(bytes / 1024).toFixed(0)} KB). ` +
+              `Outline:\n${outline}\n\n` +
+              `Use Read with offset/limit for targeted reads. ` +
+              `Unanchored reads need limit >= ${MIN_UNANCHORED_LIMIT}.`,
+          };
+        },
+      }),
+    );
+  }
+
+  // 2) Mod tool: code_outline — multi-language structural outline
+  if (letta.capabilities.tools) {
+    disposers.push(
+      letta.tools.register({
+        name: "code_outline",
+        description:
+          "Get a structural outline (functions, classes, methods with line numbers) " +
+          "of a source code file. Use BEFORE reading large code files to find the " +
+          "right line ranges. Supported languages (zero dependencies): Python, " +
+          "JavaScript, TypeScript, Go, Rust, C, C++, Java, C#, Ruby, PHP, Swift, " +
+          "Kotlin, Scala, Lua, HTML, CSS/SCSS, Shell, PowerShell, SQL, Dart, Vue, " +
+          "Svelte, Dockerfile. No dependencies required.",
+        parameters: {
+          type: "object",
+          properties: {
+            file_path: {
+              type: "string",
+              description: "Absolute path to the source file to outline.",
+            },
+          },
+          required: ["file_path"],
+          additionalProperties: false,
+        },
+        requiresApproval: false,
+        parallelSafe: true,
+        async run(ctx) {
+          const filePath = ctx.args.file_path;
+          if (!filePath) {
+            return { status: "error", content: "file_path is required" };
+          }
+
+          const ext = getExt(filePath);
+
+          // Read file buffer for line counting
+          let buf;
+          try {
+            buf = readFileSync(filePath);
+          } catch {
+            return { status: "error", content: `Could not read file: ${filePath}` };
+          }
+          const lineCount = countLinesFromBuffer(buf);
+
+          let outline = "";
+
+          // Python ast for .py files (accurate start+end lines)
+          if (ext === ".py") {
+            try {
+              outline = await outlineWithPython(filePath);
+              if (outline) {
+                outline = buildCappedOutline(outline.split("\n"), lineCount);
+                return `## ${filePath} (${lineCount} lines)\n\n${outline}`;
+              }
+            } catch {
+              // fall through
+            }
+          }
+
+          // Ctags for any language (if installed)
+          if (ctagsPath === null) {
+            await checkCtags();
+          }
+
+          if (ctagsPath) {
+            try {
+              outline = await outlineWithCtags(filePath);
+              if (outline) {
+                outline = buildCappedOutline(outline.split("\n"), lineCount);
+                return `## ${filePath} (${lineCount} lines)\n\n${outline}`;
+              }
+            } catch {
+              // fall through
+            }
+          }
+
+          // Regex patterns (zero dependencies) — shared helper
+          const regexLines = regexOutlineLines(filePath, ext);
+          if (regexLines) {
+            outline = buildCappedOutline(regexLines, lineCount);
+            return `## ${filePath} (${lineCount} lines)\n\n${outline}`;
+          }
+
+          // Fallback — capped
+          try {
+            const content = readFileSync(filePath, "utf-8");
+            const lines = content.split("\n");
+            const head = lines.slice(0, 15).map((l, i) => {
+              const line = l.length > 200 ? l.slice(0, 200) + "..." : l;
+              return `  L${i + 1}: ${line}`;
+            }).join("\n");
+            outline = buildCappedOutline(
+              `File has ${lineCount} lines (no outline backend available).\nFirst 15 lines:\n${head}`,
+              lineCount,
+            );
+          } catch {
+            outline = buildCappedOutline(
+              `File has ${lineCount} lines. No outline backend available.`,
+              lineCount,
+            );
+          }
+          return `## ${filePath} (${lineCount} lines)\n\n${outline}`;
+        },
+      }),
+    );
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/code-outline-enforce/mods/index.mjs
+++ b/packages/code-outline-enforce/mods/index.mjs
@@ -321,7 +321,7 @@ function isMemoryFile(filePath) {
 }
 
 /**
- * Resolve a possibly-relative file_path against the event's working directory.
+ * Resolve a possibly-relative file_path against the current working directory.
  * Returns absolute path or null if unable to resolve.
  */
 function resolvePath(filePath, event) {
@@ -684,7 +684,7 @@ export default function activate(letta) {
           properties: {
             file_path: {
               type: "string",
-              description: "Absolute path to the source file to outline.",
+              description: "Absolute or workspace-relative path to the source file to outline.",
             },
           },
           required: ["file_path"],
@@ -693,9 +693,14 @@ export default function activate(letta) {
         requiresApproval: false,
         parallelSafe: true,
         async run(ctx) {
-          const filePath = ctx.args.file_path;
-          if (!filePath) {
+          const inputPath = ctx.args.file_path;
+          if (typeof inputPath !== "string" || !inputPath.trim()) {
             return { status: "error", content: "file_path is required" };
+          }
+
+          const filePath = resolvePath(inputPath, ctx);
+          if (!filePath) {
+            return { status: "error", content: `Could not resolve file: ${inputPath}` };
           }
 
           const ext = getExt(filePath);

--- a/packages/code-outline-enforce/package.json
+++ b/packages/code-outline-enforce/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@letta-ai/code-outline-enforce",
+  "version": "0.2.0",
+  "description": "Forces agents to outline large code files before reading them. Permission overlay blocks full-file reads on large source files and auto-injects a capped structural outline.",
+  "author": "letta-code-agent",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "code-outline",
+    "permissions",
+    "context-efficiency"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/code-outline-enforce"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.mjs"],
+    "capabilities": ["tools", "permissions"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.22"
+    }
+  }
+}


### PR DESCRIPTION
Adds `code-outline-enforce`, a tools + permissions mod that prevents inefficient exploration of large source files.

  - Denies blind full-file reads above configurable line/byte thresholds
  - Denies tiny unanchored reads that create slow sequential crawl behavior
  - Injects a bounded regex structural outline into denial feedback
  - Provides `code_outline` tool with Python AST, Universal Ctags, regex, and fallback backends
  - Supports targeted reads through offsets or sufficiently large unanchored limits
  - Uses no required third-party dependencies

  Tested against: blind large-file reads, tiny unanchored limits, anchored reads, normalized read-file variants, Python regex outline, 600 KB one-line fallback, nonexistent file errors, and repository validation.