### PR TITLE
Add open-in-editor mod: auto-open files in editor via tmux split-pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ packages/
 ├── goal-mode/            # Goal workflow with commands, tools, and turn reminders
 ├── image-understanding/  # Vision bridge for text-only agents
 ├── memfs-search/         # Agent-callable MemFS memory search
+├── open-in-editor/       # Auto-open files in your editor via tmux split-pane
 ├── plan-mode/            # Plan-mode style workflow
 ├── spotify-statusline/   # macOS Spotify now-playing statusline
 ├── user-timestamps/      # Adds local timestamp metadata to user messages
@@ -86,6 +87,7 @@ scripts/
 - **goal-mode** - Goal workflow using commands, tools, turn reminders, and local state
 - **image-understanding** - Image-understanding tool, commands, and optional auto-captioning for text-only agents
 - **memfs-search** - Agent-callable MemFS memory search with optional QMD semantic/hybrid search
+- **open-in-editor** - Open files in your editor as the agent touches them, via tmux split-pane or external editor command
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
 - **spotify-statusline** - macOS Spotify now-playing statusline
 - **user-timestamps** - Adds local timestamp metadata to every user message

--- a/packages/open-in-editor/MOD.md
+++ b/packages/open-in-editor/MOD.md
@@ -1,55 +1,65 @@
 ---
 name: "@letta-ai/open-in-editor"
-description: "Open files in your editor as the agent touches them — tmux split-pane for nvim/vim, or any editor command."
+description: "Open files in your editor as the agent touches them — fullscreen handoff (no deps) or tmux split-pane."
 ---
 
 # Open in editor mod semantics
 
 ## When to use
 
-Use this mod when the user wants files the agent edits to automatically open in
-their editor (nvim/vim/code/hx/etc.), ideally in a tmux split pane alongside
-the Letta Code chat. Also useful when the user wants a `/edit` command to
-manually open the last-touched file or a specific path.
+Use this mod when the user wants files the agent touches to be openable in
+their editor (nvim/vim/code/hx/etc.) from within Letta Code, without
+requiring tmux or any external dependency.
 
 ## Behavior
 
 - Listens to `tool_end` events for `Edit`, `Write`, and `Read` tools.
 - Tracks the last touched file path and tool name in local state.
 - Shows a status panel (order 100, above the input) with the file name and
-  editor pane status. Hidden until the first file is touched.
-- When `autoOpen` is `true` (default), files touched by `Edit` or `Write` are
-  automatically opened in the editor. `Read` is tracked but not auto-opened.
-- Auto-open calls are serialized to prevent tmux `send-keys` interleaving when
-  the agent edits multiple files in rapid succession. Only the most recent
-  pending file is queued; earlier pending opens are superseded.
+  editor state. Hidden until the first file is touched.
+- Two modes are auto-selected based on whether `$TMUX` is set:
 
-### tmux split-pane mode
+### Fullscreen mode (outside tmux)
 
-- When inside tmux, the first open creates a right-side split pane
+- `/edit` performs a fullscreen editor handoff:
+  1. Saves terminal state (raw mode flag)
+  2. Disables raw mode on stdin
+  3. Exits the alt screen buffer (`ESC[?1049l`) and clears the screen
+  4. Calls `execFileSync(editor, [file], { stdio: "inherit" })` — this
+     blocks the Node.js event loop, giving the editor exclusive terminal
+     access. No Ink renders, timers, or I/O fire while the editor runs.
+  5. When the editor exits, re-enters the alt screen (`ESC[?1049h`),
+     restores raw mode, and sends `SIGWINCH` to force Ink to re-render.
+- This is the same pattern `git commit` uses for `$EDITOR`.
+- **Auto-open is disabled** in fullscreen mode. Blocking the event loop
+  during agent tool execution would interrupt the response stream. Files
+  are tracked in the panel; the user runs `/edit` manually.
+- Works with any editor that functions as `$EDITOR`.
+
+### tmux split-pane mode (inside tmux)
+
+- The first `/edit` creates a right-side split pane
   (`tmux split-window -h -p <tmuxSize>`) running the editor with the file.
-- For nvim/vim, subsequent opens send `Escape :e <path> Enter` to the running
-  instance via `tmux send-keys`. This preserves buffers and undo history.
+- For nvim/vim, subsequent opens send `Escape :e <path> Enter` to the
+  running instance via `tmux send-keys`. This preserves buffers and undo
+  history.
 - For other editors, the editor command is re-run in the pane via send-keys.
-- The pane ID is tracked in memory. After a `/reload`, the mod searches the
-  current tmux window's panes for one running the configured editor and
-  reattaches, avoiding duplicate panes.
-- If the tracked pane was closed by the user, a new split is created on the
-  next open.
+- When `autoOpen` is `true` (default), files touched by `Edit` or `Write`
+  are automatically opened in the editor pane. `Read` is tracked but not
+  auto-opened.
+- Auto-open calls are serialized to prevent tmux `send-keys` interleaving.
+  Only the most recent pending file is queued; earlier pending opens are
+  superseded.
+- The pane ID is tracked in memory. After a `/reload`, the mod searches
+  the current tmux window's panes for one running the configured editor
+  and reattaches, avoiding duplicate panes.
 - `/editclose` kills the editor pane via `tmux kill-pane`.
-
-### Non-tmux mode
-
-- For nvim-like editors, tries `nvr` (neovim-remote) to open in an existing
-  nvim instance. If `nvr` is not available, returns a guidance message.
-- For other editors, launches the editor command directly.
-- The full split-pane two-column experience requires tmux.
 
 ### Path escaping
 
 - For vim `:e` command: spaces, `#`, `%`, and backslashes are escaped.
-- For shell commands: file paths are wrapped in single quotes with single-quote
-  escaping.
+- For shell commands: file paths are wrapped in single quotes with
+  single-quote escaping.
 
 ## Configuration
 
@@ -63,34 +73,48 @@ Config file: `~/.letta/mods/editor-config.json`
 }
 ```
 
-Missing or malformed config falls back to defaults and emits a warning diagnostic.
+- `editor` defaults to `$VISUAL`, then `$EDITOR`, then `"nvim"`.
+- Missing or malformed config falls back to defaults and emits a warning
+  diagnostic.
 
 ## Platform assumptions
 
-- Requires tmux for split-pane mode (tested on tmux 3.4, Linux).
-- Non-tmux nvim mode benefits from `nvr` (neovim-remote) if installed.
+- Fullscreen mode: requires a TTY with alt screen buffer support. Works
+  on any terminal that supports `ESC[?1049h/l` (virtually all modern
+  terminals).
+- tmux mode: requires tmux on `PATH`.
 - The editor binary must be on `PATH`.
-- Cross-platform: uses `windowsHide` to avoid console flashes on Windows.
+- Uses `windowsHide` for tmux commands to avoid console flashes on Windows.
 
 ## Safety invariants
 
 - Only runs editor commands and tmux pane management. Never modifies files.
-- All `execFile` calls have a 5-second timeout.
-- Errors from tmux or editor commands are caught and surfaced as user-facing
-  messages, never as uncaught exceptions.
-- The mod degrades gracefully when capabilities are missing: no panel without
-  `ui.panels`, no auto-open without `events.tools`, no commands without
-  `commands`.
-- Event handler, panel, and command registrations are all disposed on reload.
+- `execFileSync` is used for fullscreen mode — it blocks the event loop,
+  which is intentional: it prevents Ink from writing to the terminal
+  while the editor has control.
+- All `execFile` calls (tmux) have a 5-second timeout.
+- Errors from tmux or editor commands are caught and surfaced as
+  user-facing messages, never as uncaught exceptions.
+- The mod degrades gracefully when capabilities are missing: no panel
+  without `ui.panels`, no auto-open without `events.tools`, no commands
+  without `commands`.
+- Event handler, panel, and command registrations are all disposed on
+  reload.
 
 ## Adaptation notes for agents
 
-- To support a new editor, just set `"editor"` in the config. Vim-like editors
-  (`nvim`, `vim`, `vi`, `neovim`) use `:e` send-keys; all others re-run the
-  editor command in the pane.
-- To add line-number jumping (open at a specific line), extend `openFile` to
-  send `:+<line>` or `:<line>` after `:e` for vim-like editors.
-- To track Bash-created files, parse `event.args.command` in the `tool_end`
-  handler — this is intentionally not done by default due to fragility.
-- The panel `render` function is pure and side-effect-free. All state updates
-  go through `panel.update()`.
+- To support a new editor, just set `"editor"` in the config. Any editor
+  that works as `$EDITOR` will work in fullscreen mode. Vim-like editors
+  (`nvim`, `vim`, `vi`, `neovim`) additionally get `:e` send-keys in tmux
+  mode; all others re-run the editor command in the pane.
+- To add line-number jumping (open at a specific line), extend
+  `openEditorFullscreen` to pass `+<line>` as an argument (nvim/vim) or
+  extend `escapeVimPath` to append `:+<line>` after `:e`.
+- To track Bash-created files, parse `event.args.command` in the
+  `tool_end` handler — this is intentionally not done by default due to
+  fragility.
+- The panel `render` function is pure and side-effect-free. All state
+  updates go through `panel.update()`.
+- The `SIGWINCH` signal is used to force Ink to re-render after the
+  editor exits. If this proves unreliable on a specific terminal, an
+  alternative is to write a resize event directly to stdout.

--- a/packages/open-in-editor/MOD.md
+++ b/packages/open-in-editor/MOD.md
@@ -1,0 +1,96 @@
+---
+name: "@letta-ai/open-in-editor"
+description: "Open files in your editor as the agent touches them — tmux split-pane for nvim/vim, or any editor command."
+---
+
+# Open in editor mod semantics
+
+## When to use
+
+Use this mod when the user wants files the agent edits to automatically open in
+their editor (nvim/vim/code/hx/etc.), ideally in a tmux split pane alongside
+the Letta Code chat. Also useful when the user wants a `/edit` command to
+manually open the last-touched file or a specific path.
+
+## Behavior
+
+- Listens to `tool_end` events for `Edit`, `Write`, and `Read` tools.
+- Tracks the last touched file path and tool name in local state.
+- Shows a status panel (order 100, above the input) with the file name and
+  editor pane status. Hidden until the first file is touched.
+- When `autoOpen` is `true` (default), files touched by `Edit` or `Write` are
+  automatically opened in the editor. `Read` is tracked but not auto-opened.
+- Auto-open calls are serialized to prevent tmux `send-keys` interleaving when
+  the agent edits multiple files in rapid succession. Only the most recent
+  pending file is queued; earlier pending opens are superseded.
+
+### tmux split-pane mode
+
+- When inside tmux, the first open creates a right-side split pane
+  (`tmux split-window -h -p <tmuxSize>`) running the editor with the file.
+- For nvim/vim, subsequent opens send `Escape :e <path> Enter` to the running
+  instance via `tmux send-keys`. This preserves buffers and undo history.
+- For other editors, the editor command is re-run in the pane via send-keys.
+- The pane ID is tracked in memory. After a `/reload`, the mod searches the
+  current tmux window's panes for one running the configured editor and
+  reattaches, avoiding duplicate panes.
+- If the tracked pane was closed by the user, a new split is created on the
+  next open.
+- `/editclose` kills the editor pane via `tmux kill-pane`.
+
+### Non-tmux mode
+
+- For nvim-like editors, tries `nvr` (neovim-remote) to open in an existing
+  nvim instance. If `nvr` is not available, returns a guidance message.
+- For other editors, launches the editor command directly.
+- The full split-pane two-column experience requires tmux.
+
+### Path escaping
+
+- For vim `:e` command: spaces, `#`, `%`, and backslashes are escaped.
+- For shell commands: file paths are wrapped in single quotes with single-quote
+  escaping.
+
+## Configuration
+
+Config file: `~/.letta/mods/editor-config.json`
+
+```json
+{
+  "editor": "nvim",
+  "autoOpen": true,
+  "tmuxSize": 38
+}
+```
+
+Missing or malformed config falls back to defaults and emits a warning diagnostic.
+
+## Platform assumptions
+
+- Requires tmux for split-pane mode (tested on tmux 3.4, Linux).
+- Non-tmux nvim mode benefits from `nvr` (neovim-remote) if installed.
+- The editor binary must be on `PATH`.
+- Cross-platform: uses `windowsHide` to avoid console flashes on Windows.
+
+## Safety invariants
+
+- Only runs editor commands and tmux pane management. Never modifies files.
+- All `execFile` calls have a 5-second timeout.
+- Errors from tmux or editor commands are caught and surfaced as user-facing
+  messages, never as uncaught exceptions.
+- The mod degrades gracefully when capabilities are missing: no panel without
+  `ui.panels`, no auto-open without `events.tools`, no commands without
+  `commands`.
+- Event handler, panel, and command registrations are all disposed on reload.
+
+## Adaptation notes for agents
+
+- To support a new editor, just set `"editor"` in the config. Vim-like editors
+  (`nvim`, `vim`, `vi`, `neovim`) use `:e` send-keys; all others re-run the
+  editor command in the pane.
+- To add line-number jumping (open at a specific line), extend `openFile` to
+  send `:+<line>` or `:<line>` after `:e` for vim-like editors.
+- To track Bash-created files, parse `event.args.command` in the `tool_end`
+  handler — this is intentionally not done by default due to fragility.
+- The panel `render` function is pure and side-effect-free. All state updates
+  go through `panel.update()`.

--- a/packages/open-in-editor/README.md
+++ b/packages/open-in-editor/README.md
@@ -1,0 +1,111 @@
+# Open in Editor
+
+#open-in-editor
+
+A Letta Code mod that opens files in your editor as the agent touches them. When the agent edits or writes a file, it can auto-open in a tmux split pane (nvim/vim) or launch any editor command you configure — giving you a live two-column layout: chat on the left, editor on the right.
+
+## Install
+
+#install
+
+```
+letta install npm:@letta-ai/open-in-editor
+```
+
+Then reload local mods:
+
+```
+/reload
+```
+
+## Configuration
+
+#configuration
+
+Create `~/.letta/mods/editor-config.json`:
+
+```json
+{
+  "editor": "nvim",
+  "autoOpen": true,
+  "tmuxSize": 38
+}
+```
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `editor` | `"nvim"` | Editor binary name. Any editor on your `PATH` works (`nvim`, `vim`, `code`, `hx`, `emacsclient`, etc.) |
+| `autoOpen` | `true` | Automatically open files when the agent edits or writes them. Set to `false` for manual `/edit` only. |
+| `tmuxSize` | `38` | Width percentage for the tmux editor pane (e.g. `38` = 38% of the window) |
+
+If the config file is missing, the mod runs with defaults.
+
+## How it works
+
+#how-it-works
+
+**File tracking.** The mod listens to `tool_end` events for `Edit`, `Write`, and `Read` tools. It tracks the last touched file and shows it in a status panel above the input bar.
+
+**Auto-open.** When `autoOpen` is `true` (default), files edited via `Edit` or `Write` are automatically opened in the editor. Files only read via `Read` are tracked but not auto-opened (to avoid noise).
+
+**tmux split-pane.** When running inside tmux, the mod creates a right-side split pane with your editor. For nvim/vim, subsequent files are opened via `:e <path>` sent to the running instance — no new process, buffers and undo history are preserved. For other editors, the editor command is re-run in the pane.
+
+**Pane recovery.** After a `/reload`, the mod searches the current tmux window for a pane running your editor and reattaches to it. No duplicate panes.
+
+**Non-tmux.** Outside tmux, the mod tries `nvr` (neovim-remote) for nvim-like editors, or launches the editor command directly. For the full split-pane experience, run Letta Code inside tmux.
+
+## Commands
+
+#commands
+
+| Command | Description |
+| --- | --- |
+| `/edit [path]` | Open a file in your editor. With no argument, opens the last file the agent touched. |
+| `/editclose` | Close the editor pane (tmux only). |
+
+## Panel
+
+#panel
+
+A status line above the input shows the last touched file and editor pane state:
+
+```
+ edit src/main.ts (Edit)                    open %5
+```
+
+When no editor pane is open:
+
+```
+ edit src/main.ts (Edit)                    /edit
+```
+
+The panel is hidden until the agent touches a file.
+
+## Editor support
+
+#editor-support
+
+| Editor | tmux split | Non-tmux | Notes |
+| --- | --- | --- | --- |
+| `nvim` / `vim` | `:e` send-keys (preserves session) | `nvr` if installed | Best experience |
+| `code` | re-run `code <file>` in pane | `code <file>` | Opens in same window |
+| `hx` | re-run `hx <file>` in pane | `hx <file>` | New instance each time |
+| `emacsclient` | re-run in pane | direct | Opens in existing frame |
+
+## Safety
+
+#safety
+
+Mods are trusted local code. Review the source before installing third-party packages.
+
+This mod only runs editor commands and tmux pane management. It does not modify files or repositories.
+
+If a mod breaks startup or command handling, recover with:
+
+```
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [MOD.md](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/open-in-editor/README.md
+++ b/packages/open-in-editor/README.md
@@ -2,7 +2,10 @@
 
 #open-in-editor
 
-A Letta Code mod that opens files in your editor as the agent touches them. When the agent edits or writes a file, it can auto-open in a tmux split pane (nvim/vim) or launch any editor command you configure — giving you a live two-column layout: chat on the left, editor on the right.
+A Letta Code mod that opens files in your editor as the agent touches them — no external dependencies required. Two modes are auto-selected based on your environment:
+
+- **Outside tmux (default):** Fullscreen editor handoff. `/edit` exits the TUI, launches your editor with full terminal control, and restores the TUI when you quit — same pattern `git commit` uses for `$EDITOR`. Zero dependencies.
+- **Inside tmux:** Split-pane with `:e` send-keys. Creates a right-side editor pane and keeps it in sync as files change. Supports auto-open.
 
 ## Install
 
@@ -34,8 +37,8 @@ Create `~/.letta/mods/editor-config.json`:
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `editor` | `"nvim"` | Editor binary name. Any editor on your `PATH` works (`nvim`, `vim`, `code`, `hx`, `emacsclient`, etc.) |
-| `autoOpen` | `true` | Automatically open files when the agent edits or writes them. Set to `false` for manual `/edit` only. |
+| `editor` | `$VISUAL`, `$EDITOR`, or `"nvim"` | Editor binary name. Any editor on your `PATH` works (`nvim`, `vim`, `code`, `hx`, `emacsclient`, etc.) |
+| `autoOpen` | `true` | Auto-open files when the agent edits them. **tmux only** — in fullscreen mode, files are tracked but you open them manually with `/edit`. |
 | `tmuxSize` | `38` | Width percentage for the tmux editor pane (e.g. `38` = 38% of the window) |
 
 If the config file is missing, the mod runs with defaults.
@@ -46,13 +49,24 @@ If the config file is missing, the mod runs with defaults.
 
 **File tracking.** The mod listens to `tool_end` events for `Edit`, `Write`, and `Read` tools. It tracks the last touched file and shows it in a status panel above the input bar.
 
-**Auto-open.** When `autoOpen` is `true` (default), files edited via `Edit` or `Write` are automatically opened in the editor. Files only read via `Read` are tracked but not auto-opened (to avoid noise).
+### Fullscreen mode (outside tmux)
 
-**tmux split-pane.** When running inside tmux, the mod creates a right-side split pane with your editor. For nvim/vim, subsequent files are opened via `:e <path>` sent to the running instance — no new process, buffers and undo history are preserved. For other editors, the editor command is re-run in the pane.
+When you run `/edit`, the mod:
 
-**Pane recovery.** After a `/reload`, the mod searches the current tmux window for a pane running your editor and reattaches to it. No duplicate panes.
+1. Saves the terminal state (raw mode, alt screen buffer)
+2. Exits the alt screen buffer and clears the screen
+3. Blocks the event loop and launches your editor with inherited stdio — the editor has full, exclusive terminal access
+4. When you quit the editor, re-enters the alt screen, restores raw mode, and sends `SIGWINCH` to force the TUI to re-render
 
-**Non-tmux.** Outside tmux, the mod tries `nvr` (neovim-remote) for nvim-like editors, or launches the editor command directly. For the full split-pane experience, run Letta Code inside tmux.
+This is the same mechanism `git commit` uses to open `$EDITOR`. No tmux, no extra processes, no scrolling behavior changes.
+
+**Auto-open is disabled** in fullscreen mode because blocking the event loop would interrupt the agent's response. Files are tracked in the panel — use `/edit` when you want to view or edit them.
+
+### tmux split-pane mode (inside tmux)
+
+The mod creates a right-side split pane with your editor. For nvim/vim, subsequent files are opened via `:e <path>` sent to the running instance — no new process, buffers and undo history are preserved. For other editors, the editor command is re-run in the pane.
+
+Auto-open works in tmux: files edited by the agent are automatically opened in the editor pane. After a `/reload`, the mod searches for an existing editor pane and reattaches to it.
 
 ## Commands
 
@@ -61,22 +75,22 @@ If the config file is missing, the mod runs with defaults.
 | Command | Description |
 | --- | --- |
 | `/edit [path]` | Open a file in your editor. With no argument, opens the last file the agent touched. |
-| `/editclose` | Close the editor pane (tmux only). |
+| `/editclose` | Close the editor pane (tmux only). In fullscreen mode, just `:q` your editor. |
 
 ## Panel
 
 #panel
 
-A status line above the input shows the last touched file and editor pane state:
+A status line above the input shows the last touched file and editor state:
 
+Fullscreen mode:
+```
+ edit src/main.ts (Edit)                    /edit to open
+```
+
+tmux with pane open:
 ```
  edit src/main.ts (Edit)                    open %5
-```
-
-When no editor pane is open:
-
-```
- edit src/main.ts (Edit)                    /edit
 ```
 
 The panel is hidden until the agent touches a file.
@@ -85,12 +99,14 @@ The panel is hidden until the agent touches a file.
 
 #editor-support
 
-| Editor | tmux split | Non-tmux | Notes |
+| Editor | Fullscreen (no tmux) | tmux split | Notes |
 | --- | --- | --- | --- |
-| `nvim` / `vim` | `:e` send-keys (preserves session) | `nvr` if installed | Best experience |
-| `code` | re-run `code <file>` in pane | `code <file>` | Opens in same window |
-| `hx` | re-run `hx <file>` in pane | `hx <file>` | New instance each time |
-| `emacsclient` | re-run in pane | direct | Opens in existing frame |
+| `nvim` / `vim` | Fullscreen handoff | `:e` send-keys (preserves session) | Best experience |
+| `code` | Fullscreen handoff | re-run `code <file>` in pane | Opens in same window |
+| `hx` | Fullscreen handoff | re-run `hx <file>` in pane | New instance each time |
+| `emacsclient` | Fullscreen handoff | re-run in pane | Opens in existing frame |
+
+Any editor that works with `$EDITOR` will work in fullscreen mode.
 
 ## Safety
 

--- a/packages/open-in-editor/mods/index.ts
+++ b/packages/open-in-editor/mods/index.ts
@@ -1,13 +1,16 @@
 // Open files in your editor as the agent touches them.
 //
-// When the agent edits or writes a file, the mod can auto-open it in a
-// tmux split pane (nvim/vim) or launch an external editor command.
-// Provides /edit and /editclose commands and a status panel.
+// Two modes, auto-selected based on environment:
+// - Inside tmux: split-pane with :e send-keys (preserves buffers, auto-open)
+// - Outside tmux: fullscreen editor handoff — exits the alt screen, blocks
+//   the event loop while the editor runs with inherited stdio, then
+//   re-enters and forces a re-render. No external dependencies needed.
 //
+// Commands: /edit [path], /editclose
 // Config: ~/.letta/mods/editor-config.json
 //   { "editor": "nvim", "autoOpen": true, "tmuxSize": 38 }
 
-import { execFile } from "node:child_process";
+import { execFileSync, execFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
@@ -17,16 +20,16 @@ import { homedir } from "node:os";
 const CONFIG_PATH = join(homedir(), ".letta", "mods", "editor-config.json");
 
 interface EditorConfig {
-  /** Editor binary name (default: "nvim") */
+  /** Editor binary name (default: $VISUAL, $EDITOR, or "nvim") */
   editor: string;
-  /** Auto-open files when the agent edits them (default: true) */
+  /** Auto-open files when the agent edits them — tmux only (default: true) */
   autoOpen: boolean;
   /** tmux split pane width as percentage of the window (default: 38) */
   tmuxSize: number;
 }
 
 const DEFAULTS: EditorConfig = {
-  editor: "nvim",
+  editor: process.env.VISUAL || process.env.EDITOR || "nvim",
   autoOpen: true,
   tmuxSize: 38,
 };
@@ -99,6 +102,55 @@ function extractFilePath(args: Record<string, unknown>): string | null {
   return typeof fp === "string" && fp.length > 0 ? fp : null;
 }
 
+// ─── Fullscreen editor handoff ────────────────────────────────────────
+//
+// Exits the alt screen buffer, disables raw mode, and blocks the event
+// loop while the editor runs with inherited stdio. When the editor exits,
+// re-enters the alt screen and sends SIGWINCH to force Ink to re-render.
+// Same pattern `git commit` uses to open $EDITOR — no tmux or deps needed.
+
+function openEditorFullscreen(filePath: string, editor: string): string {
+  const stdin = process.stdin as any;
+  const stdout = process.stdout;
+
+  // Save terminal state
+  const wasRaw = typeof stdin.isRaw === "boolean" ? stdin.isRaw : false;
+
+  // Release terminal for the editor
+  if (wasRaw) {
+    try { stdin.setRawMode(false); } catch {}
+  }
+  // Exit alt screen + clear
+  stdout.write("\x1b[?1049l\x1b[2J\x1b[H");
+
+  let errorMsg: string | null = null;
+  try {
+    execFileSync(editor, [filePath], {
+      stdio: "inherit",
+      timeout: 0,
+    });
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      errorMsg = `Editor '${editor}' not found on PATH.`;
+    } else if (err?.signal) {
+      // Killed by signal (e.g. Ctrl-C) — not an error
+    } else if (err?.status != null && err.status !== 0) {
+      errorMsg = `Editor exited with code ${err.status}.`;
+    }
+  }
+
+  // Reclaim terminal
+  stdout.write("\x1b[?1049h");
+  if (wasRaw) {
+    try { stdin.setRawMode(true); } catch {}
+  }
+
+  // Force Ink to re-render by simulating a terminal resize
+  try { process.kill(process.pid, "SIGWINCH"); } catch {}
+
+  return errorMsg ?? `Opened ${shortenPath(filePath)} in ${editor}`;
+}
+
 // ─── tmux pane management ────────────────────────────────────────────
 
 let tmuxPaneId: string | null = null;
@@ -118,67 +170,43 @@ async function tmuxPaneAlive(): Promise<boolean> {
 async function findEditorPane(editor: string): Promise<string | null> {
   try {
     const { stdout } = await exec("tmux", [
-      "list-panes",
-      "-F",
-      "#{pane_id}\t#{pane_current_command}",
+      "list-panes", "-F", "#{pane_id}\t#{pane_current_command}",
     ]);
     const target = editor.toLowerCase().trim();
     for (const line of stdout.trim().split("\n")) {
       const [paneId, cmd] = line.split("\t");
       if (cmd && cmd.toLowerCase().trim() === target) return paneId;
     }
-  } catch {
-    // not in tmux or no panes
-  }
+  } catch {}
   return null;
 }
 
-async function tmuxOpenFile(
-  filePath: string,
-  config: EditorConfig,
-): Promise<string> {
-  // Recover pane tracking after a reload
+async function tmuxOpenFile(filePath: string, config: EditorConfig): Promise<string> {
   if (!tmuxPaneId) {
     tmuxPaneId = await findEditorPane(config.editor);
   }
 
   if (await tmuxPaneAlive()) {
     if (isVimLike(config.editor)) {
-      // Send :e to the running nvim/vim instance
       const escaped = escapeVimPath(filePath);
       await exec("tmux", [
-        "send-keys",
-        "-t",
-        tmuxPaneId!,
-        "Escape",
-        `:e ${escaped}`,
-        "Enter",
+        "send-keys", "-t", tmuxPaneId!,
+        "Escape", `:e ${escaped}`, "Enter",
       ]);
     } else {
-      // For non-vim editors, re-run the editor command in the pane
       await exec("tmux", [
-        "send-keys",
-        "-t",
-        tmuxPaneId!,
-        `${config.editor} '${escapeShellSingle(filePath)}'`,
-        "Enter",
+        "send-keys", "-t", tmuxPaneId!,
+        `${config.editor} '${escapeShellSingle(filePath)}'`, "Enter",
       ]);
     }
     return `Opened ${shortenPath(filePath)} in editor`;
   }
 
-  // Create a new split pane with the editor
   try {
     const shellCmd = `${config.editor} '${escapeShellSingle(filePath)}'`;
     const { stdout } = await exec("tmux", [
-      "split-window",
-      "-h",
-      "-p",
-      String(config.tmuxSize),
-      "-P",
-      "-F",
-      "#{pane_id}",
-      shellCmd,
+      "split-window", "-h", "-p", String(config.tmuxSize),
+      "-P", "-F", "#{pane_id}", shellCmd,
     ]);
     tmuxPaneId = stdout.trim();
     return `Opened ${shortenPath(filePath)} in new editor pane`;
@@ -201,31 +229,12 @@ async function tmuxClosePane(): Promise<string> {
 
 // ─── Open dispatcher ─────────────────────────────────────────────────
 
-async function openFile(
-  filePath: string,
-  config: EditorConfig,
-): Promise<string> {
+async function openFile(filePath: string, config: EditorConfig): Promise<string> {
   if (inTmux()) {
     return tmuxOpenFile(filePath, config);
   }
-
-  // Non-tmux: try nvr (neovim-remote) for nvim-like editors
-  if (isVimLike(config.editor)) {
-    try {
-      await exec("nvr", [filePath]);
-      return `Opened ${shortenPath(filePath)} via nvr`;
-    } catch {
-      return "Not in tmux. Run /edit inside tmux for split-pane, or install nvr for remote nvim.";
-    }
-  }
-
-  // Generic: try to launch the editor directly
-  try {
-    await exec(config.editor, [filePath]);
-    return `Opened ${shortenPath(filePath)} in ${config.editor}`;
-  } catch {
-    return `Could not launch ${config.editor}. Run inside tmux for best results.`;
-  }
+  // Fullscreen editor handoff — no tmux needed
+  return openEditorFullscreen(filePath, config.editor);
 }
 
 // Serialize auto-open calls to prevent tmux key interleaving when the
@@ -233,10 +242,7 @@ async function openFile(
 let opening = false;
 let queued: string | null = null;
 
-async function autoOpen(
-  filePath: string,
-  config: EditorConfig,
-): Promise<void> {
+async function autoOpen(filePath: string, config: EditorConfig): Promise<void> {
   if (opening) {
     queued = filePath;
     return;
@@ -244,9 +250,7 @@ async function autoOpen(
   opening = true;
   try {
     await openFile(filePath, config);
-  } catch {
-    // errors are surfaced via the returned string in manual /edit
-  } finally {
+  } catch {} finally {
     opening = false;
     if (queued) {
       const next = queued;
@@ -272,6 +276,8 @@ export default function activate(letta: any) {
   let lastFile: string | null = null;
   let lastTool: string | null = null;
 
+  const useTmux = inTmux();
+
   // ── Status panel ──
   let panel: any = null;
   if (letta.capabilities.ui?.panels) {
@@ -281,16 +287,18 @@ export default function activate(letta: any) {
       render: ({ width, row, chalk }: any) => {
         if (!lastFile) return "";
         const left = `${chalk.cyan("edit")} ${shortenPath(lastFile)} ${chalk.gray(`(${lastTool})`)}`;
-        const right = tmuxPaneId
-          ? `${chalk.green("open")} ${chalk.gray(tmuxPaneId)}`
-          : chalk.gray("/edit");
+        const right = useTmux
+          ? (tmuxPaneId
+            ? `${chalk.green("open")} ${chalk.gray(tmuxPaneId)}`
+            : chalk.gray("/edit"))
+          : chalk.gray("/edit to open");
         return row(left, right, width);
       },
     });
     disposers.push(() => panel?.close());
   }
 
-  // ── Tool end: track files and auto-open ──
+  // ── Tool end: track files and auto-open (tmux only) ──
   if (letta.capabilities.events?.tools) {
     disposers.push(
       letta.events.on("tool_end", (event: any) => {
@@ -303,7 +311,8 @@ export default function activate(letta: any) {
         lastTool = event.toolName;
         panel?.update();
 
-        if (AUTO_OPEN_TOOLS.has(event.toolName) && config.autoOpen) {
+        // Auto-open only in tmux — fullscreen would block the event loop
+        if (AUTO_OPEN_TOOLS.has(event.toolName) && config.autoOpen && useTmux) {
           void autoOpen(filePath, config).then(() => panel?.update());
         }
       }),
@@ -335,11 +344,11 @@ export default function activate(letta: any) {
     disposers.push(
       letta.commands.register({
         id: "editclose",
-        description: "Close the editor pane",
+        description: "Close the editor pane (tmux only)",
         async run() {
-          const result = inTmux()
+          const result = useTmux
             ? await tmuxClosePane()
-            : "Not in tmux \u2014 nothing to close";
+            : "Not in tmux \u2014 use :q in the editor to close";
           panel?.update();
           return { type: "output", output: result };
         },

--- a/packages/open-in-editor/mods/index.ts
+++ b/packages/open-in-editor/mods/index.ts
@@ -1,0 +1,353 @@
+// Open files in your editor as the agent touches them.
+//
+// When the agent edits or writes a file, the mod can auto-open it in a
+// tmux split pane (nvim/vim) or launch an external editor command.
+// Provides /edit and /editclose commands and a status panel.
+//
+// Config: ~/.letta/mods/editor-config.json
+//   { "editor": "nvim", "autoOpen": true, "tmuxSize": 38 }
+
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ─── Config ──────────────────────────────────────────────────────────
+
+const CONFIG_PATH = join(homedir(), ".letta", "mods", "editor-config.json");
+
+interface EditorConfig {
+  /** Editor binary name (default: "nvim") */
+  editor: string;
+  /** Auto-open files when the agent edits them (default: true) */
+  autoOpen: boolean;
+  /** tmux split pane width as percentage of the window (default: 38) */
+  tmuxSize: number;
+}
+
+const DEFAULTS: EditorConfig = {
+  editor: "nvim",
+  autoOpen: true,
+  tmuxSize: 38,
+};
+
+let configError: string | null = null;
+
+function loadConfig(): EditorConfig {
+  try {
+    if (existsSync(CONFIG_PATH)) {
+      return { ...DEFAULTS, ...JSON.parse(readFileSync(CONFIG_PATH, "utf-8")) };
+    }
+  } catch (err) {
+    configError = err instanceof Error ? err.message : String(err);
+  }
+  return { ...DEFAULTS };
+}
+
+// ─── Process helpers ─────────────────────────────────────────────────
+
+function exec(
+  cmd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { timeout: 5_000, windowsHide: true }, (err, stdout, stderr) => {
+      if (err) reject(err);
+      else resolve({ stdout, stderr });
+    });
+  });
+}
+
+function inTmux(): boolean {
+  return !!process.env.TMUX;
+}
+
+function isVimLike(editor: string): boolean {
+  const e = editor.toLowerCase().trim();
+  return e === "nvim" || e === "vim" || e === "vi" || e === "neovim";
+}
+
+/** Escape a path for use inside vim's :e command */
+function escapeVimPath(path: string): string {
+  return path
+    .replace(/\\/g, "\\\\")
+    .replace(/ /g, "\\ ")
+    .replace(/#/g, "\\#")
+    .replace(/%/g, "\\%");
+}
+
+/** Escape a path for use inside single-quoted shell arguments */
+function escapeShellSingle(path: string): string {
+  return path.replace(/'/g, "'\\''");
+}
+
+/** Shorten a file path for display in the panel */
+function shortenPath(path: string, max = 48): string {
+  if (path.length <= max) return path;
+  const parts = path.split("/");
+  if (parts.length <= 2) return path;
+  return "\u2026/" + parts.slice(-2).join("/");
+}
+
+// ─── File tracking ───────────────────────────────────────────────────
+
+const FILE_TOOLS = new Set(["Edit", "Write", "Read"]);
+const AUTO_OPEN_TOOLS = new Set(["Edit", "Write"]);
+
+function extractFilePath(args: Record<string, unknown>): string | null {
+  const fp = args.file_path;
+  return typeof fp === "string" && fp.length > 0 ? fp : null;
+}
+
+// ─── tmux pane management ────────────────────────────────────────────
+
+let tmuxPaneId: string | null = null;
+
+async function tmuxPaneAlive(): Promise<boolean> {
+  if (!tmuxPaneId) return false;
+  try {
+    await exec("tmux", ["display-message", "-p", "-t", tmuxPaneId, "#{pane_id}"]);
+    return true;
+  } catch {
+    tmuxPaneId = null;
+    return false;
+  }
+}
+
+/** Search the current tmux window for a pane running the editor (recovery after reload) */
+async function findEditorPane(editor: string): Promise<string | null> {
+  try {
+    const { stdout } = await exec("tmux", [
+      "list-panes",
+      "-F",
+      "#{pane_id}\t#{pane_current_command}",
+    ]);
+    const target = editor.toLowerCase().trim();
+    for (const line of stdout.trim().split("\n")) {
+      const [paneId, cmd] = line.split("\t");
+      if (cmd && cmd.toLowerCase().trim() === target) return paneId;
+    }
+  } catch {
+    // not in tmux or no panes
+  }
+  return null;
+}
+
+async function tmuxOpenFile(
+  filePath: string,
+  config: EditorConfig,
+): Promise<string> {
+  // Recover pane tracking after a reload
+  if (!tmuxPaneId) {
+    tmuxPaneId = await findEditorPane(config.editor);
+  }
+
+  if (await tmuxPaneAlive()) {
+    if (isVimLike(config.editor)) {
+      // Send :e to the running nvim/vim instance
+      const escaped = escapeVimPath(filePath);
+      await exec("tmux", [
+        "send-keys",
+        "-t",
+        tmuxPaneId!,
+        "Escape",
+        `:e ${escaped}`,
+        "Enter",
+      ]);
+    } else {
+      // For non-vim editors, re-run the editor command in the pane
+      await exec("tmux", [
+        "send-keys",
+        "-t",
+        tmuxPaneId!,
+        `${config.editor} '${escapeShellSingle(filePath)}'`,
+        "Enter",
+      ]);
+    }
+    return `Opened ${shortenPath(filePath)} in editor`;
+  }
+
+  // Create a new split pane with the editor
+  try {
+    const shellCmd = `${config.editor} '${escapeShellSingle(filePath)}'`;
+    const { stdout } = await exec("tmux", [
+      "split-window",
+      "-h",
+      "-p",
+      String(config.tmuxSize),
+      "-P",
+      "-F",
+      "#{pane_id}",
+      shellCmd,
+    ]);
+    tmuxPaneId = stdout.trim();
+    return `Opened ${shortenPath(filePath)} in new editor pane`;
+  } catch (err) {
+    return `Failed to create editor pane: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+async function tmuxClosePane(): Promise<string> {
+  if (!tmuxPaneId) return "No editor pane to close";
+  try {
+    await exec("tmux", ["kill-pane", "-t", tmuxPaneId]);
+    tmuxPaneId = null;
+    return "Editor pane closed";
+  } catch {
+    tmuxPaneId = null;
+    return "Editor pane was already closed";
+  }
+}
+
+// ─── Open dispatcher ─────────────────────────────────────────────────
+
+async function openFile(
+  filePath: string,
+  config: EditorConfig,
+): Promise<string> {
+  if (inTmux()) {
+    return tmuxOpenFile(filePath, config);
+  }
+
+  // Non-tmux: try nvr (neovim-remote) for nvim-like editors
+  if (isVimLike(config.editor)) {
+    try {
+      await exec("nvr", [filePath]);
+      return `Opened ${shortenPath(filePath)} via nvr`;
+    } catch {
+      return "Not in tmux. Run /edit inside tmux for split-pane, or install nvr for remote nvim.";
+    }
+  }
+
+  // Generic: try to launch the editor directly
+  try {
+    await exec(config.editor, [filePath]);
+    return `Opened ${shortenPath(filePath)} in ${config.editor}`;
+  } catch {
+    return `Could not launch ${config.editor}. Run inside tmux for best results.`;
+  }
+}
+
+// Serialize auto-open calls to prevent tmux key interleaving when the
+// agent edits multiple files in rapid succession.
+let opening = false;
+let queued: string | null = null;
+
+async function autoOpen(
+  filePath: string,
+  config: EditorConfig,
+): Promise<void> {
+  if (opening) {
+    queued = filePath;
+    return;
+  }
+  opening = true;
+  try {
+    await openFile(filePath, config);
+  } catch {
+    // errors are surfaced via the returned string in manual /edit
+  } finally {
+    opening = false;
+    if (queued) {
+      const next = queued;
+      queued = null;
+      void autoOpen(next, config);
+    }
+  }
+}
+
+// ─── Activation ─────────────────────────────────────────────────────
+
+export default function activate(letta: any) {
+  const config = loadConfig();
+  const disposers: Array<() => void> = [];
+
+  if (configError) {
+    letta.diagnostics?.report?.({
+      severity: "warning",
+      message: `editor-config.json: ${configError}. Using defaults.`,
+    });
+  }
+
+  let lastFile: string | null = null;
+  let lastTool: string | null = null;
+
+  // ── Status panel ──
+  let panel: any = null;
+  if (letta.capabilities.ui?.panels) {
+    panel = letta.ui.openPanel({
+      id: "open-in-editor",
+      order: 100,
+      render: ({ width, row, chalk }: any) => {
+        if (!lastFile) return "";
+        const left = `${chalk.cyan("edit")} ${shortenPath(lastFile)} ${chalk.gray(`(${lastTool})`)}`;
+        const right = tmuxPaneId
+          ? `${chalk.green("open")} ${chalk.gray(tmuxPaneId)}`
+          : chalk.gray("/edit");
+        return row(left, right, width);
+      },
+    });
+    disposers.push(() => panel?.close());
+  }
+
+  // ── Tool end: track files and auto-open ──
+  if (letta.capabilities.events?.tools) {
+    disposers.push(
+      letta.events.on("tool_end", (event: any) => {
+        if (event.status !== "success") return;
+        if (!FILE_TOOLS.has(event.toolName)) return;
+        const filePath = extractFilePath(event.args ?? {});
+        if (!filePath) return;
+
+        lastFile = filePath;
+        lastTool = event.toolName;
+        panel?.update();
+
+        if (AUTO_OPEN_TOOLS.has(event.toolName) && config.autoOpen) {
+          void autoOpen(filePath, config).then(() => panel?.update());
+        }
+      }),
+    );
+  }
+
+  // ── /edit command ──
+  if (letta.capabilities.commands) {
+    disposers.push(
+      letta.commands.register({
+        id: "edit",
+        description: "Open a file in your editor (defaults to last touched file)",
+        args: "[path]",
+        async run(ctx: any) {
+          const filePath = (ctx.args ?? "").trim() || lastFile;
+          if (!filePath) {
+            return {
+              type: "output",
+              output: "No file to open. Use /edit <path> or have the agent edit a file first.",
+            };
+          }
+          const result = await openFile(filePath, config);
+          panel?.update();
+          return { type: "output", output: result };
+        },
+      }),
+    );
+
+    disposers.push(
+      letta.commands.register({
+        id: "editclose",
+        description: "Close the editor pane",
+        async run() {
+          const result = inTmux()
+            ? await tmuxClosePane()
+            : "Not in tmux \u2014 nothing to close";
+          panel?.update();
+          return { type: "output", output: result };
+        },
+      }),
+    );
+  }
+
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/open-in-editor/package.json
+++ b/packages/open-in-editor/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@letta-ai/open-in-editor",
+  "version": "0.1.0",
+  "description": "Open files in your editor as the agent touches them — tmux split-pane for nvim/vim, or any editor command.",
+  "author": "ninachaubal",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "editor",
+    "nvim",
+    "vim",
+    "tmux"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/open-in-editor"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["commands", "events.tools", "ui.panels"],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New `open-in-editor` mod package that tracks files the agent touches (Edit/Write/Read) via `tool_end` events
- Auto-opens edited files in a configurable editor (defaults to `nvim`)
- In tmux: creates a right-side split pane, sends `:e <path>` to the running nvim/vim instance (preserves buffers/undo history)
- Outside tmux: tries `nvr` (neovim-remote), falls back to launching the editor directly
- Generic: supports any editor command (`nvim`, `vim`, `code`, `hx`, `emacsclient`, etc.)
- Provides `/edit [path]` and `/editclose` commands
- Status panel above the input showing last touched file and editor pane state
- Configurable via `~/.letta/mods/editor-config.json`

## Test plan

- [ ] Install mod locally, run `/reload`
- [ ] Inside tmux: have the agent edit a file — verify a split pane opens with nvim
- [ ] Edit a second file — verify `:e` is sent to the existing nvim instance (no new pane)
- [ ] Run `/editclose` — verify the pane is killed
- [ ] Run `/edit <path>` manually — verify it opens the specified file
- [ ] After `/reload` — verify the mod reattaches to an existing editor pane instead of creating a duplicate
- [ ] Outside tmux — verify graceful fallback message
- [ ] Verify panel shows correct file name and tool type
- [ ] Verify `editor-config.json` with `"autoOpen": false` disables auto-open

👾 Generated with [Letta Code](https://letta.com)