### PR TITLE
feat(secrets-scrubber): redact secrets from tool outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ packages/
 ├── pets/                 # Terminal pets that animate based on turn and tool activity
 ├── plan-mode/            # Plan-mode style workflow
 ├── ponytail/             # Lazy senior dev mode — YAGNI ladder for less, simpler code
+├── secrets-scrubber/     # Redacts detected credentials from tool results before history
 ├── soft-landing/         # Recovery slash command for drift, compaction, or context overload
 ├── spotify-statusline/   # macOS Spotify now-playing statusline
 ├── sprite/               # Persistent pet that grows stats from real agent work
@@ -121,6 +122,7 @@ scripts/
 - **pets** - Terminal pets that animate based on turn and tool activity
 - **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
 - **ponytail** - Lazy senior dev mode that injects a YAGNI ladder ruleset to write less, simpler code
+- **secrets-scrubber** - Redacts detected credentials from tool results before they enter conversation history
 - **soft-landing** - Recovery slash command for drift, compaction, or context overload
 - **spotify-statusline** - macOS Spotify now-playing statusline
 - **sprite** - Persistent pet that grows stats from real agent work

--- a/packages/secrets-scrubber/MOD.md
+++ b/packages/secrets-scrubber/MOD.md
@@ -1,0 +1,40 @@
+---
+name: "@letta-ai/secrets-scrubber"
+description: "Redacts detected credentials from string tool results before they enter Letta Code conversation history."
+---
+
+# Secrets scrubber mod semantics
+
+## When to use
+
+Install this package when agents may encounter API keys, access tokens, or credential-bearing connection strings in shell output, files, HTTP responses, logs, or other tool results.
+
+## Behavior
+
+The package registers one `tool_end` handler using the `events.tools` capability.
+
+For every string tool result, the handler runs the local `@sanity-labs/secret-scan` detector plus narrow contextual rules for generic credential assignments and common authorization headers. It replaces matches with labeled redaction markers, preserves the original tool status, and passes clean results through without a replacement.
+
+The handler also recognizes Letta Code's exact overflow and background-output breadcrumb lines. It rewrites a referenced file only when all of these checks pass:
+
+- the path is absolute;
+- the parent resolves to a known Letta Code output directory;
+- the filename matches a harness-generated overflow or background-task shape;
+- the target opens without following symlinks and is a regular file;
+- the same file identity is still present immediately before atomic replacement.
+
+Known background task files are recorded at launch. Inline reads are always scanned, but the file itself is rewritten only after TaskOutput reports `completed` or `failed`; this avoids racing an active writer and losing appended output.
+
+## Failure behavior
+
+Scanning fails closed. If text scanning throws, or a recognized harness output file cannot be safely scanned or replaced, the original tool result is withheld and an error is recorded through mod diagnostics. The mod never reads a breadcrumb path outside its narrow allowlist.
+
+## Boundaries
+
+This mod protects string tool results at the final `tool_end` boundary. It does not inspect user messages, assistant text, tool arguments, live streaming chunks, pre-existing history, multimodal results, or arbitrary local files.
+
+Detection is rule-based and cannot guarantee discovery of every secret. A secret without a recognizable structure may be missed, and a matching non-secret fixture may be redacted.
+
+`tool_end` replacements use first-handler-wins semantics. The scrubber must be loaded before any other mod that replaces tool results; a result returned by an earlier handler shadows later replacements.
+
+The mod makes no network calls and spawns no subprocesses. If it prevents startup, use `letta --no-mods` or `LETTA_DISABLE_MODS=1 letta`, remove the package, and reload.

--- a/packages/secrets-scrubber/README.md
+++ b/packages/secrets-scrubber/README.md
@@ -1,0 +1,65 @@
+# Secrets scrubber
+
+Redacts detected credentials from Letta Code tool results before those results enter conversation history.
+
+The mod uses [`@sanity-labs/secret-scan`](https://github.com/sanity-io/secret-scan), a local scanner with more than 1,100 TruffleHog-derived rules. It covers common provider keys, bearer tokens, JWTs, private keys, and credential-bearing connection strings. Narrow contextual rules also cover generic password, token, API-key, secret assignments, and common authorization headers. No tool output is sent to a remote scanning service.
+
+## Install
+
+```bash
+letta install npm:@letta-ai/secrets-scrubber
+```
+
+Then run `/reload` in active sessions.
+
+## Behavior
+
+The package registers a `tool_end` event handler. For every string tool result, it:
+
+1. scans the returned text for known secret patterns;
+2. replaces each match with a labeled marker such as `[REDACTED: Github V2]`;
+3. preserves the tool's original success or error status;
+4. returns clean output unchanged.
+
+Letta Code can place large or background tool output in temporary files and return a breadcrumb instead of all bytes inline. The mod recognizes Letta Code's exact breadcrumb formats and also scrubs those files when their paths match known harness-owned locations and filename shapes. It records a background task's file at launch, keeps scrubbing each inline read, and rewrites the file only after TaskOutput reports that the writer has completed. Waiting for completion avoids racing an active writer and dropping newly appended bytes.
+
+File replacement is atomic. The mod rejects symlinks, unexpected paths, changed files, and unknown filename shapes rather than following arbitrary paths from tool output.
+
+If scanning throws or a referenced harness output file cannot be safely inspected, the mod fails closed: the tool result is replaced with a withholding notice and an error is added to mod diagnostics.
+
+## Scope and limitations
+
+- This protects **tool results entering conversation history**. It does not scan user messages, model responses, tool arguments, environment variables, or history that already exists.
+- Live terminal output may be displayed while a tool runs, before the final `tool_end` event. This mod is not a terminal-screen masking layer.
+- Secret detection is pattern-based. It can have false positives and false negatives, especially for credentials with no provider-specific structure.
+- Temporary output files are scrubbed only when Letta Code itself returns a recognized breadcrumb and the path passes the strict harness-path allowlist. The mod does not crawl the filesystem.
+- Letta Code uses first-result-wins semantics for `tool_end` replacements. Install this package before other mods that replace tool results so redaction runs first; otherwise an earlier replacement can shadow it.
+- While a background task is still running, its file may temporarily contain raw output. The mod scrubs each inline read before history and rewrites the file after TaskOutput reports completion. Legacy consumers that do not expose completion status still get inline redaction but not the final on-disk rewrite.
+
+This is defense in depth, not a substitute for least-privilege credentials, short-lived tokens, or keeping secrets out of commands when possible.
+
+## Verify
+
+```bash
+letta mods list
+```
+
+Run a controlled test with a disposable credential-shaped fixture, not a real key:
+
+```bash
+printf '%s\n' 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJ'
+```
+
+The tool result should contain a redaction marker rather than the fixture.
+
+## Development
+
+```bash
+npm install
+bun test
+bunx tsc --noEmit
+```
+
+## License
+
+MIT. The detector rules are derived from TruffleHog and retain their upstream Apache-2.0 licensing.

--- a/packages/secrets-scrubber/mods/index.ts
+++ b/packages/secrets-scrubber/mods/index.ts
@@ -1,0 +1,328 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { scan } from "@sanity-labs/secret-scan";
+
+const REDACTION_PREFIX = "REDACTED";
+const MAX_TRACKED_BACKGROUND_FILES = 1_000;
+const OVERFLOW_FILE_NAME = /^[a-zA-Z][a-zA-Z0-9_-]*-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.txt$/i;
+const BACKGROUND_FILE_NAME = /^(?:bash_\d+|task_\d+)\.log$/;
+const TASK_ID = /^(?:bash_\d+|task_\d+)$/;
+const BREADCRUMB_PATTERNS = [
+  /^\[Full output written to: (.+)]$/gm,
+  /^Output file: (.+)$/gm,
+] as const;
+const BACKGROUND_TASK_PATTERN = /^(?:Command|Task) running in background with (?:ID|task ID): ((?:bash_|task_)\d+)$/m;
+
+type ToolStatus = "success" | "error";
+
+export interface ToolEndEvent {
+  args: Record<string, unknown>;
+  output: string;
+  status: ToolStatus;
+  toolName: string;
+}
+
+export interface LettaModApi {
+  capabilities: { events: { tools: boolean } };
+  diagnostics?: {
+    report(input: { message: string; severity?: "warning" | "error" }): void;
+  };
+  events: {
+    on(
+      name: "tool_end",
+      handler: (event: ToolEndEvent) => Promise<unknown> | unknown,
+    ): () => void;
+  };
+}
+
+interface FileIdentity {
+  dev: bigint | number;
+  ino: bigint | number;
+  mode: number;
+}
+
+interface ScrubResult {
+  changed: boolean;
+  output: string;
+}
+
+interface SecretMatch {
+  end: number;
+  label: string;
+  start: number;
+}
+
+const CREDENTIAL_ASSIGNMENT = /\b(?:[a-z][a-z0-9]*[_-])*(?:password|passwd|pwd|api[_-]?key|(?:access|auth|bearer|refresh|session|id|csrf)[_-]?token|client[_-]?secret|secret[_-]?access[_-]?key|secret[_-]?key|private[_-]?key|token|secret)\b\s*[:=]\s*(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^\s,;}\]\r\n]+))/gi;
+const AUTHORIZATION_HEADER = /\b(?:authorization|proxy-authorization)\s*:\s*(?:basic|bearer|token|api[-_ ]?key)\s+([^\s,;]+)/gi;
+
+function contextualMatches(input: string): SecretMatch[] {
+  const matches: SecretMatch[] = [];
+  for (const pattern of [CREDENTIAL_ASSIGNMENT, AUTHORIZATION_HEADER]) {
+    pattern.lastIndex = 0;
+    for (const match of input.matchAll(pattern)) {
+      const value = match[1] ?? match[2] ?? match[3];
+      if (!value || value.startsWith(`[${REDACTION_PREFIX}:`)) continue;
+      const offset = match[0].lastIndexOf(value);
+      if (match.index === undefined || offset < 0) continue;
+      matches.push({
+        end: match.index + offset + value.length,
+        label: pattern === AUTHORIZATION_HEADER ? "Authorization" : "Credential",
+        start: match.index + offset,
+      });
+    }
+  }
+  return matches;
+}
+
+function allSecretMatches(input: string): SecretMatch[] {
+  const candidates: SecretMatch[] = [
+    ...scan(input).map((secret) => ({
+      end: secret.end,
+      label: secret.label,
+      start: secret.start,
+    })),
+    ...contextualMatches(input),
+  ].sort((left, right) => left.start - right.start || right.end - left.end);
+
+  const nonOverlapping: SecretMatch[] = [];
+  for (const candidate of candidates) {
+    const previous = nonOverlapping.at(-1);
+    if (previous && candidate.start < previous.end) {
+      previous.end = Math.max(previous.end, candidate.end);
+      continue;
+    }
+    nonOverlapping.push(candidate);
+  }
+  return nonOverlapping;
+}
+
+export function scrubText(input: string): ScrubResult {
+  const matches = allSecretMatches(input);
+  let output = input;
+  for (const match of matches.reverse()) {
+    output = `${output.slice(0, match.start)}[${REDACTION_PREFIX}: ${match.label}]${output.slice(match.end)}`;
+  }
+  return { changed: output !== input, output };
+}
+
+function isWithin(parent: string, candidate: string): boolean {
+  const child = relative(resolve(parent), resolve(candidate));
+  return child === "" || (!child.startsWith(`..${sep}`) && child !== ".." && !isAbsolute(child));
+}
+
+function canonicalPath(path: string): string | null {
+  try {
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function allowedOverflowPath(path: string): boolean {
+  const parent = canonicalPath(dirname(path));
+  const agentToolsRoot = canonicalPath(resolve(homedir(), ".letta", "projects"));
+  if (!parent || !agentToolsRoot || !isWithin(agentToolsRoot, parent)) return false;
+
+  const parts = relative(agentToolsRoot, parent).split(sep);
+  return parts.length === 2 && parts[0].length > 0 && parts[1] === "agent-tools";
+}
+
+function allowedBackgroundPath(path: string): boolean {
+  const parent = canonicalPath(dirname(path));
+  if (!parent) return false;
+
+  const scratchpad = process.env.LETTA_SCRATCHPAD;
+  if (scratchpad && parent === canonicalPath(scratchpad)) return true;
+
+  const tempRoot = canonicalPath(tmpdir());
+  return Boolean(
+    tempRoot &&
+      dirname(parent) === tempRoot &&
+      /^letta-background-[a-zA-Z0-9]{6}$/.test(basename(parent)),
+  );
+}
+
+export function isAllowedOutputPath(path: string): boolean {
+  if (!isAbsolute(path)) return false;
+  const fileName = basename(path);
+  if (OVERFLOW_FILE_NAME.test(fileName)) return allowedOverflowPath(path);
+  if (BACKGROUND_FILE_NAME.test(fileName)) return allowedBackgroundPath(path);
+  return false;
+}
+
+export function extractOutputPaths(output: string): string[] {
+  const paths = new Set<string>();
+  for (const pattern of BREADCRUMB_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of output.matchAll(pattern)) {
+      const path = match[1]?.trim();
+      if (path) paths.add(path);
+    }
+  }
+  return [...paths];
+}
+
+function readRegularFile(path: string): { content: string; identity: FileIdentity } | null {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const stat = fstatSync(fd, { bigint: true });
+    if (!stat.isFile()) return null;
+    return {
+      content: readFileSync(fd, "utf8"),
+      identity: { dev: stat.dev, ino: stat.ino, mode: Number(stat.mode) & 0o777 },
+    };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function sameFile(path: string, identity: FileIdentity): boolean {
+  try {
+    const stat = lstatSync(path, { bigint: true });
+    return stat.isFile() && stat.dev === identity.dev && stat.ino === identity.ino;
+  } catch {
+    return false;
+  }
+}
+
+function atomicReplace(path: string, content: string, identity: FileIdentity): boolean {
+  const tempPath = resolve(dirname(path), `.${basename(path)}.${randomUUID()}.tmp`);
+  try {
+    writeFileSync(tempPath, content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: identity.mode,
+    });
+    if (!sameFile(path, identity)) return false;
+    renameSync(tempPath, path);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(tempPath, { force: true });
+  }
+}
+
+export function scrubOutputFile(path: string): "changed" | "unchanged" | "rejected" | "failed" {
+  if (!isAllowedOutputPath(path)) return "rejected";
+
+  const original = readRegularFile(path);
+  if (!original) return "rejected";
+
+  let scrubbed: ScrubResult;
+  try {
+    scrubbed = scrubText(original.content);
+  } catch {
+    return "failed";
+  }
+  if (!scrubbed.changed) return "unchanged";
+  return atomicReplace(path, scrubbed.output, original.identity) ? "changed" : "failed";
+}
+
+function backgroundTaskId(event: ToolEndEvent): string | null {
+  if (event.args.run_in_background !== true) return null;
+  return event.output.match(BACKGROUND_TASK_PATTERN)?.[1] ?? null;
+}
+
+function taskIdFromArgs(event: ToolEndEvent): string | null {
+  const candidate = event.args.task_id ?? event.args.shell_id;
+  return typeof candidate === "string" && TASK_ID.test(candidate) ? candidate : null;
+}
+
+function completedTaskOutput(event: ToolEndEvent): boolean {
+  if (event.toolName !== "TaskOutput") return false;
+  try {
+    const parsed = JSON.parse(event.output) as { status?: unknown };
+    return parsed.status === "completed" || parsed.status === "failed";
+  } catch {
+    return false;
+  }
+}
+
+function rememberBackgroundPath(
+  paths: Map<string, string>,
+  taskId: string,
+  path: string,
+): void {
+  paths.delete(taskId);
+  paths.set(taskId, path);
+  while (paths.size > MAX_TRACKED_BACKGROUND_FILES) {
+    const oldest = paths.keys().next().value;
+    if (typeof oldest !== "string") break;
+    paths.delete(oldest);
+  }
+}
+
+export default function activate(letta: LettaModApi): (() => void) | undefined {
+  if (!letta.capabilities.events.tools) return;
+
+  const backgroundOutputPaths = new Map<string, string>();
+
+  return letta.events.on("tool_end", (event) => {
+    try {
+      const paths = extractOutputPaths(event.output);
+      const launchedTaskId = backgroundTaskId(event);
+      let fileScanFailed = false;
+
+      for (const path of paths) {
+        if (!isAllowedOutputPath(path)) continue;
+        if (launchedTaskId && BACKGROUND_FILE_NAME.test(basename(path))) {
+          rememberBackgroundPath(backgroundOutputPaths, launchedTaskId, path);
+          continue;
+        }
+
+        const result = scrubOutputFile(path);
+        if (result === "failed" || result === "rejected") fileScanFailed = true;
+      }
+
+      const consumedTaskId = taskIdFromArgs(event);
+      if (consumedTaskId && completedTaskOutput(event)) {
+        const path = backgroundOutputPaths.get(consumedTaskId);
+        if (path) {
+          const result = scrubOutputFile(path);
+          if (result === "failed" || result === "rejected") {
+            fileScanFailed = true;
+          } else {
+            backgroundOutputPaths.delete(consumedTaskId);
+          }
+        }
+      }
+
+      if (fileScanFailed) {
+        throw new Error("failed to safely scan a referenced output file");
+      }
+
+      const scrubbed = scrubText(event.output);
+      if (!scrubbed.changed) return;
+      return { result: { status: event.status, output: scrubbed.output } };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      letta.diagnostics?.report({
+        message: `Secrets scrubber failed closed: ${message}`,
+        severity: "error",
+      });
+      return {
+        result: {
+          status: event.status,
+          output: "[Tool output withheld because the secrets scrubber could not inspect it safely.]",
+        },
+      };
+    }
+  });
+}

--- a/packages/secrets-scrubber/package.json
+++ b/packages/secrets-scrubber/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@letta-ai/secrets-scrubber",
+  "version": "0.1.0",
+  "description": "A Letta Code mod that redacts detected secrets from tool results before they enter conversation history.",
+  "license": "MIT",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "secrets",
+    "redaction",
+    "security",
+    "tool-output"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/secrets-scrubber"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "mods"
+  ],
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sanity-labs/secret-scan": "1.1.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.8.3"
+  },
+  "letta": {
+    "manifestVersion": 1,
+    "mods": [
+      "./mods/index.ts"
+    ],
+    "capabilities": [
+      "events.tools"
+    ],
+    "engines": {
+      "lettaCodeCli": ">=0.27.14"
+    }
+  }
+}

--- a/packages/secrets-scrubber/test/index.test.ts
+++ b/packages/secrets-scrubber/test/index.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import activate, {
+  extractOutputPaths,
+  isAllowedOutputPath,
+  type LettaModApi,
+  scrubOutputFile,
+  scrubText,
+  type ToolEndEvent,
+} from "../mods/index.ts";
+
+const OPENAI_KEY = "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJ";
+const DATABASE_URL = "postgresql://user:password@example.com:5432/db";
+const tempDirectories: string[] = [];
+
+function createBackgroundDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "letta-background-"));
+  tempDirectories.push(directory);
+  return directory;
+}
+
+function createHarness(): {
+  diagnostics: string[];
+  emit(event: ToolEndEvent): Promise<unknown>;
+} {
+  let handler: ((event: ToolEndEvent) => Promise<unknown> | unknown) | undefined;
+  const diagnostics: string[] = [];
+  const letta: LettaModApi = {
+    capabilities: { events: { tools: true } },
+    diagnostics: {
+      report(input) {
+        diagnostics.push(input.message);
+      },
+    },
+    events: {
+      on(_name, nextHandler) {
+        handler = nextHandler;
+        return () => {
+          handler = undefined;
+        };
+      },
+    },
+  };
+  activate(letta);
+  return {
+    diagnostics,
+    async emit(event) {
+      if (!handler) throw new Error("tool_end handler was not registered");
+      return handler(event);
+    },
+  };
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("inline output scrubbing", () => {
+  test("redacts multiple secret types and preserves surrounding text", () => {
+    const input = `openai=${OPENAI_KEY}\ndatabase=${DATABASE_URL}\nkeep=this`;
+    const result = scrubText(input);
+
+    expect(result.changed).toBe(true);
+    expect(result.output).not.toContain(OPENAI_KEY);
+    expect(result.output).not.toContain(DATABASE_URL);
+    expect(result.output).toContain("[REDACTED: API Secret Key (sk-)]");
+    expect(result.output).toContain("[REDACTED: Database Connection String]");
+    expect(result.output).toContain("keep=this");
+  });
+
+  test("redacts contextual passwords, generic keys, and authorization headers", () => {
+    const input = [
+      'password: "hunter2"',
+      "OPENAI_API_KEY=unstructured-but-sensitive-value",
+      "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+      "Proxy-Authorization: token opaque-session-credential",
+    ].join("\n");
+
+    const result = scrubText(input);
+
+    expect(result.changed).toBe(true);
+    expect(result.output).toBe(
+      [
+        'password: "[REDACTED: Credential]"',
+        "OPENAI_API_KEY=[REDACTED: Credential]",
+        "Authorization: Basic [REDACTED: Authorization]",
+        "Proxy-Authorization: token [REDACTED: Authorization]",
+      ].join("\n"),
+    );
+  });
+
+  test("does not redact its own replacement markers again", () => {
+    const input = "password=[REDACTED: Credential]";
+    expect(scrubText(input)).toEqual({ changed: false, output: input });
+  });
+
+  test("returns an event replacement while preserving the tool status", async () => {
+    const harness = createHarness();
+    const result = await harness.emit({
+      args: {},
+      output: `request failed with ${OPENAI_KEY}`,
+      status: "error",
+      toolName: "Bash",
+    });
+
+    expect(result).toEqual({
+      result: {
+        status: "error",
+        output: "request failed with [REDACTED: API Secret Key (sk-)]",
+      },
+    });
+    expect(harness.diagnostics).toEqual([]);
+  });
+
+  test("does not replace clean output", async () => {
+    const harness = createHarness();
+    expect(
+      await harness.emit({
+        args: {},
+        output: "build completed successfully",
+        status: "success",
+        toolName: "Bash",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("referenced output file scrubbing", () => {
+  test("extracts only exact tool breadcrumb lines", () => {
+    expect(
+      extractOutputPaths(
+        "summary\n[Full output written to: /tmp/example.txt]\nOutput file: /tmp/task.log",
+      ),
+    ).toEqual(["/tmp/example.txt", "/tmp/task.log"]);
+    expect(extractOutputPaths("the Output file: /tmp/not-a-breadcrumb is inline")).toEqual([]);
+  });
+
+  test("rewrites an allowed background output file", () => {
+    const directory = createBackgroundDirectory();
+    const path = join(directory, "bash_1.log");
+    writeFileSync(path, `before ${OPENAI_KEY} after`, { mode: 0o600 });
+
+    expect(isAllowedOutputPath(path)).toBe(true);
+    expect(scrubOutputFile(path)).toBe("changed");
+    expect(readFileSync(path, "utf8")).toBe(
+      "before [REDACTED: API Secret Key (sk-)] after",
+    );
+  });
+
+  test("rejects unexpected names, directories, and symlinks", () => {
+    const directory = createBackgroundDirectory();
+    const outside = mkdtempSync(join(tmpdir(), "secret-scan-outside-"));
+    tempDirectories.push(outside);
+    const target = join(outside, "target.log");
+    const symlink = join(directory, "bash_2.log");
+    writeFileSync(target, OPENAI_KEY, { mode: 0o600 });
+    symlinkSync(target, symlink);
+
+    expect(isAllowedOutputPath(join(directory, "arbitrary.log"))).toBe(false);
+    expect(isAllowedOutputPath(join(outside, "bash_1.log"))).toBe(false);
+    expect(scrubOutputFile(symlink)).toBe("rejected");
+    expect(readFileSync(target, "utf8")).toBe(OPENAI_KEY);
+  });
+
+  test("withholds a breadcrumb when an allowed path is a symlink", async () => {
+    const directory = createBackgroundDirectory();
+    const outside = mkdtempSync(join(tmpdir(), "secret-scan-outside-"));
+    tempDirectories.push(outside);
+    const target = join(outside, "target.log");
+    const symlink = join(directory, "bash_3.log");
+    writeFileSync(target, OPENAI_KEY, { mode: 0o600 });
+    symlinkSync(target, symlink);
+    const harness = createHarness();
+
+    expect(
+      await harness.emit({
+        args: { run_in_background: true },
+        output: `Command running in background with ID: bash_3\nOutput file: ${symlink}`,
+        status: "success",
+        toolName: "Bash",
+      }),
+    ).toBeUndefined();
+
+    const result = await harness.emit({
+      args: { task_id: "bash_3" },
+      output: JSON.stringify({ message: "done", status: "completed" }),
+      status: "success",
+      toolName: "TaskOutput",
+    });
+
+    expect(result).toEqual({
+      result: {
+        status: "success",
+        output:
+          "[Tool output withheld because the secrets scrubber could not inspect it safely.]",
+      },
+    });
+    expect(harness.diagnostics).toHaveLength(1);
+    expect(readFileSync(target, "utf8")).toBe(OPENAI_KEY);
+  });
+
+  test("tracks a running background file and scrubs it after completion", async () => {
+    const directory = createBackgroundDirectory();
+    const path = join(directory, "task_1.log");
+    writeFileSync(path, `first=${OPENAI_KEY}`, { mode: 0o600 });
+    const harness = createHarness();
+
+    await harness.emit({
+      args: { run_in_background: true },
+      output: `Task running in background with task ID: task_1\nOutput file: ${path}`,
+      status: "success",
+      toolName: "Agent",
+    });
+    expect(readFileSync(path, "utf8")).toContain(OPENAI_KEY);
+
+    const runningOutput = JSON.stringify({
+      message: `first=${OPENAI_KEY}`,
+      status: "running",
+    });
+    const runningResult = await harness.emit({
+      args: { task_id: "task_1" },
+      output: runningOutput,
+      status: "success",
+      toolName: "TaskOutput",
+    });
+    expect(runningResult).toEqual({
+      result: {
+        status: "success",
+        output: JSON.stringify({
+          message: "first=[REDACTED: API Secret Key (sk-)]",
+          status: "running",
+        }),
+      },
+    });
+    expect(readFileSync(path, "utf8")).toContain(OPENAI_KEY);
+
+    writeFileSync(path, `later=${DATABASE_URL}`, { mode: 0o600 });
+    const output = JSON.stringify({
+      message: `later=${DATABASE_URL}`,
+      status: "completed",
+    });
+    const result = await harness.emit({
+      args: { task_id: "task_1" },
+      output,
+      status: "success",
+      toolName: "TaskOutput",
+    });
+
+    expect(readFileSync(path, "utf8")).not.toContain(DATABASE_URL);
+    expect(result).toEqual({
+      result: {
+        status: "success",
+        output: JSON.stringify({
+          message: "later=[REDACTED: Database Connection String]",
+          status: "completed",
+        }),
+      },
+    });
+  });
+});

--- a/packages/secrets-scrubber/tsconfig.json
+++ b/packages/secrets-scrubber/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["bun"]
+  },
+  "include": ["mods/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add an opt-in secrets-scrubber mod that combines the TruffleHog-derived secret-scan ruleset with contextual credential and authorization-header detection
- redact secrets before tool results enter conversation history, including atomic rewrites of harness-owned overflow files and completion-gated background output files
- fail closed on unsafe or unreadable output paths, document security boundaries and install ordering, and cover inline, overflow, symlink, and background-task behavior
- track LET-10106

👾 Generated with [Letta Code](https://letta.com)