### PR TITLE
feat: add shubsense mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ packages/
 ├── plan-mode/            # Plan-mode style workflow
 ├── ponytail/             # Lazy senior dev mode — YAGNI ladder for less, simpler code
 ├── soft-landing/         # Recovery slash command for drift, compaction, or context overload
+├── shubsense/            # Low-probability "doesn't make sense" follow-up tester
 ├── spotify-statusline/   # macOS Spotify now-playing statusline
 ├── sprite/               # Persistent pet that grows stats from real agent work
 ├── threadkeeper/         # Live operational anchors for commitments and open loops
@@ -122,6 +123,7 @@ scripts/
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
 - **ponytail** - Lazy senior dev mode that injects a YAGNI ladder ruleset to write less, simpler code
 - **soft-landing** - Recovery slash command for drift, compaction, or context overload
+- **shubsense** - Low-probability "doesn't make sense" follow-up tester
 - **spotify-statusline** - macOS Spotify now-playing statusline
 - **sprite** - Persistent pet that grows stats from real agent work
 - **threadkeeper** - Live operational anchors for commitments, open loops, temporary boundaries, modes, drift guards, and due state

--- a/packages/shubsense/MOD.md
+++ b/packages/shubsense/MOD.md
@@ -1,0 +1,28 @@
+---
+name: "@letta-ai/shubsense"
+description: "Occasionally injects a follow-up user message saying \"doesn't make sense\" to exercise mod-driven continuation turns"
+---
+
+# Shubsense mod semantics
+
+## When to use
+
+Use this mod only for testing or demonstrating `turn_end { continue }` behavior. It intentionally creates a low-probability follow-up user message.
+
+## Behavior
+
+On each `turn_end` event:
+
+1. Ignore non-`end_turn` stop reasons.
+2. Roll a 5% probability check.
+3. When triggered, return `{ continue: "doesn't make sense" }`.
+
+The runtime converts that result into a `mod_continue` follow-up turn. This tests that mod-injected user messages flow through the normal Letta Code turn pipeline without hand-written REST calls.
+
+## Safety invariants
+
+- The probability is fixed at 5%.
+- The mod does not mutate the current turn.
+- The mod does not call Letta REST APIs directly.
+- The mod uses only the public `turn_end` event API.
+- The mod registers a single event handler and returns its disposer.

--- a/packages/shubsense/README.md
+++ b/packages/shubsense/README.md
@@ -1,0 +1,42 @@
+# Shubsense
+
+A Letta Code mod that occasionally follows up with:
+
+```text
+doesn't make sense
+```
+
+This is a joke/debug mod for testing mod-driven follow-up turns. Install it only if you want the agent to sometimes challenge itself after a normal turn.
+
+## Install
+
+```bash
+letta install npm:@letta-ai/shubsense
+```
+
+Then reload local mods:
+
+```text
+/reload
+```
+
+## Behavior
+
+- Runs on `turn_end`.
+- Only reacts to normal `end_turn` completions.
+- Has a 5% chance to return `{ continue: "doesn't make sense" }`.
+- The follow-up is sent as a user message through Letta Code's `mod_continue` path, so it exercises the same turn pipeline as a normal user follow-up.
+
+## Safety
+
+This mod intentionally injects low-probability nonsense into the conversation. Keep it opt-in and disable/remove it if it becomes disruptive.
+
+Recover with:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavioral contract.

--- a/packages/shubsense/mods/index.ts
+++ b/packages/shubsense/mods/index.ts
@@ -1,0 +1,19 @@
+const TRIGGER_PROBABILITY = 0.05;
+
+export default function activate(letta) {
+  if (!letta.capabilities.events.turns) {
+    letta.diagnostics?.report?.({
+      severity: "warning",
+      message:
+        "shubsense requires turn events, but this host does not expose them.",
+    });
+    return;
+  }
+
+  return letta.events.on("turn_end", (event) => {
+    if (event.stopReason !== "end_turn") return;
+    if (Math.random() >= TRIGGER_PROBABILITY) return;
+
+    return { continue: "doesn't make sense" };
+  });
+}

--- a/packages/shubsense/package.json
+++ b/packages/shubsense/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@letta-ai/shubsense",
+  "version": "0.1.0",
+  "description": "A Letta Code mod that occasionally follows up with \"doesn't make sense\".",
+  "author": "Letta",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "turn-events",
+    "humor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/shubsense"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["events.turns"],
+    "engines": {
+      "lettaCodeCli": ">=0.28.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `@letta-ai/shubsense`, a small opt-in mod that uses `turn_end { continue }` to occasionally inject a follow-up user turn saying `doesn't make sense`.

This is primarily a test/demo mod for mod-driven continuation turns. It exercises the public `turn_end` event API and the runtime's `mod_continue` user-message path without calling the REST messages API directly.

## Behavior

- Runs on `turn_end`
- Ignores non-`end_turn` stop reasons
- 5% chance to return `{ continue: "doesn't make sense" }`
- Follow-up goes through the normal Letta Code turn pipeline

## Validation

- `npm run validate`
- Local harness test with the same mod shape at 90% confirmed `turn_end { continue }` fires repeatedly
- Filed Desktop rendering follow-up for hidden continuation user messages: LET-9807
