### PR TITLE
feat: add Linear mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ packages/
 ├── hypa/                 # Local context runtime that compresses noisy tool output
 ├── image-understanding/  # Vision bridge for text-only agents
 ├── jukebox/              # Jamendo-powered terminal music player
+├── linear/               # Batched Linear issue operations with dry-run guards
 ├── memfs-search/         # Agent-callable MemFS memory search
 ├── muscle-memory/        # Self-maintaining skill library from real tool-use patterns
 ├── oath-keeper/          # Detects agent promises and delivers on them automatically
@@ -114,6 +115,7 @@ scripts/
 - **hypa** - Local context runtime that compresses noisy tool output
 - **image-understanding** - Image-understanding tool, commands, and optional auto-captioning for text-only agents
 - **jukebox** - Jamendo-powered terminal music player with a now-playing panel
+- **linear** - Batched Linear issue reads and writes with dry-run previews and stale-state guards
 - **memfs-search** - Agent-callable MemFS memory search with optional QMD semantic/hybrid search
 - **muscle-memory** - Self-maintaining skill library from real tool-use patterns
 - **oath-keeper** - Detects agent promises and delivers on them automatically

--- a/packages/linear/MOD.md
+++ b/packages/linear/MOD.md
@@ -1,0 +1,24 @@
+---
+name: linear
+description: "Batched Linear issue tools with dry-run previews, rich reads, and stale-state guards."
+---
+
+# Linear mod
+
+Use this mod for direct Linear reads and writes. Keep triage policy, ownership rules, and automation in skills; the mod provides bounded primitives.
+
+## Behavior
+
+- Batch related reads with `identifiers`; summary reads allow 50 and full reads allow 5.
+- Read issues before writes.
+- Use `dry_run: true` to preview any create, update, comment, or relation operation without mutations.
+- Use `expected` on updates/comments when acting on previously read state. Guards support `updated_at`, state, assignee/unassigned, project/no-project, and priority.
+- Treat guards as best-effort stale-state protection, not atomic compare-and-swap.
+- Batch writes are sequential, stop after cancellation, and return per-item failures.
+- `blocked-by` is normalized to the inverse `blocks` relation. `related` is symmetric.
+
+## Authentication and team selection
+
+The mod invokes the authenticated `@schpet/linear-cli` and never reads its API token. The child environment is allowlisted and excludes secret-bearing variables.
+
+One-team workspaces are detected automatically. In multi-team workspaces, set `LINEAR_TEAM_KEY` before starting Letta Code. The team key is configuration, not a credential, and is not forwarded to the CLI child process.

--- a/packages/linear/README.md
+++ b/packages/linear/README.md
@@ -1,0 +1,50 @@
+# Linear
+
+A Letta Code mod for reading and updating Linear without a chain of one-ticket tool calls.
+
+It adds batched issue reads, rich issue detail, creates, updates, comments, and relations. Every write tool supports `dry_run: true`; updates and comments can also reject stale work with `expected` state.
+
+## Setup
+
+Install and authenticate the Linear CLI:
+
+```bash
+npm install -g @schpet/linear-cli
+linear auth login
+```
+
+The CLI stores credentials in the system keyring by default. The mod delegates authentication to the CLI and does not read `LINEAR_API_KEY`.
+
+Install the mod and reload Letta Code:
+
+```bash
+letta install npm:@letta-ai/linear
+```
+
+```text
+/reload
+```
+
+A workspace with one team is detected automatically. For a multi-team workspace, set the non-secret team key before starting Letta Code:
+
+```bash
+LINEAR_TEAM_KEY=ENG letta
+```
+
+## Tools
+
+- `linear_search` and `linear_issue`: batched summary or full reads
+- `linear_create`: up to 20 issues plus relations using local aliases
+- `linear_update` and `linear_comment`: one operation across up to 50 issues
+- `linear_relation`: batched `blocks`, `blocked-by`, `related`, and `duplicate` relations
+
+Write tools require approval, execute sequentially, stop on cancellation, and preserve per-item failures. `dry_run` executes no mutations. `expected` guards are checked immediately before each update/comment, but they are best-effort preconditions rather than atomic compare-and-swap operations.
+
+The Linear subprocess receives an allowlisted environment containing only operational values such as paths, locale, temporary directories, and keyring/session access. Letta keys, Linear API keys, cloud credentials, and unrelated agent secrets are not passed through.
+
+## Development
+
+```bash
+cd packages/linear
+bun test
+```

--- a/packages/linear/mods/index.ts
+++ b/packages/linear/mods/index.ts
@@ -1,0 +1,3 @@
+import { activateLinearMod } from "../src/activate.ts";
+
+export default activateLinearMod;

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@letta-ai/linear",
+  "version": "0.1.0",
+  "description": "Batched Linear issue tools with dry-run previews and stale-state guards for Letta Code.",
+  "author": "overlord-letta",
+  "license": "Apache-2.0",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "linear",
+    "issue-tracking",
+    "project-management"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/linear"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods",
+    "src"
+  ],
+  "scripts": {
+    "test": "bun test ./tests"
+  },
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": [
+      "commands",
+      "tools",
+      "ui.panels"
+    ],
+    "engines": {
+      "lettaCodeCli": ">=0.28.14"
+    }
+  }
+}

--- a/packages/linear/src/activate.ts
+++ b/packages/linear/src/activate.ts
@@ -1,0 +1,13 @@
+import { LinearClient } from "./client.ts";
+import { registerLinearCommand } from "./command.ts";
+import { registerLinearTools } from "./tools.ts";
+
+export function activateLinearMod(letta: any): () => void {
+  const client = new LinearClient();
+  const disposers: Array<() => void> = [];
+  if (letta.capabilities.commands) disposers.push(...registerLinearCommand(letta, client));
+  if (letta.capabilities.tools) disposers.push(...registerLinearTools(letta, client));
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
+}

--- a/packages/linear/src/client.ts
+++ b/packages/linear/src/client.ts
@@ -1,0 +1,177 @@
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { promisify } from "node:util";
+import {
+  CONFIGURED_TEAMS_QUERY,
+  DEFAULT_LIMIT,
+  ISSUE_FULL_QUERY,
+  ISSUE_SUMMARY_QUERY,
+} from "./config.ts";
+import type {
+  IssueDetail,
+  LinearConnection,
+  LinearIssue,
+  LinearRunner,
+  LinearTeam,
+  QueryResult,
+} from "./types.ts";
+import { compactError, normalizeIssueIdentifier } from "./utils.ts";
+
+const execFileAsync = promisify(execFile);
+const CHILD_ENV_KEYS = [
+  "PATH",
+  "HOME",
+  "XDG_CONFIG_HOME",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "USERPROFILE",
+  "SYSTEMROOT",
+  "COMSPEC",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "LANG",
+  "LC_ALL",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "XDG_RUNTIME_DIR",
+  "DISPLAY",
+  "WAYLAND_DISPLAY",
+  "SECURITYSESSIONID",
+  "NO_COLOR",
+] as const;
+
+export function buildLinearChildEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of CHILD_ENV_KEYS) {
+    if (source[key] !== undefined) env[key] = source[key];
+  }
+  return env;
+}
+
+export function readLinearTeamKey(source: NodeJS.ProcessEnv = process.env): string | undefined {
+  const value = source.LINEAR_TEAM_KEY?.trim();
+  return value || undefined;
+}
+
+export function formatLinearProcessError(error: unknown): string {
+  if (!error || typeof error !== "object") return "Linear CLI failed";
+  const candidate = error as { stderr?: string; stdout?: string; code?: string | number };
+  const output = candidate.stderr?.trim() || candidate.stdout?.trim();
+  if (output) return compactError(output);
+  if (candidate.code === "ENOENT") return "Linear CLI executable not found";
+  return candidate.code !== undefined
+    ? `Linear CLI failed (exit ${String(candidate.code)})`
+    : "Linear CLI failed";
+}
+
+export function createLinearRunner(executable = "linear"): LinearRunner {
+  const env = buildLinearChildEnv();
+  return async (args, signal) => {
+    try {
+      const { stdout } = await execFileAsync(executable, args, {
+        cwd: homedir(),
+        encoding: "utf8",
+        env,
+        maxBuffer: 16 * 1024 * 1024,
+        signal,
+        windowsHide: true,
+      });
+      return stdout.trim();
+    } catch (error) {
+      throw new Error(formatLinearProcessError(error));
+    }
+  };
+}
+
+export class LinearClient {
+  private team: LinearTeam | undefined;
+
+  constructor(
+    private readonly run: LinearRunner = createLinearRunner(),
+    private readonly configuredTeamKey: string | undefined = readLinearTeamKey(),
+  ) {}
+
+  async text(args: string[], signal?: AbortSignal): Promise<string> {
+    return this.run(args, signal);
+  }
+
+  async api<T>(query: string, variables: Record<string, unknown>, signal?: AbortSignal): Promise<T> {
+    const output = await this.run(["api", query, "--variables-json", JSON.stringify(variables)], signal);
+    const parsed = JSON.parse(output) as { data?: T; errors?: Array<{ message?: string }> };
+    if (parsed.errors?.length) {
+      throw new Error(parsed.errors.map((error) => error.message ?? "Linear GraphQL error").join("; "));
+    }
+    if (!parsed.data) throw new Error("Linear GraphQL response did not include data");
+    return parsed.data;
+  }
+
+  async queryIssues(options: {
+    search?: string;
+    state?: string;
+    assignee?: string;
+    project?: string;
+    limit?: number;
+    signal?: AbortSignal;
+  }): Promise<LinearIssue[]> {
+    const team = await this.getTeam(options.signal);
+    const args = [
+      "issue",
+      "query",
+      "--team",
+      team.key,
+      "--limit",
+      String(options.limit ?? DEFAULT_LIMIT),
+      "--json",
+      "--no-pager",
+    ];
+    if (options.search) args.push("--search", options.search);
+    else args.push("--sort", "priority");
+    if (options.state) args.push("--state", options.state);
+    if (options.assignee) args.push("--assignee", options.assignee);
+    if (options.project) args.push("--project", options.project);
+
+    const output = await this.run(args, options.signal);
+    const parsed = JSON.parse(output) as QueryResult;
+    return Array.isArray(parsed.nodes) ? parsed.nodes : [];
+  }
+
+  async getIssues(identifiers: string[], detail: IssueDetail, signal?: AbortSignal): Promise<LinearIssue[]> {
+    const data = await this.api<{ issues?: QueryResult }>(
+      detail === "full" ? ISSUE_FULL_QUERY : ISSUE_SUMMARY_QUERY,
+      { ids: identifiers },
+      signal,
+    );
+    return Array.isArray(data.issues?.nodes) ? data.issues.nodes : [];
+  }
+
+  async getIssue(identifier: string, signal?: AbortSignal): Promise<LinearIssue> {
+    const normalized = normalizeIssueIdentifier(identifier);
+    const issues = await this.getIssues([normalized], "summary", signal);
+    const issue = issues.find((candidate) => candidate.identifier?.toUpperCase() === normalized);
+    if (!issue) throw new Error(`Linear issue not found: ${normalized}`);
+    return issue;
+  }
+
+  async getTeam(signal?: AbortSignal): Promise<LinearTeam> {
+    if (this.team) return this.team;
+    const filter = this.configuredTeamKey
+      ? { key: { eqIgnoreCase: this.configuredTeamKey } }
+      : {};
+    const data = await this.api<{ teams?: LinearConnection<LinearTeam> }>(
+      CONFIGURED_TEAMS_QUERY,
+      { filter },
+      signal,
+    );
+    const teams = Array.isArray(data.teams?.nodes) ? data.teams.nodes : [];
+    if (teams.length === 0) {
+      throw new Error(this.configuredTeamKey
+        ? `Linear team not found: ${this.configuredTeamKey}`
+        : "No Linear teams found for the authenticated workspace");
+    }
+    if (!this.configuredTeamKey && teams.length > 1) {
+      throw new Error("Set LINEAR_TEAM_KEY when the Linear workspace has multiple teams");
+    }
+    this.team = teams[0];
+    return this.team;
+  }
+}

--- a/packages/linear/src/command.ts
+++ b/packages/linear/src/command.ts
@@ -1,0 +1,144 @@
+import { LinearClient } from "./client.ts";
+import {
+  DEFAULT_LIMIT,
+  MAX_BATCH_SIZE,
+  MAX_FULL_BATCH_SIZE,
+  PANEL_LIMIT,
+} from "./config.ts";
+import { formatIssues, formatReadResults } from "./format.ts";
+import type { PanelState } from "./types.ts";
+import { compactError } from "./utils.ts";
+
+export function registerLinearCommand(letta: any, client: LinearClient): Array<() => void> {
+  const disposers: Array<() => void> = [];
+  let panel: { update(): void; close(): void } | null = null;
+  const panelState: PanelState = { loading: false, error: null, issues: [], updatedAt: null };
+
+  const closePanel = () => {
+    panel?.close();
+    panel = null;
+  };
+
+  const ensurePanel = () => {
+    if (!letta.capabilities.ui.panels || panel) return;
+    panel = letta.ui.openPanel({
+      id: "linear",
+      order: 90,
+      render(ctx: any) {
+        if (panelState.loading && panelState.issues.length === 0) return "Linear · loading active issues…";
+        if (panelState.error) return `Linear · ${panelState.error}`;
+        if (panelState.issues.length === 0) return "Linear · no active issues";
+        const header = ctx.row(
+          "Linear · active",
+          panelState.updatedAt
+            ? `updated ${panelState.updatedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+            : "",
+          ctx.width,
+        );
+        const rows = panelState.issues.slice(0, PANEL_LIMIT).map((issue) => {
+          const id = issue.identifier ?? "?";
+          const linkedId = issue.url ? ctx.link(id, issue.url) : id;
+          return ctx.row(`${linkedId}  ${issue.title ?? "Untitled"}`, issue.state?.name ?? "", ctx.width);
+        });
+        return [header, ...rows];
+      },
+    });
+  };
+
+  const refreshPanel = async (signal?: AbortSignal) => {
+    panelState.loading = true;
+    panelState.error = null;
+    panel?.update();
+    try {
+      panelState.issues = await client.queryIssues({ state: "started", limit: PANEL_LIMIT, signal });
+      panelState.updatedAt = new Date();
+    } catch (error) {
+      panelState.error = compactError(error);
+    } finally {
+      panelState.loading = false;
+      panel?.update();
+    }
+  };
+
+  disposers.push(
+    letta.commands.register({
+      id: "linear",
+      description: "Browse Linear issues and show the active-work panel",
+      args: "[mine|search <text>|full ENG-123 [ENG-456...]|ENG-123 [ENG-456...]|refresh|hide]",
+      showInTranscript: false,
+      async run(ctx: any) {
+        const input = String(ctx.args ?? "").trim();
+        const [subcommand, ...rest] = input.split(/\s+/);
+        try {
+          if (!input || subcommand === "refresh") {
+            if (letta.capabilities.ui.panels) {
+              ensurePanel();
+              await refreshPanel(ctx.signal);
+              return { type: "handled" };
+            }
+            return {
+              type: "output",
+              output: formatIssues(await client.queryIssues({ state: "started", limit: DEFAULT_LIMIT, signal: ctx.signal })),
+            };
+          }
+          if (subcommand === "hide") {
+            closePanel();
+            return { type: "output", output: "Linear panel hidden." };
+          }
+          if (subcommand === "mine") {
+            const team = await client.getTeam(ctx.signal);
+            const output = await client.text(
+              ["issue", "mine", "--team", team.key, "--sort", "priority", "--limit", String(DEFAULT_LIMIT), "--no-pager"],
+              ctx.signal,
+            );
+            return { type: "output", output: output || "No assigned Linear issues found." };
+          }
+          if (subcommand === "search") {
+            const search = rest.join(" ").trim();
+            if (!search) return { type: "output", output: "Usage: /linear search <text>" };
+            return {
+              type: "output",
+              output: formatIssues(await client.queryIssues({ search, limit: DEFAULT_LIMIT, signal: ctx.signal })),
+            };
+          }
+          if (subcommand === "full") {
+            const identifiers = rest.join(" ").split(/[\s,]+/).map((value) => value.toUpperCase()).filter(Boolean);
+            if (
+              identifiers.length === 0
+              || identifiers.length > MAX_FULL_BATCH_SIZE
+              || !identifiers.every((value) => /^[A-Z]+-\d+$/.test(value))
+            ) {
+              return { type: "output", output: `Usage: /linear full ENG-123 [ENG-456...] (maximum ${MAX_FULL_BATCH_SIZE})` };
+            }
+            const unique = [...new Set(identifiers)];
+            return {
+              type: "output",
+              output: formatReadResults(unique, await client.getIssues(unique, "full", ctx.signal), "full"),
+            };
+          }
+          const identifiers = input.split(/[\s,]+/).filter(Boolean).map((value) => value.toUpperCase());
+          if (
+            identifiers.length > 0
+            && identifiers.length <= MAX_BATCH_SIZE
+            && identifiers.every((value) => /^[A-Z]+-\d+$/.test(value))
+          ) {
+            const unique = [...new Set(identifiers)];
+            return {
+              type: "output",
+              output: formatReadResults(unique, await client.getIssues(unique, "summary", ctx.signal), "summary"),
+            };
+          }
+          return {
+            type: "output",
+            output: "Usage: /linear [mine | search <text> | full ENG-123 [ENG-456...] | ENG-123 [ENG-456...] | refresh | hide]",
+          };
+        } catch (error) {
+          return { type: "output", output: `Linear error: ${compactError(error)}` };
+        }
+      },
+    }),
+  );
+
+  disposers.push(closePanel);
+  return disposers;
+}

--- a/packages/linear/src/config.ts
+++ b/packages/linear/src/config.ts
@@ -1,0 +1,190 @@
+export const DEFAULT_LIMIT = 10;
+export const PANEL_LIMIT = 4;
+export const MAX_BATCH_SIZE = 50;
+export const MAX_CREATE_BATCH_SIZE = 20;
+export const MAX_FULL_BATCH_SIZE = 5;
+export const MAX_RELATION_BATCH_SIZE = 50;
+
+export const CONFIGURED_TEAMS_QUERY = `
+query LinearModConfiguredTeams($filter: TeamFilter!) {
+  teams(first: 2, filter: $filter) { nodes { id key name } }
+}`;
+
+const ISSUE_RESULT_FIELDS = `
+  id identifier title url description priority priorityLabel dueDate estimate createdAt updatedAt completedAt canceledAt
+  state { id name type }
+  assignee { id name displayName }
+  creator { id name displayName }
+  project { id name slugId url }
+  projectMilestone { id name }
+  cycle { id name number startsAt endsAt }
+  labels(first: 50) { nodes { id name } }
+  parent { id identifier title url state { name } }
+`;
+
+export const ISSUE_SUMMARY_QUERY = `
+query LinearModIssueSummaries($ids: [ID!]!) {
+  issues(first: ${MAX_BATCH_SIZE}, filter: { id: { in: $ids } }) {
+    nodes { ${ISSUE_RESULT_FIELDS} }
+  }
+}`;
+
+export const ISSUE_FULL_QUERY = `
+query LinearModFullIssues($ids: [ID!]!) {
+  issues(first: ${MAX_FULL_BATCH_SIZE}, filter: { id: { in: $ids } }) {
+    nodes {
+      ${ISSUE_RESULT_FIELDS}
+      children(first: 50) { nodes { id identifier title url state { name } } }
+      comments(last: 10) { nodes { id body createdAt url user { name displayName } } }
+      attachments(first: 20) { nodes { id title url subtitle sourceType createdAt } }
+      relations(first: 50) { nodes { id type relatedIssue { id identifier title url state { name } } } }
+      inverseRelations(first: 50) { nodes { id type issue { id identifier title url state { name } } } }
+    }
+  }
+}`;
+
+export const WRITE_METADATA_QUERY = `
+query LinearModWriteMetadata(
+  $teamId: ID!
+  $projectFilter: ProjectFilter!
+  $stateFilter: WorkflowStateFilter!
+  $userFilter: UserFilter!
+  $labelFilter: IssueLabelFilter!
+  $issueFilter: IssueFilter!
+  $cycleFilter: CycleFilter!
+  $milestoneFilter: ProjectMilestoneFilter!
+) {
+  viewer { id name displayName email }
+  teams(first: 1, filter: { id: { eq: $teamId } }) { nodes { id key name activeCycle { id name number } } }
+  projects(first: 50, filter: $projectFilter) { nodes { id name slugId } }
+  workflowStates(first: 50, filter: $stateFilter) { nodes { id name type position team { id key } } }
+  users(first: 50, filter: $userFilter) { nodes { id name displayName email } }
+  issueLabels(first: 50, filter: $labelFilter) { nodes { id name team { id key } } }
+  issues(first: 50, filter: $issueFilter) { nodes { id identifier title } }
+  cycles(first: 50, filter: $cycleFilter) { nodes { id name number team { id key } } }
+  projectMilestones(first: 50, filter: $milestoneFilter) { nodes { id name project { id name slugId } } }
+}`;
+
+export const CREATE_ISSUE_MUTATION = `
+mutation LinearModCreateIssue($input: IssueCreateInput!) {
+  issueCreate(input: $input) {
+    success
+    issue { ${ISSUE_RESULT_FIELDS} }
+  }
+}`;
+
+export const UPDATE_ISSUE_MUTATION = `
+mutation LinearModUpdateIssue($id: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $id, input: $input) {
+    success
+    issue { ${ISSUE_RESULT_FIELDS} }
+  }
+}`;
+
+export const COMMENT_MUTATION = `
+mutation LinearModCreateComment($input: CommentCreateInput!) {
+  commentCreate(input: $input) {
+    success
+    comment { id body createdAt url user { name displayName } }
+  }
+}`;
+
+export const CREATE_RELATION_MUTATION = `
+mutation LinearModCreateRelation($input: IssueRelationCreateInput!) {
+  issueRelationCreate(input: $input) {
+    success
+    issueRelation {
+      id type
+      issue { id identifier title url }
+      relatedIssue { id identifier title url }
+    }
+  }
+}`;
+
+export const FIND_RELATION_QUERY = `
+query LinearModFindRelation($issueId: String!) {
+  issue(id: $issueId) {
+    id identifier
+    relations(first: 50) {
+      nodes { id type relatedIssue { id identifier } }
+    }
+    inverseRelations(first: 50) {
+      nodes { id type issue { id identifier } }
+    }
+  }
+}`;
+
+export const DELETE_RELATION_MUTATION = `
+mutation LinearModDeleteRelation($id: String!) {
+  issueRelationDelete(id: $id) { success }
+}`;
+
+export const IDENTIFIER_PROPERTIES = {
+  identifier: { type: "string", description: "One issue identifier. Kept for backward compatibility." },
+  identifiers: {
+    type: "array",
+    items: { type: "string" },
+    minItems: 1,
+    maxItems: MAX_BATCH_SIZE,
+    uniqueItems: true,
+    description: `Issue identifiers, for example [\"ENG-123\", \"ENG-456\"]. Summary reads allow ${MAX_BATCH_SIZE}; full reads allow ${MAX_FULL_BATCH_SIZE}.`,
+  },
+} as const;
+
+export const WRITE_FIELD_PROPERTIES = {
+  title: { type: "string" },
+  description: { type: "string" },
+  project: { type: "string" },
+  state: { type: "string" },
+  assignee: { type: "string" },
+  priority: { type: "integer", minimum: 1, maximum: 4 },
+  labels: { type: "array", items: { type: "string" } },
+  parent: { type: "string" },
+  due_date: { type: "string" },
+  estimate: { type: "integer", minimum: 0 },
+  milestone: { type: "string" },
+  cycle: { type: "string" },
+} as const;
+
+export const DRY_RUN_PROPERTY = {
+  dry_run: {
+    type: "boolean",
+    description: "Preview resolved operations and current state without executing mutations.",
+  },
+} as const;
+
+export const EXPECTED_ISSUE_SCHEMA = {
+  type: "object",
+  minProperties: 1,
+  properties: {
+    updated_at: { type: "string", description: "Expected issue updatedAt timestamp from a prior read" },
+    state: { type: "string", description: "Expected exact state name or state type" },
+    assignee: { type: "string", description: "Expected exact assignee id, name, or display name" },
+    unassigned: { type: "boolean", enum: [true], description: "Require the issue to be unassigned" },
+    project: { type: "string", description: "Expected exact project id, name, or slug" },
+    no_project: { type: "boolean", enum: [true], description: "Require the issue to have no project" },
+    priority: { type: "integer", minimum: 0, maximum: 4 },
+  },
+  additionalProperties: false,
+} as const;
+
+export const RELATION_ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    from: { type: "string", description: "Source issue identifier or local create key" },
+    type: { type: "string", enum: ["blocks", "blocked-by", "related", "duplicate"] },
+    to: { type: "string", description: "Target issue identifier or local create key" },
+  },
+  required: ["from", "type", "to"],
+  additionalProperties: false,
+} as const;
+
+export const CREATE_ITEM_SCHEMA = {
+  type: "object",
+  properties: {
+    key: { type: "string", description: "Optional local alias, for example api or ui" },
+    ...WRITE_FIELD_PROPERTIES,
+  },
+  required: ["title"],
+  additionalProperties: false,
+} as const;

--- a/packages/linear/src/format.ts
+++ b/packages/linear/src/format.ts
@@ -1,0 +1,230 @@
+import type {
+  BatchResult,
+  CreateResult,
+  IssueDetail,
+  LinearComment,
+  LinearIssue,
+  MutationPreview,
+  RelationResult,
+} from "./types.ts";
+import { actorName, connectionNodes, truncate } from "./utils.ts";
+
+export function issueLine(issue: LinearIssue): string {
+  const id = issue.identifier ?? "?";
+  const state = issue.state?.name ?? "Unknown";
+  const priority = issue.priorityLabel && issue.priorityLabel !== "No priority"
+    ? ` · ${issue.priorityLabel}`
+    : "";
+  const assignee = issue.assignee?.displayName ?? issue.assignee?.name;
+  return `${id}  ${issue.title ?? "Untitled"}  [${state}${priority}]${assignee ? ` · ${assignee}` : ""}`;
+}
+
+export function formatIssues(issues: LinearIssue[]): string {
+  if (issues.length === 0) return "No Linear issues found.";
+  return issues
+    .map((issue) => `${issueLine(issue)}${issue.url ? `\n${issue.url}` : ""}`)
+    .join("\n\n");
+}
+
+function formatComment(comment: LinearComment): string[] {
+  const heading = [comment.createdAt?.slice(0, 10), actorName(comment.user)]
+    .filter(Boolean)
+    .join(" · ");
+  return [
+    `- ${heading || "Comment"}${comment.url ? ` · ${comment.url}` : ""}`,
+    truncate(comment.body?.trim() || "[empty comment]"),
+  ];
+}
+
+export function formatIssue(issue: LinearIssue, detail: IssueDetail): string {
+  const lines = [
+    `${issue.identifier ?? "Issue"}: ${issue.title ?? "Untitled"}`,
+    [issue.state?.name, issue.priorityLabel, issue.assignee?.displayName ?? issue.assignee?.name]
+      .filter(Boolean)
+      .join(" · "),
+  ];
+  if (issue.project?.name) lines.push(`Project: ${issue.project.name}`);
+  const labels = connectionNodes(issue.labels).map((label) => label.name).filter(Boolean);
+  if (labels.length) lines.push(`Labels: ${labels.join(", ")}`);
+  if (issue.cycle?.name) lines.push(`Cycle: ${issue.cycle.name}`);
+  if (issue.projectMilestone?.name) lines.push(`Milestone: ${issue.projectMilestone.name}`);
+  if (issue.dueDate) lines.push(`Due: ${issue.dueDate}`);
+  if (typeof issue.estimate === "number") lines.push(`Estimate: ${issue.estimate}`);
+  if (issue.url) lines.push(issue.url);
+  if (issue.description) lines.push("", truncate(issue.description.trim(), detail === "full" ? 8000 : 4000));
+
+  if (detail === "full") {
+    if (issue.parent?.identifier) {
+      lines.push("", `Parent: ${issue.parent.identifier} · ${issue.parent.title ?? "Untitled"}`);
+    }
+
+    const children = connectionNodes(issue.children);
+    if (children.length) {
+      lines.push(
+        "",
+        "Children:",
+        ...children.map((child) =>
+          `- ${child.identifier ?? "?"} · ${child.title ?? "Untitled"} [${child.state?.name ?? "Unknown"}]`),
+      );
+    }
+
+    const relations = [
+      ...connectionNodes(issue.relations).map((relation) =>
+        `${issue.identifier ?? "?"} ${relation.type ?? "related"} ${relation.relatedIssue?.identifier ?? "?"} · ${relation.relatedIssue?.title ?? "Untitled"}`),
+      ...connectionNodes(issue.inverseRelations).map((relation) =>
+        `${relation.issue?.identifier ?? "?"} ${relation.type ?? "related"} ${issue.identifier ?? "?"} · ${relation.issue?.title ?? "Untitled"}`),
+    ];
+    if (relations.length) lines.push("", "Relations:", ...relations.map((relation) => `- ${relation}`));
+
+    const attachments = connectionNodes(issue.attachments);
+    if (attachments.length) {
+      lines.push(
+        "",
+        "Attachments:",
+        ...attachments.map((attachment) =>
+          `- ${attachment.title ?? attachment.sourceType ?? "Attachment"}${attachment.url ? `\n  ${attachment.url}` : ""}`),
+      );
+    }
+
+    const comments = connectionNodes(issue.comments);
+    if (comments.length) {
+      lines.push("", `Comments (latest ${comments.length}):`);
+      for (const comment of comments) lines.push(...formatComment(comment));
+    }
+
+    if (issue.createdAt || issue.updatedAt) {
+      lines.push(
+        "",
+        [issue.createdAt ? `Created ${issue.createdAt}` : "", issue.updatedAt ? `Updated ${issue.updatedAt}` : ""]
+          .filter(Boolean)
+          .join(" · "),
+      );
+    }
+  }
+  return lines.filter((line, index) => line || index > 3).join("\n");
+}
+
+export function formatReadResults(identifiers: string[], issues: LinearIssue[], detail: IssueDetail): string {
+  const byIdentifier = new Map(issues.map((issue) => [issue.identifier?.toUpperCase(), issue]));
+  return identifiers
+    .map((identifier) => {
+      const issue = byIdentifier.get(identifier);
+      return issue ? formatIssue(issue, detail) : `${identifier}: Linear issue not found.`;
+    })
+    .join("\n\n---\n\n");
+}
+
+function issueResult(issue: LinearIssue | undefined): Record<string, unknown> | undefined {
+  if (!issue) return undefined;
+  return {
+    identifier: issue.identifier,
+    title: issue.title,
+    url: issue.url,
+    state: issue.state?.name,
+    assignee: issue.assignee?.displayName ?? issue.assignee?.name,
+    project: issue.project?.name,
+    priority: issue.priorityLabel,
+  };
+}
+
+export function formatCreateResults(results: CreateResult[], relations: RelationResult[]): string {
+  return JSON.stringify({
+    created: results.filter((result) => result.issue).map((result) => ({
+      key: result.key,
+      ...issueResult(result.issue?.issue),
+    })),
+    create_errors: results.filter((result) => result.error).map((result) => ({
+      key: result.key,
+      title: result.title,
+      error: result.error,
+    })),
+    relations: relations.map((relation) => ({
+      from: relation.from,
+      type: relation.type,
+      to: relation.to,
+      status: relation.error ? "error" : "ok",
+      ...(relation.error ? { error: relation.error } : {}),
+    })),
+  }, null, 2);
+}
+
+export function formatCreatePreview(results: CreateResult[], relations: RelationResult[]): string {
+  return JSON.stringify({
+    action: "create",
+    dry_run: true,
+    planned: results.filter((result) => result.input).length,
+    failed: results.filter((result) => result.error).length,
+    creates: results.filter((result) => result.input).map((result) => ({
+      key: result.key,
+      title: result.title,
+      status: "planned",
+      resolved_input: result.input,
+    })),
+    create_errors: results.filter((result) => result.error).map((result) => ({
+      key: result.key,
+      title: result.title,
+      error: result.error,
+    })),
+    relations: relations.map((relation) => ({
+      from: relation.from,
+      type: relation.type,
+      to: relation.to,
+      status: relation.error ? "error" : "planned",
+      ...(relation.error ? { error: relation.error } : {}),
+    })),
+  }, null, 2);
+}
+
+export function formatMutationResults<T>(action: string, results: Array<BatchResult<T>>): string {
+  return JSON.stringify({
+    action,
+    succeeded: results.filter((result) => !result.error).length,
+    failed: results.filter((result) => result.error).length,
+    results: results.map((result) => ({
+      identifier: result.identifier,
+      status: result.error ? "error" : "ok",
+      ...(result.error ? { error: result.error } : {}),
+      ...(result.value && typeof result.value === "object"
+        ? { value: "identifier" in result.value ? issueResult(result.value as LinearIssue) : result.value }
+        : {}),
+    })),
+  }, null, 2);
+}
+
+export function formatMutationPreview(action: string, results: Array<BatchResult<MutationPreview>>): string {
+  return JSON.stringify({
+    action,
+    dry_run: true,
+    planned: results.filter((result) => !result.error).length,
+    failed: results.filter((result) => result.error).length,
+    results: results.map((result) => ({
+      identifier: result.identifier,
+      status: result.error ? "error" : "planned",
+      ...(result.error ? { error: result.error } : {}),
+      ...(result.value
+        ? {
+            current: issueResult(result.value.current),
+            ...(result.value.changes ? { changes: result.value.changes } : {}),
+            ...(result.value.resolvedChanges ? { resolved_changes: result.value.resolvedChanges } : {}),
+            ...(result.value.comment ? { comment: result.value.comment } : {}),
+            ...(result.value.expected ? { expected: result.value.expected } : {}),
+          }
+        : {}),
+    })),
+    note: "Preview only. Expected-state guards are best-effort preconditions, not atomic compare-and-swap operations.",
+  }, null, 2);
+}
+
+export function formatRelationResults(operation: string, results: RelationResult[], dryRun = false): string {
+  return JSON.stringify({
+    operation,
+    ...(dryRun ? { dry_run: true } : {}),
+    results: results.map((result) => ({
+      from: result.from,
+      type: result.type,
+      to: result.to,
+      status: result.error ? "error" : dryRun || result.dryRun ? "planned" : "ok",
+      ...(result.error ? { error: result.error } : {}),
+    })),
+  }, null, 2);
+}

--- a/packages/linear/src/tools.ts
+++ b/packages/linear/src/tools.ts
@@ -1,0 +1,458 @@
+import { LinearClient } from "./client.ts";
+import {
+  CREATE_ITEM_SCHEMA,
+  DRY_RUN_PROPERTY,
+  EXPECTED_ISSUE_SCHEMA,
+  IDENTIFIER_PROPERTIES,
+  MAX_BATCH_SIZE,
+  MAX_CREATE_BATCH_SIZE,
+  MAX_FULL_BATCH_SIZE,
+  MAX_RELATION_BATCH_SIZE,
+  RELATION_ITEM_SCHEMA,
+  WRITE_FIELD_PROPERTIES,
+} from "./config.ts";
+import {
+  formatCreateResults,
+  formatCreatePreview,
+  formatIssue,
+  formatIssues,
+  formatMutationResults,
+  formatMutationPreview,
+  formatReadResults,
+  formatRelationResults,
+} from "./format.ts";
+import type {
+  CreateItem,
+  CreateResult,
+  CreatedIssue,
+  ExpectedIssueState,
+  IssueDetail,
+  LinearIssue,
+  MutationPreview,
+  RelationResult,
+  ToolArgs,
+} from "./types.ts";
+import {
+  aliasKey,
+  arrayArg,
+  compactError,
+  createItems,
+  expectedIssueFromArgs,
+  hasWriteFields,
+  identifierArgs,
+  invalidIdentifier,
+  normalizeIssueIdentifier,
+  numberArg,
+  relationSpecs,
+  runSequential,
+  stringArg,
+  validateWriteFields,
+  validateExpectedIssueState,
+  writeFieldsFromArgs,
+} from "./utils.ts";
+import {
+  assertExpectedIssueState,
+  buildAliasMap,
+  commentIssue,
+  createIssue,
+  loadWriteMetadata,
+  readAndGuardIssue,
+  resolveWriteInput,
+  runRelations,
+  updateIssue,
+} from "./write.ts";
+
+function identifierError(identifiers: string[], max = MAX_BATCH_SIZE): string | undefined {
+  if (identifiers.length === 0) return "at least one identifier is required";
+  if (identifiers.length > max) return `no more than ${max} identifiers are allowed`;
+  const invalid = invalidIdentifier(identifiers);
+  return invalid ? `invalid Linear issue identifier: ${invalid}` : undefined;
+}
+
+function normalizeCreateItem(item: CreateItem): CreateItem {
+  return {
+    key: stringArg(item.key),
+    ...writeFieldsFromArgs(item as ToolArgs),
+  };
+}
+
+async function previewIssueMutations(
+  client: LinearClient,
+  identifiers: string[],
+  expected: ExpectedIssueState | undefined,
+  build: (issue: LinearIssue) => MutationPreview,
+  signal?: AbortSignal,
+) {
+  const issues = await client.getIssues(identifiers, "summary", signal);
+  const byIdentifier = new Map(issues.map((issue) => [issue.identifier?.toUpperCase(), issue]));
+  return runSequential(identifiers, async (identifier) => {
+    const issue = byIdentifier.get(identifier);
+    if (!issue) throw new Error(`Linear issue not found: ${identifier}`);
+    assertExpectedIssueState(issue, expected);
+    return build(issue);
+  }, signal);
+}
+
+async function loadKnownIssueIdentifiers(
+  client: LinearClient,
+  identifiers: string[],
+  signal?: AbortSignal,
+): Promise<Set<string>> {
+  const issues: LinearIssue[] = [];
+  for (let start = 0; start < identifiers.length; start += MAX_BATCH_SIZE) {
+    if (signal?.aborted) break;
+    issues.push(...await client.getIssues(identifiers.slice(start, start + MAX_BATCH_SIZE), "summary", signal));
+  }
+  return new Set(issues
+    .map((issue) => issue.identifier?.toUpperCase())
+    .filter((identifier): identifier is string => Boolean(identifier)));
+}
+
+export function registerLinearTools(letta: any, client: LinearClient): Array<() => void> {
+  const disposers: Array<() => void> = [];
+
+  disposers.push(letta.tools.register({
+    name: "linear_search",
+    description: "Search and filter Linear issues when issue context, ownership, status, or duplicates matter.",
+    parameters: {
+      type: "object",
+      properties: {
+        search: { type: "string", description: "Full-text search query" },
+        state: { type: "string", enum: ["triage", "backlog", "unstarted", "started", "completed", "canceled"] },
+        assignee: { type: "string", description: "Assignee username or name" },
+        project: { type: "string", description: "Project name" },
+        limit: { type: "number", description: "Maximum results, from 1 to 50" },
+        detail: {
+          type: "string",
+          enum: ["summary", "full"],
+          description: `Use full to expand up to ${MAX_FULL_BATCH_SIZE} results with comments, relations, attachments, and hierarchy`,
+        },
+      },
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx: any) {
+      const args = ctx.args as ToolArgs;
+      const detail: IssueDetail = args.detail === "full" ? "full" : "summary";
+      const issues = await client.queryIssues({
+        search: stringArg(args.search),
+        state: stringArg(args.state),
+        assignee: stringArg(args.assignee),
+        project: stringArg(args.project),
+        limit: detail === "full"
+          ? Math.min(numberArg(args.limit, 10), MAX_FULL_BATCH_SIZE)
+          : numberArg(args.limit, 10),
+        signal: ctx.signal,
+      });
+      if (detail === "summary" || issues.length === 0) return formatIssues(issues);
+      const identifiers = [...new Set(issues.map((issue) => issue.identifier).filter((value): value is string => Boolean(value)))];
+      return formatReadResults(identifiers, await client.getIssues(identifiers, "full", ctx.signal), "full");
+    },
+  }));
+
+  disposers.push(letta.tools.register({
+    name: "linear_issue",
+    description: "Read one or more Linear issues by identifier before acting on or discussing them. Batch related lookups with identifiers.",
+    parameters: {
+      type: "object",
+      properties: {
+        ...IDENTIFIER_PROPERTIES,
+        detail: {
+          type: "string",
+          enum: ["summary", "full"],
+          description: `Full includes recent comments, attachments, relations, labels, parent, and children; maximum ${MAX_FULL_BATCH_SIZE} issues`,
+        },
+      },
+      additionalProperties: false,
+    },
+    requiresApproval: false,
+    parallelSafe: true,
+    async run(ctx: any) {
+      const args = ctx.args as ToolArgs;
+      const identifiers = identifierArgs(args);
+      const detail: IssueDetail = args.detail === "full" ? "full" : "summary";
+      const error = identifierError(identifiers, detail === "full" ? MAX_FULL_BATCH_SIZE : MAX_BATCH_SIZE);
+      if (error) return { status: "error", content: error };
+      return formatReadResults(identifiers, await client.getIssues(identifiers, detail, ctx.signal), detail);
+    },
+  }));
+
+  disposers.push(letta.tools.register({
+    name: "linear_create",
+    description: "Create one or more Linear issues. Use items for batches, local keys for relations, and dry_run to preview resolved inputs without mutations.",
+    parameters: {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          minItems: 1,
+          maxItems: MAX_CREATE_BATCH_SIZE,
+          description: "Issues to create. A key is a local alias that relations can reference after creation.",
+          items: CREATE_ITEM_SCHEMA,
+        },
+        relations: {
+          type: "array",
+          maxItems: MAX_RELATION_BATCH_SIZE,
+          description: "Relations applied after creation. from/to may be local item keys or existing issue identifiers.",
+          items: RELATION_ITEM_SCHEMA,
+        },
+        ...DRY_RUN_PROPERTY,
+        ...WRITE_FIELD_PROPERTIES,
+      },
+      additionalProperties: false,
+    },
+    requiresApproval: true,
+    parallelSafe: false,
+    async run(ctx: any) {
+      const args = ctx.args as ToolArgs;
+      const dryRun = args.dry_run === true;
+      const items = createItems(args).map(normalizeCreateItem);
+      const relations = relationSpecs(args.relations);
+      if (items.length === 0) return { status: "error", content: "title or items is required" };
+      if (items.length > MAX_CREATE_BATCH_SIZE) {
+        return { status: "error", content: `no more than ${MAX_CREATE_BATCH_SIZE} issues can be created at once` };
+      }
+      if (relations.length > MAX_RELATION_BATCH_SIZE) {
+        return { status: "error", content: `no more than ${MAX_RELATION_BATCH_SIZE} relations are allowed` };
+      }
+      const keys = items.map((item) => item.key).filter((value): value is string => Boolean(value));
+      if (keys.some((key) => /^[A-Za-z]+-\d+$/.test(key))) {
+        return { status: "error", content: "local item keys cannot look like Linear issue identifiers" };
+      }
+      if (new Set(keys.map((key) => key.toLowerCase())).size !== keys.length) {
+        return { status: "error", content: "local item keys must be unique" };
+      }
+
+      const validation = items.map((item) => validateWriteFields(item, true));
+      const validItems = items.filter((_item, index) => !validation[index]);
+      const metadata = validItems.length ? await loadWriteMetadata(client, validItems, ctx.signal) : undefined;
+      const results: CreateResult[] = [];
+      for (let index = 0; index < items.length; index += 1) {
+        if (ctx.signal?.aborted) break;
+        const item = items[index];
+        if (validation[index]) {
+          results.push({ key: item.key, title: item.title, error: validation[index] });
+          continue;
+        }
+        try {
+          if (dryRun) {
+            results.push({
+              key: item.key,
+              title: item.title,
+              input: resolveWriteInput(item, metadata!, { create: true }),
+            });
+          } else {
+            const issue = await createIssue(client, item, metadata!, ctx.signal);
+            results.push({ key: item.key, title: item.title, issue });
+          }
+        } catch (error) {
+          results.push({
+            key: item.key,
+            title: item.title,
+            error: ctx.signal?.aborted ? "operation canceled" : compactError(error),
+          });
+          if (ctx.signal?.aborted) break;
+        }
+      }
+
+      if (dryRun) {
+        const planned = results.filter((result) => result.input);
+        const aliases = new Map<string, string>();
+        for (const result of planned) {
+          if (result.key) aliases.set(aliasKey(result.key), `NEW(${result.key})`);
+        }
+        const plannedIssueReferences = new Set(aliases.values());
+        const existingReferences = [...new Set(relations.flatMap((relation) => [relation.from, relation.to]).flatMap((value) => {
+          const text = stringArg(value);
+          if (!text || aliases.has(aliasKey(text))) return [];
+          try {
+            return [normalizeIssueIdentifier(text)];
+          } catch {
+            return [];
+          }
+        }))];
+        const knownIssueIdentifiers = await loadKnownIssueIdentifiers(client, existingReferences, ctx.signal);
+        const relationResults: RelationResult[] = planned.length
+          ? await runRelations(client, relations, aliases, "add", ctx.signal, {
+              dryRun: true,
+              knownIssueIdentifiers,
+              plannedIssueReferences,
+            })
+          : relations.map((relation) => ({
+              from: stringArg(relation.from) ?? "?",
+              type: stringArg(relation.type) ?? "?",
+              to: stringArg(relation.to) ?? "?",
+              error: "skipped because no issue creates passed validation",
+            }));
+        return formatCreatePreview(results, relationResults);
+      }
+
+      const created = results.map((result) => result.issue).filter((issue): issue is CreatedIssue => Boolean(issue));
+      if (!Array.isArray(args.items) && relations.length === 0 && created.length === 1) {
+        return formatIssue(created[0].issue, "summary");
+      }
+      const relationResults: RelationResult[] = created.length
+        ? await runRelations(client, relations, buildAliasMap(created), "add", ctx.signal)
+        : relations.map((relation) => ({
+            from: stringArg(relation.from) ?? "?",
+            type: stringArg(relation.type) ?? "?",
+            to: stringArg(relation.to) ?? "?",
+            error: "skipped because no issues were created",
+          }));
+      return formatCreateResults(results, relationResults);
+    },
+  }));
+
+  disposers.push(letta.tools.register({
+    name: "linear_relation",
+    description: "Add or delete issue relations in a batch. Use dry_run to verify issues and relation state without mutations.",
+    parameters: {
+      type: "object",
+      properties: {
+        operation: { type: "string", enum: ["add", "delete"] },
+        relations: {
+          type: "array",
+          minItems: 1,
+          maxItems: MAX_RELATION_BATCH_SIZE,
+          items: RELATION_ITEM_SCHEMA,
+        },
+        ...DRY_RUN_PROPERTY,
+      },
+      required: ["operation", "relations"],
+      additionalProperties: false,
+    },
+    requiresApproval: true,
+    parallelSafe: false,
+    async run(ctx: any) {
+      const operation = stringArg(ctx.args.operation);
+      const dryRun = ctx.args.dry_run === true;
+      if (operation !== "add" && operation !== "delete") {
+        return { status: "error", content: "operation must be add or delete" };
+      }
+      const specs = relationSpecs(ctx.args.relations);
+      if (!specs.length) return { status: "error", content: "at least one relation is required" };
+      if (specs.length > MAX_RELATION_BATCH_SIZE) {
+        return { status: "error", content: `no more than ${MAX_RELATION_BATCH_SIZE} relations are allowed` };
+      }
+      let knownIssueIdentifiers: Set<string> | undefined;
+      if (dryRun) {
+        const endpointIds = [...new Set(specs.flatMap((spec) => [spec.from, spec.to]).flatMap((value) => {
+          const text = stringArg(value);
+          if (!text) return [];
+          try {
+            return [normalizeIssueIdentifier(text)];
+          } catch {
+            return [];
+          }
+        }))];
+        knownIssueIdentifiers = await loadKnownIssueIdentifiers(client, endpointIds, ctx.signal);
+      }
+      return formatRelationResults(
+        operation,
+        await runRelations(client, specs, new Map(), operation, ctx.signal, { dryRun, knownIssueIdentifiers }),
+        dryRun,
+      );
+    },
+  }));
+
+  disposers.push(letta.tools.register({
+    name: "linear_update",
+    description: "Apply the same field changes to one or more Linear issues. Use dry_run for a batched preview and expected for best-effort stale-state guards.",
+    parameters: {
+      type: "object",
+      properties: {
+        ...IDENTIFIER_PROPERTIES,
+        ...WRITE_FIELD_PROPERTIES,
+        expected: EXPECTED_ISSUE_SCHEMA,
+        ...DRY_RUN_PROPERTY,
+      },
+      additionalProperties: false,
+    },
+    requiresApproval: true,
+    parallelSafe: false,
+    async run(ctx: any) {
+      const args = ctx.args as ToolArgs;
+      const dryRun = args.dry_run === true;
+      const identifiers = identifierArgs(args);
+      const idError = identifierError(identifiers);
+      if (idError) return { status: "error", content: idError };
+      const fields = writeFieldsFromArgs(args);
+      if (!hasWriteFields(fields)) return { status: "error", content: "at least one field to update is required" };
+      const fieldError = validateWriteFields(fields);
+      if (fieldError) return { status: "error", content: fieldError };
+      const expected = expectedIssueFromArgs(args);
+      const expectedError = validateExpectedIssueState(expected);
+      if (expectedError) return { status: "error", content: expectedError };
+      const metadata = await loadWriteMetadata(client, [fields], ctx.signal);
+      const resolvedChanges = resolveWriteInput(fields, metadata, { create: false });
+      if (dryRun) {
+        return formatMutationPreview("update", await previewIssueMutations(
+          client,
+          identifiers,
+          expected,
+          (current) => ({ identifier: current.identifier!, current, changes: fields, resolvedChanges, expected }),
+          ctx.signal,
+        ));
+      }
+      const results = await runSequential(
+        identifiers,
+        async (identifier) => {
+          if (expected) await readAndGuardIssue(client, identifier, expected, ctx.signal);
+          return updateIssue(client, identifier, fields, metadata, ctx.signal);
+        },
+        ctx.signal,
+      );
+      return formatMutationResults("update", results);
+    },
+  }));
+
+  disposers.push(letta.tools.register({
+    name: "linear_comment",
+    description: "Add the same comment to one or more Linear issues. Use dry_run for a batched preview and expected for best-effort stale-state guards.",
+    parameters: {
+      type: "object",
+      properties: {
+        ...IDENTIFIER_PROPERTIES,
+        body: { type: "string", description: "Markdown comment body" },
+        expected: EXPECTED_ISSUE_SCHEMA,
+        ...DRY_RUN_PROPERTY,
+      },
+      required: ["body"],
+      additionalProperties: false,
+    },
+    requiresApproval: true,
+    parallelSafe: false,
+    async run(ctx: any) {
+      const identifiers = identifierArgs(ctx.args as ToolArgs);
+      const dryRun = ctx.args.dry_run === true;
+      const idError = identifierError(identifiers);
+      if (idError) return { status: "error", content: idError };
+      const body = stringArg(ctx.args.body);
+      if (!body) return { status: "error", content: "body is required" };
+      const expected = expectedIssueFromArgs(ctx.args as ToolArgs);
+      const expectedError = validateExpectedIssueState(expected);
+      if (expectedError) return { status: "error", content: expectedError };
+      if (dryRun) {
+        return formatMutationPreview("comment", await previewIssueMutations(
+          client,
+          identifiers,
+          expected,
+          (current) => ({ identifier: current.identifier!, current, comment: body, expected }),
+          ctx.signal,
+        ));
+      }
+      const results = await runSequential(
+        identifiers,
+        async (identifier) => {
+          if (expected) await readAndGuardIssue(client, identifier, expected, ctx.signal);
+          return commentIssue(client, identifier, body, ctx.signal);
+        },
+        ctx.signal,
+      );
+      return formatMutationResults("comment", results);
+    },
+  }));
+
+  return disposers;
+}

--- a/packages/linear/src/types.ts
+++ b/packages/linear/src/types.ts
@@ -1,0 +1,169 @@
+export type IssueDetail = "summary" | "full";
+export type ToolArgs = Record<string, unknown>;
+export type LinearConnection<T> = { nodes?: T[] } | null;
+export type LinearTeam = { id: string; key: string; name?: string };
+export type LinearActor = { id?: string; displayName?: string; name?: string } | null;
+
+export type LinearIssueRef = {
+  id?: string;
+  identifier?: string;
+  title?: string;
+  url?: string;
+  state?: { name?: string } | null;
+};
+
+export type LinearIssueRelation = {
+  id?: string;
+  type?: string;
+  issue?: LinearIssueRef | null;
+  relatedIssue?: LinearIssueRef | null;
+};
+
+export type LinearComment = {
+  id?: string;
+  body?: string;
+  createdAt?: string;
+  url?: string;
+  user?: LinearActor;
+};
+
+export type LinearAttachment = {
+  id?: string;
+  title?: string;
+  url?: string;
+  subtitle?: string;
+  sourceType?: string;
+  createdAt?: string;
+};
+
+export type LinearIssue = LinearIssueRef & {
+  priority?: number;
+  priorityLabel?: string;
+  state?: { id?: string; name?: string; type?: string } | null;
+  assignee?: LinearActor;
+  creator?: LinearActor;
+  project?: { id?: string; name?: string; slugId?: string; url?: string } | null;
+  projectMilestone?: { id?: string; name?: string } | null;
+  cycle?: { id?: string; name?: string; number?: number; startsAt?: string; endsAt?: string } | null;
+  description?: string | null;
+  dueDate?: string | null;
+  estimate?: number | null;
+  createdAt?: string;
+  updatedAt?: string;
+  completedAt?: string | null;
+  canceledAt?: string | null;
+  labels?: LinearConnection<{ id?: string; name?: string }>;
+  parent?: LinearIssueRef | null;
+  children?: LinearConnection<LinearIssueRef>;
+  comments?: LinearConnection<LinearComment>;
+  attachments?: LinearConnection<LinearAttachment>;
+  relations?: LinearConnection<LinearIssueRelation>;
+  inverseRelations?: LinearConnection<LinearIssueRelation>;
+};
+
+export type QueryResult = { nodes?: LinearIssue[] };
+
+export type CreateItem = {
+  key?: string;
+  title?: string;
+  description?: string;
+  project?: string;
+  state?: string;
+  assignee?: string;
+  priority?: number;
+  labels?: string[];
+  parent?: string;
+  due_date?: string;
+  estimate?: number;
+  milestone?: string;
+  cycle?: string;
+};
+
+export type UpdateFields = Omit<CreateItem, "key">;
+export type ExpectedIssueState = {
+  updated_at?: string;
+  state?: string;
+  assignee?: string;
+  unassigned?: boolean;
+  project?: string;
+  no_project?: boolean;
+  priority?: number;
+};
+export type RelationType = "blocks" | "blocked-by" | "related" | "duplicate";
+export type RelationSpec = { from?: string; type?: string; to?: string };
+
+export type BatchResult<T> = {
+  identifier: string;
+  value?: T;
+  error?: string;
+};
+
+export type CreatedIssue = {
+  key?: string;
+  identifier: string;
+  url?: string;
+  issue: LinearIssue;
+};
+
+export type CreateResult = {
+  key?: string;
+  title?: string;
+  issue?: CreatedIssue;
+  input?: Record<string, unknown>;
+  error?: string;
+};
+
+export type RelationResult = {
+  from: string;
+  type: string;
+  to: string;
+  relation?: LinearIssueRelation;
+  dryRun?: boolean;
+  error?: string;
+};
+
+export type MutationPreview = {
+  identifier: string;
+  current: LinearIssue;
+  changes?: UpdateFields;
+  resolvedChanges?: Record<string, unknown>;
+  comment?: string;
+  expected?: ExpectedIssueState;
+};
+
+export type PanelState = {
+  loading: boolean;
+  error: string | null;
+  issues: LinearIssue[];
+  updatedAt: Date | null;
+};
+
+export type LinearRunner = (args: string[], signal?: AbortSignal) => Promise<string>;
+
+export type MetadataNode = {
+  id: string;
+  name?: string;
+  displayName?: string;
+  email?: string;
+  key?: string;
+  slugId?: string;
+  type?: string;
+  number?: number;
+  position?: number;
+  identifier?: string;
+  activeCycle?: { id?: string; name?: string; number?: number } | null;
+  team?: { id?: string; key?: string } | null;
+  project?: { id?: string; name?: string; slugId?: string } | null;
+};
+
+export type WriteMetadata = {
+  viewer: MetadataNode;
+  teams: LinearConnection<MetadataNode>;
+  projects: LinearConnection<MetadataNode>;
+  workflowStates: LinearConnection<MetadataNode>;
+  users: LinearConnection<MetadataNode>;
+  issueLabels: LinearConnection<MetadataNode>;
+  issues: LinearConnection<MetadataNode>;
+  cycles: LinearConnection<MetadataNode>;
+  projectMilestones: LinearConnection<MetadataNode>;
+};

--- a/packages/linear/src/utils.ts
+++ b/packages/linear/src/utils.ts
@@ -1,0 +1,197 @@
+import type {
+  BatchResult,
+  CreateItem,
+  ExpectedIssueState,
+  LinearActor,
+  LinearConnection,
+  RelationSpec,
+  ToolArgs,
+  UpdateFields,
+} from "./types.ts";
+
+const ISSUE_IDENTIFIER = /^[A-Z]+-\d+$/;
+
+export function stringArg(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function numberArg(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(50, Math.trunc(value)));
+}
+
+export function arrayArg<T extends object>(value: unknown): T[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is T => Boolean(item) && typeof item === "object")
+    : [];
+}
+
+export function connectionNodes<T>(connection: LinearConnection<T> | undefined): T[] {
+  return Array.isArray(connection?.nodes) ? connection.nodes : [];
+}
+
+export function actorName(actor: LinearActor | undefined): string {
+  return actor?.displayName ?? actor?.name ?? "Unknown";
+}
+
+export function truncate(text: string, limit = 4000): string {
+  return text.length > limit ? `${text.slice(0, limit)}\n[truncated]` : text;
+}
+
+export function compactError(error: unknown): string {
+  if (!error || typeof error !== "object") return String(error);
+  const candidate = error as { stderr?: string; stdout?: string; message?: string };
+  const text = candidate.stderr || candidate.stdout || candidate.message || String(error);
+  return text.trim().split("\n").slice(-4).join("\n").slice(0, 800);
+}
+
+export function identifierArgs(args: ToolArgs): string[] {
+  const values = [args.identifier, ...(Array.isArray(args.identifiers) ? args.identifiers : [])];
+  return [...new Set(values
+    .map(stringArg)
+    .filter((value): value is string => Boolean(value))
+    .map((value) => value.toUpperCase()))];
+}
+
+export function invalidIdentifier(identifiers: string[]): string | undefined {
+  return identifiers.find((identifier) => !ISSUE_IDENTIFIER.test(identifier));
+}
+
+export function normalizeIssueIdentifier(value: string): string {
+  const normalized = value.trim().toUpperCase();
+  if (!ISSUE_IDENTIFIER.test(normalized)) throw new Error(`invalid Linear issue identifier: ${value}`);
+  return normalized;
+}
+
+export function createItems(args: ToolArgs): CreateItem[] {
+  const items = arrayArg<CreateItem>(args.items);
+  if (items.length) return items;
+  const title = stringArg(args.title);
+  if (!title) return [];
+  return [{ key: undefined, ...writeFieldsFromArgs(args), title }];
+}
+
+export function writeFieldsFromArgs(args: ToolArgs): UpdateFields {
+  const labels = Array.isArray(args.labels)
+    ? args.labels.map(stringArg).filter((value): value is string => Boolean(value))
+    : [];
+  return {
+    title: stringArg(args.title),
+    description: stringArg(args.description),
+    project: stringArg(args.project),
+    state: stringArg(args.state),
+    assignee: stringArg(args.assignee),
+    priority: typeof args.priority === "number" ? args.priority : undefined,
+    labels: labels.length ? labels : undefined,
+    parent: stringArg(args.parent),
+    due_date: stringArg(args.due_date),
+    estimate: typeof args.estimate === "number" ? args.estimate : undefined,
+    milestone: stringArg(args.milestone),
+    cycle: stringArg(args.cycle),
+  };
+}
+
+export function validateWriteFields(fields: UpdateFields, requireTitle = false): string | undefined {
+  if (requireTitle && !stringArg(fields.title)) return "title is required";
+  if (
+    typeof fields.priority === "number"
+    && (!Number.isFinite(fields.priority) || fields.priority < 1 || fields.priority > 4 || !Number.isInteger(fields.priority))
+  ) {
+    return "priority must be an integer between 1 and 4";
+  }
+  if (typeof fields.estimate === "number" && (!Number.isFinite(fields.estimate) || fields.estimate < 0 || !Number.isInteger(fields.estimate))) {
+    return "estimate must be a non-negative integer";
+  }
+  if (fields.parent && !ISSUE_IDENTIFIER.test(fields.parent.toUpperCase())) return `invalid parent issue identifier: ${fields.parent}`;
+  if (fields.milestone && !fields.project) return "milestone requires project";
+  return undefined;
+}
+
+export function hasWriteFields(fields: UpdateFields): boolean {
+  return Object.values(fields).some((value) => value !== undefined);
+}
+
+export function expectedIssueFromArgs(args: ToolArgs): ExpectedIssueState | undefined {
+  if (!args.expected || typeof args.expected !== "object" || Array.isArray(args.expected)) return undefined;
+  const expected = args.expected as Record<string, unknown>;
+  return {
+    updated_at: stringArg(expected.updated_at),
+    state: stringArg(expected.state),
+    assignee: stringArg(expected.assignee),
+    unassigned: typeof expected.unassigned === "boolean" ? expected.unassigned : undefined,
+    project: stringArg(expected.project),
+    no_project: typeof expected.no_project === "boolean" ? expected.no_project : undefined,
+    priority: typeof expected.priority === "number" ? expected.priority : undefined,
+  };
+}
+
+export function validateExpectedIssueState(expected: ExpectedIssueState | undefined): string | undefined {
+  if (!expected) return undefined;
+  if (!Object.values(expected).some((value) => value !== undefined)) return "expected must include at least one guard";
+  if (expected.assignee && expected.unassigned !== undefined) return "expected.assignee and expected.unassigned are mutually exclusive";
+  if (expected.project && expected.no_project !== undefined) return "expected.project and expected.no_project are mutually exclusive";
+  if (expected.unassigned === false) return "expected.unassigned must be true when provided";
+  if (expected.no_project === false) return "expected.no_project must be true when provided";
+  if (expected.updated_at && !Number.isFinite(Date.parse(expected.updated_at))) return "expected.updated_at must be a valid timestamp";
+  if (
+    expected.priority !== undefined
+    && (!Number.isInteger(expected.priority) || expected.priority < 0 || expected.priority > 4)
+  ) {
+    return "expected.priority must be an integer between 0 and 4";
+  }
+  return undefined;
+}
+
+export function aliasKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function resolveIssueRef(value: string, aliases: Map<string, string>): string {
+  const alias = aliases.get(aliasKey(value));
+  if (alias) return alias;
+  try {
+    return normalizeIssueIdentifier(value);
+  } catch {
+    throw new Error(`unknown local issue key or invalid Linear issue identifier: ${value}`);
+  }
+}
+
+export function relationSpecs(value: unknown): RelationSpec[] {
+  return arrayArg<RelationSpec>(value);
+}
+
+export async function runSequential<T>(
+  identifiers: string[],
+  operation: (identifier: string) => Promise<T>,
+  signal?: AbortSignal,
+): Promise<Array<BatchResult<T>>> {
+  const results: Array<BatchResult<T>> = [];
+  for (const identifier of identifiers) {
+    if (signal?.aborted) break;
+    try {
+      results.push({ identifier, value: await operation(identifier) });
+    } catch (error) {
+      results.push({ identifier, error: signal?.aborted ? "operation canceled" : compactError(error) });
+      if (signal?.aborted) break;
+    }
+  }
+  return results;
+}
+
+export function uniqueStrings(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+export function emptyIdFilter(): Record<string, unknown> {
+  return { id: { in: [] } };
+}
+
+export function caseInsensitiveOr(field: string, values: string[]): Record<string, unknown> {
+  return values.length
+    ? { or: values.map((value) => ({ [field]: { eqIgnoreCase: value } })) }
+    : emptyIdFilter();
+}
+
+export function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}

--- a/packages/linear/src/write.ts
+++ b/packages/linear/src/write.ts
@@ -1,0 +1,467 @@
+import { LinearClient } from "./client.ts";
+import {
+  COMMENT_MUTATION,
+  CREATE_ISSUE_MUTATION,
+  CREATE_RELATION_MUTATION,
+  DELETE_RELATION_MUTATION,
+  FIND_RELATION_QUERY,
+  UPDATE_ISSUE_MUTATION,
+  WRITE_METADATA_QUERY,
+} from "./config.ts";
+import type {
+  CreateItem,
+  CreatedIssue,
+  ExpectedIssueState,
+  LinearComment,
+  LinearIssue,
+  LinearIssueRelation,
+  LinearTeam,
+  MetadataNode,
+  RelationResult,
+  RelationSpec,
+  RelationType,
+  UpdateFields,
+  WriteMetadata,
+} from "./types.ts";
+import {
+  aliasKey,
+  compactError,
+  connectionNodes,
+  emptyIdFilter,
+  isUuid,
+  normalizeIssueIdentifier,
+  resolveIssueRef,
+  stringArg,
+  uniqueStrings,
+} from "./utils.ts";
+
+type WriteInput = Record<string, unknown>;
+
+type RelationRunOptions = {
+  dryRun?: boolean;
+  validateExisting?: boolean;
+  knownIssueIdentifiers?: Set<string>;
+  plannedIssueReferences?: Set<string>;
+};
+
+function stringOrFilter(field: string, values: string[]): Record<string, unknown> {
+  return values.length
+    ? { or: values.map((value) => ({ [field]: { eqIgnoreCase: value } })) }
+    : emptyIdFilter();
+}
+
+function buildMetadataVariables(items: UpdateFields[], team: LinearTeam): Record<string, unknown> {
+  const projects = uniqueStrings(items.map((item) => stringArg(item.project)));
+  const states = uniqueStrings(items.map((item) => stringArg(item.state)));
+  const users = uniqueStrings(items
+    .map((item) => stringArg(item.assignee))
+    .filter((value) => value !== "self" && value !== "@me"));
+  const labels = uniqueStrings(items.flatMap((item) => item.labels ?? []));
+  const parents = uniqueStrings(items.map((item) => stringArg(item.parent))).map(normalizeIssueIdentifier);
+  const cycles = uniqueStrings(items.map((item) => stringArg(item.cycle)));
+  const milestones = uniqueStrings(items.map((item) => stringArg(item.milestone)));
+
+  const projectOr = projects.flatMap((value) => [
+    { name: { eq: value } },
+    { slugId: { eq: value } },
+    ...(isUuid(value) ? [{ id: { eq: value } }] : []),
+  ]);
+  const stateOr = states.flatMap((value) => [
+    { name: { eqIgnoreCase: value } },
+    { type: { eqIgnoreCase: value } },
+  ]);
+  const userOr = users.flatMap((value) => [
+    { email: { eqIgnoreCase: value } },
+    { displayName: { eqIgnoreCase: value } },
+    { name: { containsIgnoreCaseAndAccent: value } },
+  ]);
+  const cycleOr = cycles.flatMap((value) => [
+    ...(value.toLowerCase() === "active" ? [{ isActive: { eq: true } }] : []),
+    { name: { eqIgnoreCase: value } },
+    ...(/^\d+$/.test(value) ? [{ number: { eq: Number(value) } }] : []),
+  ]);
+
+  return {
+    teamId: team.id,
+    projectFilter: projectOr.length ? { or: projectOr } : emptyIdFilter(),
+    stateFilter: stateOr.length
+      ? { and: [{ team: { id: { eq: team.id } } }, { or: stateOr }] }
+      : emptyIdFilter(),
+    userFilter: userOr.length ? { or: userOr } : emptyIdFilter(),
+    labelFilter: labels.length
+      ? {
+          and: [
+            stringOrFilter("name", labels),
+            { or: [{ team: { id: { eq: team.id } } }, { team: { null: true } }] },
+          ],
+        }
+      : emptyIdFilter(),
+    issueFilter: parents.length ? { id: { in: parents } } : emptyIdFilter(),
+    cycleFilter: cycleOr.length
+      ? { and: [{ team: { id: { eq: team.id } } }, { or: cycleOr }] }
+      : emptyIdFilter(),
+    milestoneFilter: milestones.length ? stringOrFilter("name", milestones) : emptyIdFilter(),
+  };
+}
+
+export async function loadWriteMetadata(
+  client: LinearClient,
+  items: UpdateFields[],
+  signal?: AbortSignal,
+): Promise<WriteMetadata> {
+  const team = await client.getTeam(signal);
+  return client.api<WriteMetadata>(WRITE_METADATA_QUERY, buildMetadataVariables(items, team), signal);
+}
+
+function findProject(value: string, metadata: WriteMetadata): MetadataNode {
+  const lower = value.toLowerCase();
+  const project = connectionNodes(metadata.projects).find((node) =>
+    node.id === value || node.name?.toLowerCase() === lower || node.slugId?.toLowerCase() === lower);
+  if (!project) throw new Error(`Linear project not found: ${value}`);
+  return project;
+}
+
+function findState(value: string, metadata: WriteMetadata): MetadataNode {
+  const lower = value.toLowerCase();
+  const states = [...connectionNodes(metadata.workflowStates)].sort(
+    (a, b) => (a.position ?? Number.MAX_SAFE_INTEGER) - (b.position ?? Number.MAX_SAFE_INTEGER),
+  );
+  const state = states.find((node) => node.name?.toLowerCase() === lower)
+    ?? states.find((node) => node.type?.toLowerCase() === lower);
+  if (!state) throw new Error(`Linear workflow state not found for the configured team: ${value}`);
+  return state;
+}
+
+function findUser(value: string, metadata: WriteMetadata): MetadataNode {
+  if (value === "self" || value === "@me") return metadata.viewer;
+  const lower = value.toLowerCase();
+  const users = connectionNodes(metadata.users);
+  const user = users.find((node) => node.email?.toLowerCase() === lower)
+    ?? users.find((node) => node.displayName?.toLowerCase() === lower)
+    ?? users.find((node) => node.name?.toLowerCase() === lower);
+  if (!user) throw new Error(`Linear user not found: ${value}`);
+  return user;
+}
+
+function findLabel(value: string, metadata: WriteMetadata): MetadataNode {
+  const lower = value.toLowerCase();
+  const label = connectionNodes(metadata.issueLabels).find((node) => node.name?.toLowerCase() === lower);
+  if (!label) throw new Error(`Linear label not found for the configured team: ${value}`);
+  return label;
+}
+
+function findParent(value: string, metadata: WriteMetadata): MetadataNode {
+  const identifier = normalizeIssueIdentifier(value);
+  const parent = connectionNodes(metadata.issues).find((node) => node.identifier?.toUpperCase() === identifier);
+  if (!parent) throw new Error(`Linear parent issue not found: ${identifier}`);
+  return parent;
+}
+
+function findCycle(value: string, metadata: WriteMetadata): { id: string } {
+  const lower = value.toLowerCase();
+  if (lower === "active") {
+    const active = connectionNodes(metadata.teams)[0]?.activeCycle;
+    if (!active?.id) throw new Error("Linear active cycle not found for the configured team");
+    return { id: active.id };
+  }
+  const cycle = connectionNodes(metadata.cycles).find((node) =>
+    node.name?.toLowerCase() === lower || String(node.number) === value);
+  if (!cycle) throw new Error(`Linear cycle not found for the configured team: ${value}`);
+  return cycle;
+}
+
+function findMilestone(value: string, projectId: string, metadata: WriteMetadata): MetadataNode {
+  const lower = value.toLowerCase();
+  const milestone = connectionNodes(metadata.projectMilestones).find((node) =>
+    node.name?.toLowerCase() === lower && node.project?.id === projectId);
+  if (!milestone) throw new Error(`Linear milestone not found in selected project: ${value}`);
+  return milestone;
+}
+
+export function resolveWriteInput(
+  fields: UpdateFields,
+  metadata: WriteMetadata,
+  options: { create: boolean },
+): WriteInput {
+  const input: WriteInput = {};
+  const team = connectionNodes(metadata.teams)[0];
+  if (options.create) {
+    if (!team?.id) throw new Error("Configured Linear team metadata was not returned");
+    input.teamId = team.id;
+  }
+  if (fields.title !== undefined) input.title = fields.title;
+  if (fields.description !== undefined) input.description = fields.description;
+  if (fields.priority !== undefined) input.priority = Math.trunc(fields.priority);
+  if (fields.due_date !== undefined) input.dueDate = fields.due_date;
+  if (fields.estimate !== undefined) input.estimate = fields.estimate;
+
+  let projectId: string | undefined;
+  if (fields.project) {
+    projectId = findProject(fields.project, metadata).id;
+    input.projectId = projectId;
+  }
+  if (fields.state) input.stateId = findState(fields.state, metadata).id;
+  if (fields.assignee) input.assigneeId = findUser(fields.assignee, metadata).id;
+  if (fields.labels?.length) input.labelIds = fields.labels.map((label) => findLabel(label, metadata).id);
+  if (fields.parent) input.parentId = findParent(fields.parent, metadata).id;
+  if (fields.cycle) input.cycleId = findCycle(fields.cycle, metadata).id;
+  if (fields.milestone) {
+    if (!projectId) throw new Error("milestone requires project");
+    input.projectMilestoneId = findMilestone(fields.milestone, projectId, metadata).id;
+  }
+  return input;
+}
+
+function matches(value: string | undefined, expected: string): boolean {
+  return value?.toLowerCase() === expected.toLowerCase();
+}
+
+export function assertExpectedIssueState(issue: LinearIssue, expected: ExpectedIssueState | undefined): void {
+  if (!expected) return;
+  const identifier = issue.identifier ?? "issue";
+  const mismatch = (field: string, wanted: unknown, actual: unknown): never => {
+    throw new Error(`guard failed for ${identifier}: expected ${field} ${String(wanted)}, found ${String(actual)}`);
+  };
+
+  if (expected.updated_at) {
+    const expectedTime = Date.parse(expected.updated_at);
+    const actualTime = issue.updatedAt ? Date.parse(issue.updatedAt) : Number.NaN;
+    if (expectedTime !== actualTime) mismatch("updated_at", expected.updated_at, issue.updatedAt ?? "missing");
+  }
+  if (
+    expected.state
+    && !matches(issue.state?.name, expected.state)
+    && !matches(issue.state?.type, expected.state)
+    && !matches(issue.state?.id, expected.state)
+  ) {
+    mismatch("state", expected.state, issue.state?.name ?? "none");
+  }
+  if (expected.unassigned && issue.assignee) mismatch("assignee", "unassigned", issue.assignee.displayName ?? issue.assignee.name ?? issue.assignee.id ?? "assigned");
+  if (
+    expected.assignee
+    && !matches(issue.assignee?.id, expected.assignee)
+    && !matches(issue.assignee?.name, expected.assignee)
+    && !matches(issue.assignee?.displayName, expected.assignee)
+  ) {
+    mismatch("assignee", expected.assignee, issue.assignee?.displayName ?? issue.assignee?.name ?? "unassigned");
+  }
+  if (expected.no_project && issue.project) mismatch("project", "none", issue.project.name ?? issue.project.slugId ?? issue.project.id ?? "assigned");
+  if (
+    expected.project
+    && !matches(issue.project?.id, expected.project)
+    && !matches(issue.project?.name, expected.project)
+    && !matches(issue.project?.slugId, expected.project)
+  ) {
+    mismatch("project", expected.project, issue.project?.name ?? "none");
+  }
+  if (expected.priority !== undefined && (issue.priority ?? 0) !== expected.priority) {
+    mismatch("priority", expected.priority, issue.priority ?? 0);
+  }
+}
+
+export async function readAndGuardIssue(
+  client: LinearClient,
+  identifier: string,
+  expected: ExpectedIssueState | undefined,
+  signal?: AbortSignal,
+): Promise<LinearIssue> {
+  const issue = await client.getIssue(identifier, signal);
+  assertExpectedIssueState(issue, expected);
+  return issue;
+}
+
+export async function createIssue(
+  client: LinearClient,
+  item: CreateItem,
+  metadata: WriteMetadata,
+  signal?: AbortSignal,
+): Promise<CreatedIssue> {
+  const data = await client.api<{
+    issueCreate?: { success?: boolean; issue?: LinearIssue | null };
+  }>(CREATE_ISSUE_MUTATION, { input: resolveWriteInput(item, metadata, { create: true }) }, signal);
+  if (!data.issueCreate?.success || !data.issueCreate.issue?.identifier) {
+    throw new Error("Linear issue creation failed without returning an issue");
+  }
+  return {
+    key: stringArg(item.key),
+    identifier: data.issueCreate.issue.identifier,
+    url: data.issueCreate.issue.url,
+    issue: data.issueCreate.issue,
+  };
+}
+
+export async function updateIssue(
+  client: LinearClient,
+  identifier: string,
+  fields: UpdateFields,
+  metadata: WriteMetadata,
+  signal?: AbortSignal,
+): Promise<LinearIssue> {
+  const data = await client.api<{
+    issueUpdate?: { success?: boolean; issue?: LinearIssue | null };
+  }>(UPDATE_ISSUE_MUTATION, {
+    id: normalizeIssueIdentifier(identifier),
+    input: resolveWriteInput(fields, metadata, { create: false }),
+  }, signal);
+  if (!data.issueUpdate?.success || !data.issueUpdate.issue?.identifier) {
+    throw new Error(`Linear update failed for ${identifier}`);
+  }
+  return data.issueUpdate.issue;
+}
+
+export async function commentIssue(
+  client: LinearClient,
+  identifier: string,
+  body: string,
+  signal?: AbortSignal,
+): Promise<LinearComment> {
+  const data = await client.api<{
+    commentCreate?: { success?: boolean; comment?: LinearComment | null };
+  }>(COMMENT_MUTATION, {
+    input: { issueId: normalizeIssueIdentifier(identifier), body },
+  }, signal);
+  if (!data.commentCreate?.success || !data.commentCreate.comment) {
+    throw new Error(`Linear comment failed for ${identifier}`);
+  }
+  return data.commentCreate.comment;
+}
+
+function normalizeRelation(from: string, type: RelationType, to: string): {
+  issueId: string;
+  relatedIssueId: string;
+  type: Exclude<RelationType, "blocked-by">;
+} {
+  return type === "blocked-by"
+    ? { issueId: to, relatedIssueId: from, type: "blocks" }
+    : { issueId: from, relatedIssueId: to, type };
+}
+
+async function addRelation(
+  client: LinearClient,
+  from: string,
+  type: RelationType,
+  to: string,
+  signal?: AbortSignal,
+): Promise<LinearIssueRelation> {
+  const input = normalizeRelation(from, type, to);
+  const data = await client.api<{
+    issueRelationCreate?: { success?: boolean; issueRelation?: LinearIssueRelation | null };
+  }>(CREATE_RELATION_MUTATION, { input }, signal);
+  if (!data.issueRelationCreate?.success || !data.issueRelationCreate.issueRelation) {
+    throw new Error(`Linear relation creation failed: ${from} ${type} ${to}`);
+  }
+  return data.issueRelationCreate.issueRelation;
+}
+
+async function findRelation(
+  client: LinearClient,
+  from: string,
+  type: RelationType,
+  to: string,
+  signal?: AbortSignal,
+): Promise<LinearIssueRelation | undefined> {
+  const normalized = normalizeRelation(from, type, to);
+  const found = await client.api<{
+    issue?: {
+      relations?: { nodes?: LinearIssueRelation[] };
+      inverseRelations?: { nodes?: LinearIssueRelation[] };
+    } | null;
+  }>(FIND_RELATION_QUERY, { issueId: normalized.issueId }, signal);
+  const relation = connectionNodes(found.issue?.relations).find((candidate) =>
+    candidate.type === normalized.type
+      && candidate.relatedIssue?.identifier?.toUpperCase() === normalized.relatedIssueId)
+    ?? (normalized.type === "related"
+      ? connectionNodes(found.issue?.inverseRelations).find((candidate) =>
+          candidate.type === "related"
+          && candidate.issue?.identifier?.toUpperCase() === normalized.relatedIssueId)
+      : undefined);
+  return relation;
+}
+
+async function deleteRelation(
+  client: LinearClient,
+  from: string,
+  type: RelationType,
+  to: string,
+  signal?: AbortSignal,
+): Promise<LinearIssueRelation> {
+  const relation = await findRelation(client, from, type, to, signal);
+  if (!relation?.id) throw new Error(`Linear relation not found: ${from} ${type} ${to}`);
+  const deleted = await client.api<{ issueRelationDelete?: { success?: boolean } }>(
+    DELETE_RELATION_MUTATION,
+    { id: relation.id },
+    signal,
+  );
+  if (!deleted.issueRelationDelete?.success) throw new Error(`Linear relation deletion failed: ${from} ${type} ${to}`);
+  return relation;
+}
+
+export async function runRelations(
+  client: LinearClient,
+  specs: RelationSpec[],
+  aliases: Map<string, string>,
+  operation: "add" | "delete",
+  signal?: AbortSignal,
+  options: RelationRunOptions = {},
+): Promise<RelationResult[]> {
+  const allowed = new Set<RelationType>(["blocks", "blocked-by", "related", "duplicate"]);
+  const seen = new Set<string>();
+  const results: RelationResult[] = [];
+  for (const spec of specs) {
+    if (signal?.aborted) break;
+    const rawFrom = stringArg(spec.from) ?? "?";
+    const rawType = stringArg(spec.type)?.toLowerCase() ?? "?";
+    const rawTo = stringArg(spec.to) ?? "?";
+    try {
+      if (!allowed.has(rawType as RelationType)) {
+        throw new Error("relation type must be blocks, blocked-by, related, or duplicate");
+      }
+      const type = rawType as RelationType;
+      const from = resolveIssueRef(rawFrom, aliases);
+      const to = resolveIssueRef(rawTo, aliases);
+      if (from === to) throw new Error("an issue cannot be related to itself");
+      const normalized = normalizeRelation(from, type, to);
+      const relationKey = normalized.type === "related"
+        ? `${[normalized.issueId, normalized.relatedIssueId].sort().join("|")}|related`
+        : `${normalized.issueId}|${normalized.type}|${normalized.relatedIssueId}`;
+      if (seen.has(relationKey)) throw new Error("duplicate relation in batch");
+      seen.add(relationKey);
+      if (options.dryRun) {
+        let relation: LinearIssueRelation | undefined;
+        if (options.validateExisting !== false) {
+          if (options.knownIssueIdentifiers) {
+            const fromPlanned = options.plannedIssueReferences?.has(from) ?? false;
+            const toPlanned = options.plannedIssueReferences?.has(to) ?? false;
+            if (!fromPlanned && !options.knownIssueIdentifiers.has(from)) throw new Error(`Linear issue not found: ${from}`);
+            if (!toPlanned && !options.knownIssueIdentifiers.has(to)) throw new Error(`Linear issue not found: ${to}`);
+            if (!fromPlanned && !toPlanned) relation = await findRelation(client, from, type, to, signal);
+          } else {
+            await client.getIssue(from, signal);
+            await client.getIssue(to, signal);
+            relation = await findRelation(client, from, type, to, signal);
+          }
+          if (operation === "add" && relation) throw new Error(`Linear relation already exists: ${from} ${type} ${to}`);
+          if (operation === "delete" && !relation) throw new Error(`Linear relation not found: ${from} ${type} ${to}`);
+        }
+        results.push({ from, type, to, relation, dryRun: true });
+        continue;
+      }
+      const relation = operation === "add"
+        ? await addRelation(client, from, type, to, signal)
+        : await deleteRelation(client, from, type, to, signal);
+      results.push({ from, type, to, relation });
+    } catch (error) {
+      results.push({ from: rawFrom, type: rawType, to: rawTo, error: compactError(error) });
+      if (signal?.aborted) break;
+    }
+  }
+  return results;
+}
+
+export function buildAliasMap(created: CreatedIssue[]): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const issue of created) {
+    if (issue.key) aliases.set(aliasKey(issue.key), issue.identifier);
+  }
+  return aliases;
+}

--- a/packages/linear/tests/linear.test.ts
+++ b/packages/linear/tests/linear.test.ts
@@ -1,0 +1,518 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildLinearChildEnv,
+  formatLinearProcessError,
+  LinearClient,
+  readLinearTeamKey,
+} from "../src/client.ts";
+import { registerLinearCommand } from "../src/command.ts";
+import { registerLinearTools } from "../src/tools.ts";
+import type { LinearRunner, LinearTeam, WriteMetadata } from "../src/types.ts";
+import { resolveWriteInput } from "../src/write.ts";
+
+const metadata: WriteMetadata = {
+  viewer: { id: "user-self", name: "alex", displayName: "alex", email: "alex@example.com" },
+  teams: { nodes: [{ id: "team-eng", key: "ENG", name: "Engineering", activeCycle: { id: "cycle-active", name: "Active", number: 7 } }] },
+  projects: { nodes: [{ id: "project-product", name: "Product Work", slugId: "product-work" }] },
+  workflowStates: { nodes: [
+    { id: "state-review", name: "In Review", type: "started", position: 3, team: { key: "ENG" } },
+    { id: "state-progress", name: "In Progress", type: "started", position: 1, team: { key: "ENG" } },
+  ] },
+  users: { nodes: [{ id: "user-blair", name: "Blair User", displayName: "blair", email: "blair@example.com" }] },
+  issueLabels: { nodes: [{ id: "label-bug", name: "Bug", team: null }] },
+  issues: { nodes: [{ id: "issue-parent", identifier: "ENG-50", name: "Parent" }] },
+  cycles: { nodes: [{ id: "cycle-8", name: "Next Cycle", number: 8, team: { key: "ENG" } }] },
+  projectMilestones: { nodes: [{ id: "milestone-one", name: "Milestone One", project: { id: "project-product", name: "Product Work" } }] },
+};
+
+function issue(identifier: string, title = identifier, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `uuid-${identifier}`,
+    identifier,
+    title,
+    url: `https://linear.app/example/issue/${identifier}`,
+    state: { id: "state-progress", name: "In Progress", type: "started" },
+    assignee: { id: "user-blair", name: "Blair User", displayName: "blair" },
+    priority: 2,
+    priorityLabel: "High",
+    project: { id: "project-product", name: "Product Work" },
+    labels: { nodes: [{ id: "label-bug", name: "Bug" }] },
+    updatedAt: "2026-07-22T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+type FakeOptions = {
+  failCreateAt?: number;
+  abortAfterCreate?: AbortController;
+  issueResults?: Array<ReturnType<typeof issue>>;
+  teamResults?: LinearTeam[];
+};
+
+function createFakeRunner(options: FakeOptions = {}) {
+  const calls: Array<{ args: string[]; variables?: Record<string, any> }> = [];
+  let createCount = 0;
+  const runner: LinearRunner = async (args) => {
+    const variables = args[0] === "api" ? JSON.parse(args[3]) : undefined;
+    calls.push({ args, variables });
+    if (args[0] === "issue" && args[1] === "query") {
+      return JSON.stringify({ nodes: [issue("ENG-10", "Search result")] });
+    }
+    if (args[0] === "issue" && args[1] === "mine") return "ENG-10  My task";
+    const query = args[1] ?? "";
+    if (query.includes("LinearModConfiguredTeams")) {
+      return JSON.stringify({ data: { teams: { nodes: options.teamResults ?? metadata.teams?.nodes } } });
+    }
+    if (query.includes("LinearModWriteMetadata")) return JSON.stringify({ data: metadata });
+    if (query.includes("LinearModCreateIssue")) {
+      createCount += 1;
+      if (options.failCreateAt === createCount) {
+        return JSON.stringify({ errors: [{ message: "simulated create failure" }] });
+      }
+      const identifier = `ENG-${99 + createCount}`;
+      const response = JSON.stringify({ data: { issueCreate: { success: true, issue: issue(identifier, variables.input.title) } } });
+      options.abortAfterCreate?.abort();
+      return response;
+    }
+    if (query.includes("LinearModUpdateIssue")) {
+      return JSON.stringify({ data: { issueUpdate: { success: true, issue: issue(variables.id, variables.input.title ?? variables.id) } } });
+    }
+    if (query.includes("LinearModCreateComment")) {
+      return JSON.stringify({ data: { commentCreate: { success: true, comment: { id: "comment-1", body: variables.input.body, url: "https://linear.app/comment/1" } } } });
+    }
+    if (query.includes("LinearModCreateRelation")) {
+      return JSON.stringify({ data: { issueRelationCreate: { success: true, issueRelation: { id: "relation-1", type: variables.input.type } } } });
+    }
+    if (query.includes("LinearModFindRelation")) {
+      return JSON.stringify({ data: { issue: {
+        relations: { nodes: [{ id: "relation-1", type: "blocks", relatedIssue: { identifier: "ENG-200" } }] },
+        inverseRelations: { nodes: [{ id: "relation-related", type: "related", issue: { identifier: "ENG-300" } }] },
+      } } });
+    }
+    if (query.includes("LinearModDeleteRelation")) {
+      return JSON.stringify({ data: { issueRelationDelete: { success: true } } });
+    }
+    if (query.includes("LinearModIssueSummaries") || query.includes("LinearModFullIssues")) {
+      const candidates = options.issueResults ?? [issue("ENG-10", "Read result")];
+      const requested = new Set((variables?.ids ?? []).map((value: string) => value.toUpperCase()));
+      return JSON.stringify({ data: { issues: {
+        nodes: candidates.filter((candidate) => requested.has(candidate.identifier.toUpperCase())),
+      } } });
+    }
+    throw new Error(`unexpected fake Linear call: ${args.join(" ")}`);
+  };
+  return { calls, client: new LinearClient(runner) };
+}
+
+function register(client: LinearClient) {
+  const tools = new Map<string, any>();
+  const letta = {
+    capabilities: { tools: true, commands: false, ui: { panels: false } },
+    tools: { register(tool: any) { tools.set(tool.name, tool); return () => tools.delete(tool.name); } },
+  };
+  const disposers = registerLinearTools(letta, client);
+  return { disposers, tools };
+}
+
+describe("credential boundary", () => {
+  test("passes only operational environment variables to the Linear CLI", () => {
+    const env = buildLinearChildEnv({
+      PATH: "/bin",
+      HOME: "/home/test",
+      DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1/bus",
+      LINEAR_API_KEY: "lin_secret",
+      LETTA_API_KEY: "letta_secret",
+      AWS_SECRET_ACCESS_KEY: "aws_secret",
+      USER: "private-user",
+      LOGNAME: "private-user",
+    });
+    expect(env).toEqual({
+      PATH: "/bin",
+      HOME: "/home/test",
+      DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1/bus",
+    });
+    expect(readLinearTeamKey({ LINEAR_TEAM_KEY: " ENG " })).toBe("ENG");
+    expect(readLinearTeamKey({ LINEAR_API_KEY: "secret" })).toBeUndefined();
+    expect(formatLinearProcessError({
+      code: 1,
+      message: "Command failed: linear api --variables-json private-issue-body",
+    })).toBe("Linear CLI failed (exit 1)");
+    expect(formatLinearProcessError({ code: "ENOENT", message: "private-command" }))
+      .toBe("Linear CLI executable not found");
+  });
+
+  test("auto-selects one team and requires configuration for multi-team workspaces", async () => {
+    const single = createFakeRunner();
+    await expect(single.client.getTeam()).resolves.toMatchObject({ id: "team-eng", key: "ENG" });
+
+    const multiple = createFakeRunner({ teamResults: [
+      { id: "team-one", key: "ONE" },
+      { id: "team-two", key: "TWO" },
+    ] });
+    await expect(multiple.client.getTeam()).rejects.toThrow("Set LINEAR_TEAM_KEY when the Linear workspace has multiple teams");
+  });
+});
+
+describe("structured field resolution", () => {
+  test("resolves human-facing fields to GraphQL IDs without reading a secret", () => {
+    expect(resolveWriteInput({
+      title: "Structured issue",
+      project: "Product Work",
+      state: "started",
+      assignee: "self",
+      priority: 2,
+      labels: ["Bug"],
+      parent: "eng-50",
+      due_date: "2026-08-01",
+      estimate: 3,
+      milestone: "Milestone One",
+      cycle: "active",
+    }, metadata, { create: true })).toEqual({
+      teamId: "team-eng",
+      title: "Structured issue",
+      projectId: "project-product",
+      stateId: "state-progress",
+      assigneeId: "user-self",
+      priority: 2,
+      labelIds: ["label-bug"],
+      parentId: "issue-parent",
+      dueDate: "2026-08-01",
+      estimate: 3,
+      projectMilestoneId: "milestone-one",
+      cycleId: "cycle-active",
+    });
+  });
+
+  test("requires an exact assignee match instead of selecting a substring result", () => {
+    expect(resolveWriteInput({ assignee: "Blair User" }, metadata, { create: false })).toEqual({
+      assigneeId: "user-blair",
+    });
+    expect(() => resolveWriteInput({ assignee: "Bla" }, metadata, { create: false }))
+      .toThrow("Linear user not found: Bla");
+  });
+});
+
+describe("tool registration", () => {
+  test("registers the complete public surface with approval on writes", () => {
+    const { tools } = register(createFakeRunner().client);
+    expect([...tools.keys()]).toEqual([
+      "linear_search",
+      "linear_issue",
+      "linear_create",
+      "linear_relation",
+      "linear_update",
+      "linear_comment",
+    ]);
+    expect(tools.get("linear_search").requiresApproval).toBe(false);
+    expect(tools.get("linear_issue").parallelSafe).toBe(true);
+    for (const name of ["linear_create", "linear_relation", "linear_update", "linear_comment"]) {
+      expect(tools.get(name).requiresApproval).toBe(true);
+      expect(tools.get(name).parallelSafe).toBe(false);
+      expect(tools.get(name).parameters.properties.dry_run.type).toBe("boolean");
+    }
+    expect(tools.get("linear_update").parameters.properties.expected.type).toBe("object");
+    expect(tools.get("linear_comment").parameters.properties.expected.type).toBe("object");
+  });
+});
+
+describe("structured mutations", () => {
+  test("creates a batch, resolves aliases, deduplicates inverse relations, and reports partial failures", async () => {
+    const fake = createFakeRunner({ failCreateAt: 2 });
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_create").run({
+      args: {
+        items: [
+          { key: "api", title: "API task", project: "Product Work", priority: 2 },
+          { key: "failed", title: "Fail task" },
+          { key: "ui", title: "UI task", parent: "ENG-50", estimate: 2 },
+        ],
+        relations: [
+          { from: "api", type: "blocks", to: "ui" },
+          { from: "ui", type: "blocked-by", to: "api" },
+          { from: "failed", type: "related", to: "api" },
+        ],
+      },
+    }));
+
+    expect(output.created.map((item: any) => item.identifier)).toEqual(["ENG-100", "ENG-102"]);
+    expect(output.create_errors).toEqual([{ key: "failed", title: "Fail task", error: "simulated create failure" }]);
+    expect(output.relations.filter((item: any) => item.status === "ok")).toHaveLength(1);
+    expect(output.relations.some((item: any) => item.error === "duplicate relation in batch")).toBe(true);
+    expect(output.relations.some((item: any) => item.error?.includes("unknown local issue key"))).toBe(true);
+
+    const writeCalls = fake.calls.filter((call) => call.args[0] !== "issue");
+    expect(writeCalls.every((call) => call.args[0] === "api")).toBe(true);
+    const relationInput = writeCalls.find((call) => call.args[1].includes("LinearModCreateRelation"))?.variables?.input;
+    expect(relationInput).toEqual({ issueId: "ENG-100", relatedIssueId: "ENG-102", type: "blocks" });
+  });
+
+  test("returns normalized update and comment results", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const updated = JSON.parse(await tools.get("linear_update").run({
+      args: { identifiers: ["ENG-10", "ENG-11"], title: "New title", project: "Product Work", state: "started" },
+    }));
+    expect(updated).toMatchObject({ action: "update", succeeded: 2, failed: 0 });
+    expect(updated.results[0].value).toMatchObject({ identifier: "ENG-10", title: "New title", state: "In Progress" });
+
+    const commented = JSON.parse(await tools.get("linear_comment").run({
+      args: { identifiers: ["ENG-10", "ENG-11"], body: "Status update" },
+    }));
+    expect(commented).toMatchObject({ action: "comment", succeeded: 2, failed: 0 });
+    expect(commented.results[0].value).toMatchObject({ id: "comment-1", body: "Status update" });
+  });
+
+  test("deletes blocked-by relations using normalized GraphQL direction", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_relation").run({
+      args: { operation: "delete", relations: [{ from: "ENG-200", type: "blocked-by", to: "ENG-100" }] },
+    }));
+    expect(output.results[0].status).toBe("ok");
+    const findCall = fake.calls.find((call) => call.args[1]?.includes("LinearModFindRelation"));
+    expect(findCall?.variables).toEqual({ issueId: "ENG-100" });
+  });
+
+  test("deduplicates symmetric related pairs and deletes inverse related relations", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const added = JSON.parse(await tools.get("linear_relation").run({
+      args: { operation: "add", relations: [
+        { from: "ENG-300", type: "related", to: "ENG-400" },
+        { from: "ENG-400", type: "related", to: "ENG-300" },
+      ] },
+    }));
+    expect(added.results.filter((item: any) => item.status === "ok")).toHaveLength(1);
+    expect(added.results[1].error).toBe("duplicate relation in batch");
+
+    const deleted = JSON.parse(await tools.get("linear_relation").run({
+      args: { operation: "delete", relations: [{ from: "ENG-400", type: "related", to: "ENG-300" }] },
+    }));
+    expect(deleted.results[0].status).toBe("ok");
+    const deleteCall = fake.calls.find((call) =>
+      call.args[1]?.includes("LinearModDeleteRelation") && call.variables?.id === "relation-related");
+    expect(deleteCall).toBeDefined();
+  });
+
+  test("stops remaining creates after cancellation", async () => {
+    const controller = new AbortController();
+    const fake = createFakeRunner({ abortAfterCreate: controller });
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_create").run({
+      args: { items: [{ title: "First" }, { title: "Second" }] },
+      signal: controller.signal,
+    }));
+    expect(output.created).toHaveLength(1);
+    expect(fake.calls.filter((call) => call.args[1]?.includes("LinearModCreateIssue"))).toHaveLength(1);
+  });
+
+  test("keeps the flat single-create call shape compatible", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const output = await tools.get("linear_create").run({ args: { title: "Single task" } });
+    expect(output).toContain("ENG-100: Single task");
+  });
+
+  test("rejects fractional priority and estimate before metadata or writes", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_create").run({
+      args: { items: [{ title: "Bad priority", priority: 1.5 }, { title: "Bad estimate", estimate: 2.5 }] },
+    }));
+    expect(output.create_errors.map((item: any) => item.error)).toEqual([
+      "priority must be an integer between 1 and 4",
+      "estimate must be a non-negative integer",
+    ]);
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  test("previews creates and alias relations without executing mutations", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_create").run({
+      args: {
+        dry_run: true,
+        items: [
+          { key: "api", title: "API task", project: "Product Work", state: "started" },
+          { key: "ui", title: "UI task", parent: "ENG-50" },
+        ],
+        relations: [{ from: "api", type: "blocks", to: "ui" }],
+      },
+    }));
+    expect(output).toMatchObject({ action: "create", dry_run: true, planned: 2, failed: 0 });
+    expect(output.creates[0]).toMatchObject({
+      key: "api",
+      status: "planned",
+      resolved_input: { teamId: "team-eng", projectId: "project-product", stateId: "state-progress" },
+    });
+    expect(output.relations[0]).toMatchObject({ from: "NEW(api)", type: "blocks", to: "NEW(ui)", status: "planned" });
+    expect(fake.calls.some((call) => /LinearMod(CreateIssue|CreateRelation)/.test(call.args[1] ?? ""))).toBe(false);
+  });
+
+  test("rejects missing existing relation targets in create previews", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_create").run({
+      args: {
+        dry_run: true,
+        items: [{ key: "new", title: "New task" }],
+        relations: [{ from: "new", type: "related", to: "ENG-999" }],
+      },
+    }));
+    expect(output.planned).toBe(1);
+    expect(output.relations[0]).toMatchObject({
+      from: "new",
+      to: "ENG-999",
+      status: "error",
+      error: "Linear issue not found: ENG-999",
+    });
+    expect(fake.calls.some((call) => /LinearMod(CreateIssue|CreateRelation)/.test(call.args[1] ?? ""))).toBe(false);
+  });
+
+  test("batches update previews and reports stale items without mutating", async () => {
+    const fake = createFakeRunner({ issueResults: [
+      issue("ENG-10"),
+      issue("ENG-11", "Changed", { state: { id: "state-done", name: "Done", type: "completed" } }),
+    ] });
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_update").run({
+      args: {
+        identifiers: ["ENG-10", "ENG-11"],
+        title: "Next title",
+        state: "started",
+        expected: { state: "In Progress", priority: 2, updated_at: "2026-07-22T00:00:00Z" },
+        dry_run: true,
+      },
+    }));
+    expect(output).toMatchObject({ action: "update", dry_run: true, planned: 1, failed: 1 });
+    expect(output.results[0]).toMatchObject({
+      identifier: "ENG-10",
+      status: "planned",
+      resolved_changes: { title: "Next title", stateId: "state-progress" },
+    });
+    expect(output.results[1].error).toContain("expected state In Progress, found Done");
+    expect(fake.calls.filter((call) => call.args[1]?.includes("LinearModIssueSummaries"))).toHaveLength(1);
+    expect(fake.calls.some((call) => call.args[1]?.includes("LinearModUpdateIssue"))).toBe(false);
+  });
+
+  test("rechecks expected state per item and preserves partial batch writes", async () => {
+    const fake = createFakeRunner({ issueResults: [
+      issue("ENG-10"),
+      issue("ENG-11", "Changed", { assignee: { id: "user-casey", name: "Casey User", displayName: "casey" } }),
+    ] });
+    const { tools } = register(fake.client);
+    const output = JSON.parse(await tools.get("linear_update").run({
+      args: {
+        identifiers: ["ENG-10", "ENG-11"],
+        priority: 3,
+        expected: { assignee: "blair" },
+      },
+    }));
+    expect(output).toMatchObject({ action: "update", succeeded: 1, failed: 1 });
+    expect(output.results[1].error).toContain("expected assignee blair, found casey");
+    expect(fake.calls.filter((call) => call.args[1]?.includes("LinearModIssueSummaries"))).toHaveLength(2);
+    expect(fake.calls.filter((call) => call.args[1]?.includes("LinearModUpdateIssue"))).toHaveLength(1);
+  });
+
+  test("previews comments and relations without executing mutations", async () => {
+    const fake = createFakeRunner({ issueResults: [issue("ENG-100"), issue("ENG-200")] });
+    const { tools } = register(fake.client);
+    const comment = await tools.get("linear_comment").run({
+      args: { identifiers: ["ENG-100"], body: "Ship it", expected: { unassigned: false }, dry_run: true },
+    });
+    expect(comment).toEqual({ status: "error", content: "expected.unassigned must be true when provided" });
+
+    const relation = JSON.parse(await tools.get("linear_relation").run({
+      args: {
+        operation: "delete",
+        relations: [{ from: "ENG-100", type: "blocks", to: "ENG-200" }],
+        dry_run: true,
+      },
+    }));
+    expect(relation).toMatchObject({ operation: "delete", dry_run: true });
+    expect(relation.results[0].status).toBe("planned");
+    expect(fake.calls.filter((call) => call.args[1]?.includes("LinearModIssueSummaries"))).toHaveLength(1);
+    expect(fake.calls.some((call) => /LinearMod(CreateComment|DeleteRelation)/.test(call.args[1] ?? ""))).toBe(false);
+  });
+
+  test("chunks large relation preview endpoint reads at the issue query limit", async () => {
+    const identifiers = Array.from({ length: 52 }, (_value, index) => `ENG-${1000 + index}`);
+    const fake = createFakeRunner({ issueResults: identifiers.map((identifier) => issue(identifier)) });
+    const { tools } = register(fake.client);
+    const relations = Array.from({ length: 26 }, (_value, index) => ({
+      from: identifiers[index * 2],
+      type: "related",
+      to: identifiers[index * 2 + 1],
+    }));
+    const output = JSON.parse(await tools.get("linear_relation").run({
+      args: { operation: "add", relations, dry_run: true },
+    }));
+    expect(output.results.every((result: any) => result.status === "planned")).toBe(true);
+    const reads = fake.calls.filter((call) => call.args[1]?.includes("LinearModIssueSummaries"));
+    expect(reads).toHaveLength(2);
+    expect(reads.map((call) => call.variables?.ids.length)).toEqual([50, 2]);
+    expect(fake.calls.some((call) => call.args[1]?.includes("LinearModCreateRelation"))).toBe(false);
+  });
+
+  test("previews comments with guards and rejects conflicting guard fields", async () => {
+    const fake = createFakeRunner({ issueResults: [issue("ENG-10")] });
+    const { tools } = register(fake.client);
+    const preview = JSON.parse(await tools.get("linear_comment").run({
+      args: { identifiers: ["ENG-10"], body: "Status", expected: { assignee: "blair" }, dry_run: true },
+    }));
+    expect(preview).toMatchObject({ action: "comment", dry_run: true, planned: 1, failed: 0 });
+    expect(preview.results[0]).toMatchObject({ status: "planned", comment: "Status" });
+
+    const invalid = await tools.get("linear_update").run({
+      args: { identifiers: ["ENG-10"], state: "started", expected: { assignee: "blair", unassigned: true } },
+    });
+    expect(invalid).toEqual({ status: "error", content: "expected.assignee and expected.unassigned are mutually exclusive" });
+  });
+});
+
+describe("read behavior", () => {
+  test("reads multiple issues and expands search results", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const read = await tools.get("linear_issue").run({ args: { identifiers: ["ENG-10", "ENG-11"] } });
+    expect(read).toContain("ENG-10: Read result");
+    expect(read).toContain("ENG-11: Linear issue not found");
+
+    const search = await tools.get("linear_search").run({ args: { search: "result", detail: "full" } });
+    expect(search).toContain("ENG-10: Read result");
+    expect(fake.calls.some((call) => call.args[0] === "issue" && call.args[1] === "query")).toBe(true);
+  });
+
+  test("enforces the full-detail batch limit at the cross-field validation boundary", async () => {
+    const fake = createFakeRunner();
+    const { tools } = register(fake.client);
+    const result = await tools.get("linear_issue").run({
+      args: { identifiers: ["ENG-1", "ENG-2", "ENG-3", "ENG-4", "ENG-5", "ENG-6"], detail: "full" },
+    });
+    expect(result).toEqual({ status: "error", content: "no more than 5 identifiers are allowed" });
+    expect(fake.calls).toHaveLength(0);
+  });
+});
+
+describe("slash command", () => {
+  test("supports rich comma-separated reads, search, mine, and empty-input guards", async () => {
+    const fake = createFakeRunner();
+    const commands = new Map<string, any>();
+    const letta = {
+      capabilities: { commands: true, ui: { panels: false } },
+      commands: { register(command: any) { commands.set(command.id, command); return () => commands.delete(command.id); } },
+    };
+    const disposers = registerLinearCommand(letta, fake.client);
+    const command = commands.get("linear");
+
+    const full = await command.run({ args: "full ENG-10,ENG-11" });
+    expect(full.output).toContain("ENG-10: Read result");
+    expect(full.output).toContain("ENG-11: Linear issue not found");
+    expect((await command.run({ args: "search result" })).output).toContain("Search result");
+    expect((await command.run({ args: "mine" })).output).toBe("ENG-10  My task");
+    expect((await command.run({ args: ",,," })).output).toStartWith("Usage: /linear");
+
+    for (const dispose of disposers.reverse()) dispose();
+    expect(commands.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a publishable Linear mod with:

- batched search, issue reads, creates, updates, comments, and relations
- dry-run previews on every write tool
- best-effort expected-state guards for updates and comments
- a `/linear` command with an optional active-work panel

## Why

Linear work often requires repeated one-ticket calls and approvals. The new primitives batch related operations while preserving per-item failures and explicit approval on every write surface.

## Safety

- invokes the Linear CLI with `execFile` and structured GraphQL variables; no shell interpolation
- passes the CLI an operational environment allowlist rather than agent/cloud secrets
- delegates authentication to the Linear CLI system-keyring flow
- rejects ambiguous assignee matches and validates relation endpoints during dry runs
- discovers single-team workspaces automatically; multi-team setups opt in with `LINEAR_TEAM_KEY`

`expected` guards are intentionally documented as non-atomic: they re-read each issue immediately before its mutation but cannot provide compare-and-swap semantics through Linear.

## Validation

- `bun test ./tests` — 22 tests, 89 assertions
- TypeScript no-emit check across source and tests
- `npm run validate`
- `npm pack ./packages/linear --dry-run --json` — expected 13-file package surface only
- isolated `letta install` + `letta mods list`
- loaded through the Letta mod engine: 1 command and 6 tools, no diagnostics
- live smoke: all four write tools returned planned dry-run results and a follow-up read confirmed no issue change
- confidentiality scan of the exact public diff and package tarball found no secrets, private tickets, workspace data, local paths, or internal links
