### PR TITLE
Add ponytail mod: lazy senior dev YAGNI ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ packages/
 ├── output-compressor/    # Reversibly compresses large tool outputs before the model sees them
 ├── pets/                 # Terminal pets that animate based on turn and tool activity
 ├── plan-mode/            # Plan-mode style workflow
+├── ponytail/             # Lazy senior dev mode — YAGNI ladder for less, simpler code
 ├── soft-landing/         # Recovery slash command for drift, compaction, or context overload
 ├── spotify-statusline/   # macOS Spotify now-playing statusline
 ├── sprite/               # Persistent pet that grows stats from real agent work
@@ -115,6 +116,7 @@ scripts/
 - **output-compressor** - Reversibly compresses large tool outputs before the model sees them
 - **pets** - Terminal pets that animate based on turn and tool activity
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
+- **ponytail** - Lazy senior dev mode that injects a YAGNI ladder ruleset to write less, simpler code
 - **soft-landing** - Recovery slash command for drift, compaction, or context overload
 - **spotify-statusline** - macOS Spotify now-playing statusline
 - **sprite** - Persistent pet that grows stats from real agent work

--- a/packages/ponytail/LICENSE
+++ b/packages/ponytail/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dietrich Gebert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ponytail/MOD.md
+++ b/packages/ponytail/MOD.md
@@ -1,0 +1,91 @@
+---
+name: "@vedant020000/ponytail"
+description: "Lazy senior dev mode — YAGNI ladder that makes the agent write less, simpler code."
+---
+
+# Ponytail mod semantics
+
+## When to use
+
+Use this mod to make the agent write less code by stopping at the first rung of the YAGNI ladder that holds: skip speculative features, reuse existing code, prefer stdlib and native platform features, use installed dependencies, write one-liners, and only then write the minimum code that works.
+
+The ruleset is injected at the start of each conversation and persists until deactivated with "stop ponytail", "normal mode", or `/ponytail off`.
+
+## Behavioral contract
+
+When ponytail is active, the agent should:
+
+1. Read the task and trace the code it touches end to end before writing anything.
+2. Climb the ladder: YAGNI → reuse → stdlib → native → installed dependency → one line → minimum.
+3. Never simplify away input validation at trust boundaries, error handling that prevents data loss, security measures, or accessibility basics.
+4. Leave a `ponytail:` comment on deliberate simplifications, naming the ceiling and upgrade path.
+5. Leave one runnable self-check for non-trivial logic (assert-based demo or one small test).
+
+## Commands
+
+### `/ponytail [lite|full|ultra|off]`
+
+Report or switch ponytail intensity level. No argument reports the current level.
+
+- **lite** — Build what's asked, name the lazier alternative in one line.
+- **full** — The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default.
+- **ultra** — YAGNI extremist. Deletion before addition. Challenges requirements.
+- **off** — Deactivate ponytail.
+
+### `/ponytail-review`
+
+Sends a prompt to review the current diff for over-engineering. Returns a delete-list with tags: delete, stdlib, native, yagni, shrink.
+
+### `/ponytail-audit`
+
+Sends a prompt to audit the whole repo for over-engineering, not just the diff.
+
+### `/ponytail-debt`
+
+Sends a prompt to harvest `ponytail:` comments into a tracked debt ledger, so deferrals don't rot.
+
+### `/ponytail-gain`
+
+Displays a static benchmark scoreboard showing measured impact (less code, less cost, more speed).
+
+### `/ponytail-help`
+
+Displays a quick reference card for all commands and levels.
+
+## Events
+
+### `turn_start`
+
+On the first turn of a conversation, injects the ponytail ruleset as a system reminder (filtered to the active level). Also detects natural-language deactivation ("stop ponytail", "normal mode") and turns ponytail off.
+
+### `conversation_open`
+
+Resets mode to the configured default and clears the injection flag on new conversations.
+
+## State
+
+State (current mode + injection flag) is stored in the platform config directory:
+
+- Linux/macOS: `~/.config/ponytail/state.json`
+- Windows: `%APPDATA%\ponytail\state.json`
+
+## Configuration
+
+Default mode can be set via:
+
+1. `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`)
+2. Config file: `~/.config/ponytail/config.json` (Windows: `%APPDATA%\ponytail\config.json`) with `{ "defaultMode": "lite" }`
+3. Default: `full`
+
+Resolution: env var > config file > `full`.
+
+## UI
+
+Sets a status value `ponytail-mode` showing the current level (e.g. "FULL", "LITE"). Cleared when ponytail is off or the mod is disposed.
+
+## Adaptation notes for agents
+
+- Do not import Letta Code internals. Use the public mod API and Node built-ins only.
+- The mod uses `node:fs`, `node:path`, `node:os` — no third-party dependencies.
+- State is written to the user's config directory, not the mods folder.
+- The ruleset is a large embedded string (`SKILL_BODY`) — it is filtered per-level by `filterSkillBodyForMode` before injection.

--- a/packages/ponytail/README.md
+++ b/packages/ponytail/README.md
@@ -1,0 +1,101 @@
+# Ponytail for Letta Code
+
+Makes your Letta Code agent think like the laziest senior dev in the room. The best code is the code you never wrote.
+
+This is a [Letta Code](https://docs.letta.com/letta-code/index.md) mod port of [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) — the same ruleset, the same ladder, the same commands, adapted to Letta Code's mod API.
+
+## What it does
+
+Before writing code, the agent stops at the first rung that holds:
+
+1. **Does this need to exist?** → no: skip it (YAGNI)
+2. **Already in this codebase?** → reuse it, don't rewrite
+3. **Stdlib does it?** → use it
+4. **Native platform feature?** → use it
+5. **Installed dependency?** → use it
+6. **One line?** → one line
+7. **Only then:** the minimum that works
+
+Lazy about the solution, never about reading. The agent traces the real flow end to end before picking a rung. Trust-boundary validation, data-loss handling, security, and accessibility are never on the chopping block.
+
+## Install
+
+```bash
+letta install npm:@vedant020000/ponytail
+```
+
+Then reload local mods:
+
+```
+/reload
+```
+
+You can also install from a local checkout of this repository:
+
+```bash
+git clone https://github.com/letta-ai/mods.git
+cd mods/packages/ponytail
+letta install .
+```
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `/ponytail [lite\|full\|ultra\|off]` | Set the intensity, or turn it off. No argument reports the current level. |
+| `/ponytail-review` | Review the current diff for over-engineering, hands back a delete-list. |
+| `/ponytail-audit` | Audit the whole repo for over-engineering, not just the diff. |
+| `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked debt ledger. |
+| `/ponytail-gain` | Show the measured impact scoreboard (less code, less cost, more speed). |
+| `/ponytail-help` | Quick reference for the commands above. |
+
+## Levels
+
+| Level | What changes |
+|-------|-------------|
+| **lite** | Build what's asked, name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Challenges requirements. |
+
+## Configuration
+
+Set the default level for every new session:
+
+**Environment variable:**
+```bash
+PONYTAIL_DEFAULT_MODE=full  # lite | full | ultra | off
+```
+
+**Config file:**
+- Linux/macOS: `~/.config/ponytail/config.json`
+- Windows: `%APPDATA%\ponytail\config.json`
+
+```json
+{ "defaultMode": "lite" }
+```
+
+Resolution: env var > config file > `full`.
+
+Deactivate anytime by saying "stop ponytail" or "normal mode". Resume with `/ponytail full` (or lite/ultra).
+
+## How it works
+
+The mod registers six slash commands and two event handlers:
+
+- **`turn_start` event** — injects the ponytail ruleset into the first user turn of each conversation (as a system reminder), and detects natural-language deactivation ("stop ponytail", "normal mode").
+- **`conversation_open` event** — resets mode to the configured default on new conversations.
+- **Commands** — `/ponytail` switches levels and re-injects the ruleset; the others send review/audit/debt prompts or display static output.
+
+State (current mode + injection flag) is persisted to the platform config directory (`~/.config/ponytail/state.json` on Linux/macOS, `%APPDATA%\ponytail\state.json` on Windows), not in the mods folder.
+
+## Safety
+
+This mod is trusted local code and can execute with the user's local permissions. Review the source before installing or modifying it.
+
+The mod only uses Node.js built-ins (`node:fs`, `node:path`, `node:os`). No third-party dependencies. No network access. No shell execution.
+
+## License
+
+MIT — same as the [original project](https://github.com/DietrichGebert/ponytail).
+
+Credit: [Dietrich Gebert](https://github.com/DietrichGebert) — the ruleset, the ladder, and the benchmark methodology are all his.

--- a/packages/ponytail/mods/ponytail.js
+++ b/packages/ponytail/mods/ponytail.js
@@ -343,13 +343,6 @@ export default function activate(letta) {
   function setMode(mode) {
     state.mode = mode;
     saveState(state);
-    if (letta.capabilities.ui && letta.capabilities.ui.statusValues) {
-      if (mode === "off") {
-        letta.ui.clearStatus("ponytail-mode");
-      } else {
-        letta.ui.setStatus("ponytail-mode", mode.toUpperCase());
-      }
-    }
   }
 
   // ── Commands ─────────────────────────────────────────────────────────────
@@ -467,13 +460,6 @@ export default function activate(letta) {
         state.mode = getDefaultMode();
         state.injected = false;
         saveState(state);
-        if (
-          letta.capabilities.ui &&
-          letta.capabilities.ui.statusValues &&
-          state.mode !== "off"
-        ) {
-          letta.ui.setStatus("ponytail-mode", state.mode.toUpperCase());
-        }
       }),
     );
   }
@@ -508,8 +494,5 @@ export default function activate(letta) {
 
   return function () {
     for (const dispose of disposers.reverse()) dispose();
-    if (letta.capabilities.ui && letta.capabilities.ui.statusValues) {
-      letta.ui.clearStatus("ponytail-mode");
-    }
   };
 };

--- a/packages/ponytail/mods/ponytail.js
+++ b/packages/ponytail/mods/ponytail.js
@@ -1,0 +1,515 @@
+// Ponytail — Lazy senior dev mode for Letta Code
+// 1:1 port of https://github.com/DietrichGebert/ponytail
+// MIT License — Copyright (c) Dietrich Gebert
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+// ─── Config ────────────────────────────────────────────────────────────────
+
+const DEFAULT_MODE = "full";
+const VALID_MODES = ["off", "lite", "full", "ultra"];
+
+function getConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, "ponytail");
+  }
+  if (process.platform === "win32") {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"),
+      "ponytail",
+    );
+  }
+  return path.join(os.homedir(), ".config", "ponytail");
+}
+
+const STATE_FILE = path.join(getConfigDir(), "state.json");
+
+function getDefaultMode() {
+  // 1. Environment variable (highest priority)
+  const envMode = process.env.PONYTAIL_DEFAULT_MODE;
+  if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
+    return envMode.toLowerCase();
+  }
+  // 2. Config file
+  try {
+    const configPath = path.join(getConfigDir(), "config.json");
+    const raw = fs.readFileSync(configPath, "utf8").replace(/^\uFEFF/, "");
+    const config = JSON.parse(raw);
+    if (config.defaultMode && VALID_MODES.includes(config.defaultMode.toLowerCase())) {
+      return config.defaultMode.toLowerCase();
+    }
+  } catch (_) {
+    // Config file doesn't exist or is invalid — fall through
+  }
+  // 3. Default
+  return DEFAULT_MODE;
+}
+
+function normalizeMode(mode) {
+  if (typeof mode !== "string") return null;
+  const normalized = mode.trim().toLowerCase();
+  return VALID_MODES.includes(normalized) ? normalized : null;
+}
+
+function isDeactivationCommand(text) {
+  const t = String(text || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[.!\?\s]+$/, "");
+  return t === "stop ponytail" || t === "normal mode";
+}
+
+// ─── State ─────────────────────────────────────────────────────────────────
+
+function loadState() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+    return {
+      mode: normalizeMode(raw.mode) || getDefaultMode(),
+      injected: Boolean(raw.injected),
+    };
+  } catch (_) {
+    return { mode: getDefaultMode(), injected: false };
+  }
+}
+
+function saveState(state) {
+  try {
+    fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), "utf8");
+  } catch (_) {
+    // Silent fail — state is best-effort
+  }
+}
+
+// ─── Instructions ──────────────────────────────────────────────────────────
+
+const SKILL_BODY = [
+  "# Ponytail",
+  "",
+  "You are a lazy senior developer. Lazy means efficient, not careless. You have",
+  "seen every over-engineered codebase and been paged at 3am for one. The best",
+  "code is the code never written.",
+  "",
+  "## Persistence",
+  "",
+  "ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if",
+  'unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.',
+  "Switch: `/ponytail lite|full|ultra`.",
+  "",
+  "## The ladder",
+  "",
+  "Stop at the first rung that holds:",
+  "",
+  "1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)",
+  "2. **Already in this codebase?** A helper, util, type, or pattern that already lives here \u2192 reuse it. Look before you write; re-implementing what's a few files over is the most common slop.",
+  "3. **Stdlib does it?** Use it.",
+  "4. **Native platform feature covers it?** `<input type=\"date\">` over a picker lib, CSS over JS, DB constraint over app code.",
+  "5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.",
+  "6. **Can it be one line?** One line.",
+  "7. **Only then:** the minimum code that works.",
+  "",
+  "The ladder is a reflex, not a research project \u2014 but it runs *after* you",
+  "understand the problem, not instead of it. Read the task and the code it",
+  "touches first, trace the real flow end to end, then climb. Two rungs work \u2192",
+  "take the higher one and move on. The first lazy solution that works is the",
+  "right one \u2014 once you actually know what the change has to touch.",
+  "",
+  "**Bug fix = root cause, not symptom.** A report names a symptom. Before you",
+  "edit, grep every caller of the function you're about to touch. The lazy fix IS",
+  "the root-cause fix: one guard in the shared function is a smaller diff than a",
+  "guard in every caller \u2014 and patching only the path the ticket names leaves",
+  "every sibling caller still broken. Fix it once, where all callers route through.",
+  "",
+  "## Rules",
+  "",
+  "- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.",
+  '- No boilerplate, no scaffolding "for later", later can scaffold for itself.',
+  "- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.",
+  "- Fewest files possible. Shortest working diff wins \u2014 but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.",
+  '- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.',
+  "- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.",
+  "- Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n\u00b2) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.",
+  "",
+  "## Output",
+  "",
+  "Code first. Then at most three short lines: what was skipped, when to add it.",
+  "No essays, no feature tours, no design notes. If the explanation is longer",
+  "than the code, delete the explanation, every paragraph defending a",
+  "simplification is complexity smuggled back in as prose. Explanation the user",
+  "explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,",
+  "give it in full, the rule is only against unrequested prose.",
+  "",
+  "Pattern: `[code] \u2192 skipped: [X], add when [Y].`",
+  "",
+  "## Intensity",
+  "",
+  "| Level | What change |",
+  "|-------|------------|",
+  "| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |",
+  "| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |",
+  "| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |",
+  "",
+  'Example: "Add a cache for these API responses."',
+  '- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you\'d rather not own a cache class."',
+  '- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."',
+  '- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."',
+  "",
+  "## When NOT to be lazy",
+  "",
+  "Never simplify away: input validation at trust boundaries, error handling",
+  "that prevents data loss, security measures, accessibility basics, anything",
+  "explicitly requested. User insists on the full version \u2192 build it, no",
+  "re-arguing.",
+  "",
+  "Never lazy about understanding the problem. The ladder shortens the",
+  "solution, never the reading. Trace the whole thing first \u2014 every file the",
+  "change touches, the actual flow \u2014 before picking a rung. Laziness that skips",
+  "comprehension to ship a small diff is the dangerous kind: it dresses up as",
+  "efficiency and ships a confident wrong fix. Read fully, then be lazy.",
+  "",
+  "Hardware is never the ideal on paper: a real clock drifts, a real sensor",
+  "reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not",
+  "just less code, the physical world needs tuning a minimal model can't see.",
+  "",
+  "Lazy code without its check is unfinished. Non-trivial logic (a branch, a",
+  "loop, a parser, a money/security path) leaves ONE runnable check behind, the",
+  "smallest thing that fails if the logic breaks: an `assert`-based",
+  "`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no",
+  "fixtures, no per-function suites unless asked. Trivial one-liners need no",
+  "test, YAGNI applies to tests too.",
+  "",
+  "## Boundaries",
+  "",
+  "Ponytail governs what you build, not how you talk (pair with Caveman for",
+  'terse prose). "stop ponytail" / "normal mode": revert. Level persists until',
+  "changed or session end.",
+  "",
+  "The shortest path to done is the right path.",
+].join("\n");
+
+function filterSkillBodyForMode(body, mode) {
+  const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
+
+  return String(body || "")
+    .split(/\r?\n/)
+    .filter((line) => {
+      // Intensity table rows: | **lite** | ... |
+      const tableLabel = line.match(/^\|\s*\*\*(.+?)\*\*\s*\|/);
+      if (tableLabel) {
+        const labelMode = normalizeMode(tableLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      // Worked examples: - lite: ...
+      const exampleLabel = line.match(/^-\s*([^:]+):\s*/);
+      if (exampleLabel) {
+        const labelMode = normalizeMode(exampleLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
+
+      return true;
+    })
+    .join("\n");
+}
+
+function getPonytailInstructions(mode) {
+  const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
+  return (
+    "PONYTAIL MODE ACTIVE \u2014 level: " +
+    effectiveMode +
+    "\n\n" +
+    filterSkillBodyForMode(SKILL_BODY, effectiveMode)
+  );
+}
+
+// ─── Command Prompts ──────────────────────────────────────────────────────
+
+const REVIEW_PROMPT = [
+  "Review the current code changes for over-engineering only, not correctness.",
+  "One line per finding: L<line>: <tag> <what to cut>. <replacement>.",
+  "Tags: delete (dead code/speculative feature), stdlib (reinvented standard",
+  "library), native (dependency doing what the platform does), yagni (abstraction",
+  "with one implementation), shrink (same logic, fewer lines).",
+  "End with the net lines removable.",
+  "If nothing to cut: 'Lean already. Ship.'",
+].join(" ");
+
+const AUDIT_PROMPT = [
+  "Audit the entire repository for over-engineering only, not correctness.",
+  "Scan the whole tree, not a diff.",
+  "One line per finding, ranked biggest cut first:",
+  "<tag> <what to cut>. <replacement>. [path].",
+  "Tags: delete (dead code/speculative feature), stdlib (reinvented standard",
+  "library), native (dependency doing what the platform does), yagni (abstraction",
+  "with one implementation), shrink (same logic, fewer lines).",
+  "End with the net lines and dependencies removable.",
+  "If nothing to cut: 'Lean already. Ship.'",
+].join(" ");
+
+const DEBT_PROMPT = [
+  "Harvest every `ponytail:` comment in this repository into a debt ledger so",
+  "deferrals do not rot into 'later means never'.",
+  "Grep the whole tree for comment markers",
+  "(grep -rnE '(#|//) ?ponytail:' .,",
+  "skipping node_modules/.git/build output).",
+  "One row per marker, grouped by file:",
+  "<file>:<line> \u2014 <what was simplified>.",
+  "ceiling: <the limit named in the comment>.",
+  "upgrade: <the trigger to revisit>.",
+  "Tag any marker that names no upgrade path or trigger as no-trigger, those rot",
+  "silently. End with the count of markers and how many lack a trigger.",
+  "If none: 'No ponytail: debt. Clean ledger.'",
+  "Report only, change nothing.",
+].join(" ");
+
+const GAIN_OUTPUT = [
+  "  ponytail gain                     benchmark median \u00b7 5 tasks \u00b7 3 models",
+  "",
+  "  Lines of code   no-skill  \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588  100%",
+  "                  ponytail  \u2588\u2588\u258c\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7    6\u201320%   \u25bc 80\u201394%",
+  "  Cost            no-skill  \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588  100%",
+  "                  ponytail  \u2588\u2588\u2588\u2588\u2588\u258c\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7   23\u201353%  \u25bc 47\u201377%",
+  "  Speed           ponytail  \u25b8 3\u20136\u00d7 faster",
+  "",
+  "  This repo:  /ponytail-debt  (shortcuts you deferred)",
+  "              /ponytail-audit (what's still cuttable)",
+].join("\n");
+
+const HELP_OUTPUT = [
+  "Ponytail \u2014 Lazy senior dev mode",
+  "",
+  "Levels:",
+  "  /ponytail lite     Build what's asked, name the lazier alternative in one line.",
+  "  /ponytail          Full (default). The ladder: YAGNI \u2192 stdlib \u2192 native \u2192 one line \u2192 minimum.",
+  "  /ponytail ultra    YAGNI extremist. Deletion before addition. Challenges requirements.",
+  "",
+  "Commands:",
+  "  /ponytail          Report current level, or switch (lite/full/ultra/off)",
+  "  /ponytail-review   Over-engineering review of current changes",
+  "  /ponytail-audit    Whole-repo over-engineering audit",
+  "  /ponytail-debt     Harvest ponytail: comments into a tracked ledger",
+  "  /ponytail-gain     Measured-impact scoreboard from the benchmark",
+  "  /ponytail-help     This card",
+  "",
+  "Deactivate:",
+  '  Say "stop ponytail", "normal mode", or /ponytail off.',
+  "  Resume anytime with /ponytail full (or lite/ultra).",
+  "",
+  "Default mode: full. Change with PONYTAIL_DEFAULT_MODE env var (off|lite|full|ultra)",
+  "  or config file: ~/.config/ponytail/config.json (Windows: %APPDATA%\\ponytail\\config.json)",
+  '  { "defaultMode": "lite" }',
+  "  Resolution: env var > config file > full.",
+  "",
+  "Full docs: https://github.com/DietrichGebert/ponytail",
+].join("\n");
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function extractUserText(input) {
+  if (!Array.isArray(input)) return "";
+  for (const item of input) {
+    if (item.type !== "approval" && item.role === "user") {
+      if (typeof item.content === "string") return item.content;
+      if (Array.isArray(item.content)) {
+        return item.content
+          .filter((p) => p && p.type === "text" && typeof p.text === "string")
+          .map((p) => p.text)
+          .join(" ");
+      }
+    }
+  }
+  return "";
+}
+
+function prependToContent(content, prefix) {
+  if (typeof content === "string") {
+    return prefix + "\n\n" + content;
+  }
+  if (Array.isArray(content)) {
+    return [{ type: "text", text: prefix }, ...content];
+  }
+  return content;
+}
+
+// ─── Mod ───────────────────────────────────────────────────────────────────
+
+export default function activate(letta) {
+  const disposers = [];
+  let state = loadState();
+
+  function setMode(mode) {
+    state.mode = mode;
+    saveState(state);
+    if (letta.capabilities.ui && letta.capabilities.ui.statusValues) {
+      if (mode === "off") {
+        letta.ui.clearStatus("ponytail-mode");
+      } else {
+        letta.ui.setStatus("ponytail-mode", mode.toUpperCase());
+      }
+    }
+  }
+
+  // ── Commands ─────────────────────────────────────────────────────────────
+
+  if (letta.capabilities.commands) {
+    // /ponytail [lite|full|ultra|off]
+    disposers.push(
+      letta.commands.register({
+        id: "ponytail",
+        description: "Report or switch ponytail intensity level (lite/full/ultra/off)",
+        args: "[lite|full|ultra|off]",
+        run(ctx) {
+          const level = (ctx.args || "").trim().toLowerCase();
+
+          // No args — report current mode
+          if (!level) {
+            if (state.mode === "off") {
+              return {
+                type: "output",
+                output: "Ponytail is OFF. Use /ponytail full (or lite/ultra) to resume.",
+              };
+            }
+            return {
+              type: "output",
+              output: "Ponytail is active \u2014 level: " + state.mode.toUpperCase(),
+            };
+          }
+
+          // Set mode
+          if (level === "off") {
+            setMode("off");
+            return { type: "output", output: "Ponytail OFF. Use /ponytail full to resume." };
+          }
+          const normalized = normalizeMode(level);
+          if (!normalized) {
+            return {
+              type: "output",
+              output: "Unknown mode: " + level + ". Use: lite, full, ultra, or off.",
+            };
+          }
+          setMode(normalized);
+          state.injected = true;
+          saveState(state);
+          return {
+            type: "prompt",
+            content: getPonytailInstructions(normalized),
+            systemReminder: true,
+          };
+        },
+      }),
+    );
+
+    // /ponytail-review
+    disposers.push(
+      letta.commands.register({
+        id: "ponytail-review",
+        description: "Review changes for over-engineering, what can be deleted",
+        run() {
+          return { type: "prompt", content: REVIEW_PROMPT, systemReminder: true };
+        },
+      }),
+    );
+
+    // /ponytail-audit
+    disposers.push(
+      letta.commands.register({
+        id: "ponytail-audit",
+        description: "Audit the whole repo for over-engineering, what can be deleted",
+        run() {
+          return { type: "prompt", content: AUDIT_PROMPT, systemReminder: true };
+        },
+      }),
+    );
+
+    // /ponytail-debt
+    disposers.push(
+      letta.commands.register({
+        id: "ponytail-debt",
+        description: "Harvest ponytail: comments into a tracked debt ledger",
+        run() {
+          return { type: "prompt", content: DEBT_PROMPT, systemReminder: true };
+        },
+      }),
+    );
+
+    // /ponytail-gain
+    disposers.push(
+      letta.commands.register({
+        id: "ponytail-gain",
+        description: "Show ponytail's measured impact scoreboard (less code, cost, time)",
+        run() {
+          return { type: "output", output: GAIN_OUTPUT };
+        },
+      }),
+    );
+
+    // /ponytail-help
+    disposers.push(
+      letta.commands.register({
+        id: "ponytail-help",
+        description: "Quick reference for ponytail levels, skills, and commands",
+        run() {
+          return { type: "output", output: HELP_OUTPUT };
+        },
+      }),
+    );
+  }
+
+  // ── Events ───────────────────────────────────────────────────────────────
+
+  if (letta.capabilities.events && letta.capabilities.events.lifecycle) {
+    disposers.push(
+      letta.events.on("conversation_open", function () {
+        // Reset state on new conversation — matches SessionStart hook
+        state.mode = getDefaultMode();
+        state.injected = false;
+        saveState(state);
+        if (
+          letta.capabilities.ui &&
+          letta.capabilities.ui.statusValues &&
+          state.mode !== "off"
+        ) {
+          letta.ui.setStatus("ponytail-mode", state.mode.toUpperCase());
+        }
+      }),
+    );
+  }
+
+  if (letta.capabilities.events && letta.capabilities.events.turns) {
+    disposers.push(
+      letta.events.on("turn_start", function (event) {
+        // Detect natural-language deactivation — matches UserPromptSubmit hook
+        const userText = extractUserText(event.input);
+        if (userText && isDeactivationCommand(userText)) {
+          setMode("off");
+          return;
+        }
+
+        // Inject ruleset on first turn if ponytail is active — matches SessionStart
+        if (state.mode !== "off" && !state.injected) {
+          state.injected = true;
+          saveState(state);
+          const ruleset = getPonytailInstructions(state.mode);
+          event.input = event.input.map(function (item) {
+            if (item.type !== "approval" && item.role === "user") {
+              return { ...item, content: prependToContent(item.content, ruleset) };
+            }
+            return item;
+          });
+        }
+      }),
+    );
+  }
+
+  // ── Cleanup ──────────────────────────────────────────────────────────────
+
+  return function () {
+    for (const dispose of disposers.reverse()) dispose();
+    if (letta.capabilities.ui && letta.capabilities.ui.statusValues) {
+      letta.ui.clearStatus("ponytail-mode");
+    }
+  };
+};

--- a/packages/ponytail/package.json
+++ b/packages/ponytail/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@vedant020000/ponytail",
+  "version": "1.0.0",
+  "description": "Lazy senior dev mode for Letta Code — a port of DietrichGebert/ponytail",
+  "author": "Vedant020000",
+  "license": "MIT",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "ponytail",
+    "yagni",
+    "lazy-dev",
+    "code-quality",
+    "agent-skills"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/ponytail"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "LICENSE",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/ponytail.js"],
+    "capabilities": ["commands", "events.turns", "events.lifecycle"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.0"
+    }
+  }
+}

--- a/packages/ponytail/package.json
+++ b/packages/ponytail/package.json
@@ -2,7 +2,7 @@
   "name": "@vedant020000/ponytail",
   "version": "1.0.0",
   "description": "Lazy senior dev mode for Letta Code — a port of DietrichGebert/ponytail",
-  "author": "Vedant020000",
+  "author": "vedant020000",
   "license": "MIT",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary

- Adds `ponytail` mod package — a port of [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) (MIT) for Letta Code
- Injects a YAGNI ladder ruleset at conversation start to make the agent write less, simpler code
- Six slash commands: `/ponytail`, `/ponytail-review`, `/ponytail-audit`, `/ponytail-debt`, `/ponytail-gain`, `/ponytail-help`
- Three intensity levels: `lite`, `full` (default), `ultra` — switchable via `/ponytail` command, env var, or config file
- Two event handlers: `turn_start` (ruleset injection + deactivation detection), `conversation_open` (mode reset)
- Status value showing the current level
- State persisted to platform config dir (`~/.config/ponytail/state.json` / `%APPDATA%\ponytail\state.json`)
- Only uses Node built-ins (`node:fs`, `node:path`, `node:os`). No third-party dependencies, no network access, no shell execution.

## Package structure

```
packages/ponytail/
├── package.json    # npm metadata + letta manifest
├── README.md       # user-facing docs
├── MOD.md          # agent-facing semantics
├── LICENSE         # MIT
└── mods/
    └── ponytail.js # mod implementation
```

## Test plan

- [ ] `letta install npm:@vedant020000/ponytail` (once published to npm)
- [ ] `letta install ./packages/ponytail` (local install from repo checkout)
- [ ] Run `/reload` and verify `/ponytail-help` shows the help card
- [ ] Run `/ponytail` and verify it reports the current level
- [ ] Run `/ponytail ultra` and verify the ruleset switches to ultra mode
- [ ] Say "stop ponytail" and verify it deactivates
- [ ] Run `/ponytail full` and verify it reactivates
- [ ] Run `/ponytail-review`, `/ponytail-audit`, `/ponytail-debt`, `/ponytail-gain` and verify each command works
- [ ] Open a new conversation and verify the mode resets to the configured default
- [ ] Verify `ponytail-mode` status value appears in the statusline

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>