### PR TITLE
feat(catalog): add featured mod curation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Official package source, ecosystem curation, and release infrastructure
+* @cpacker @carenthomas
+
+/catalog/ @cpacker @carenthomas
+/.github/ @cpacker @carenthomas
+/scripts/ @cpacker @carenthomas

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "catalog/**"
       - "packages/**"
       - "scripts/**"
       - "package.json"
@@ -28,7 +29,7 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
-      - name: Validate manifests
+      - name: Validate repository
         run: npm run validate
 
       - name: Detect changed packages
@@ -100,6 +101,14 @@ jobs:
               continue
             fi
 
+            case "$name" in
+              @letta-ai/*) ;;
+              *)
+                echo "Skipping community-owned package $name; this workflow only publishes the @letta-ai scope."
+                continue
+                ;;
+            esac
+
             if npm view "$name@$version" version >/dev/null 2>&1; then
               echo "Skipping $name@$version because it is already published."
               continue
@@ -109,11 +118,10 @@ jobs:
             npm publish "./$package_dir" --access public
           done < changed-packages.txt
 
-  # Tell the marketing site to regenerate its mod catalog now that new packages
-  # are on npm. The target repo is kept in a secret (not hardcoded) so this public
-  # workflow / its logs don't reference the private site repo. No-ops if the
-  # secrets are absent — the site also refreshes on a schedule, so this just makes
-  # the update near-real-time.
+  # Tell the catalog site to regenerate after package publications or public
+  # curation changes. The dispatch destination stays configurable through
+  # repository secrets. No-ops if the secrets are absent — the site also refreshes
+  # on a schedule.
   notify-site:
     needs: publish
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,7 @@ name: Validate
 on:
   pull_request:
     paths:
+      - "catalog/**"
       - "packages/**"
       - "scripts/**"
       - "package.json"
@@ -15,7 +16,7 @@ permissions:
 
 jobs:
   validate:
-    name: Validate mod packages
+    name: Validate mods repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,5 +27,5 @@ jobs:
         with:
           node-version: 22
 
-      - name: Validate manifests
+      - name: Validate repository
         run: npm run validate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+## Community packages
+
+Community mod authors retain ownership of their source and publication. Create the package in an author-owned repository, publish it under an author-owned npm name, and include the `letta-package` keyword for catalog discovery.
+
+A minimal package manifest looks like this:
+
+```json
+{
+  "name": "@publisher/example-mod",
+  "keywords": ["letta-package", "letta-mod"],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": ["./mods/index.ts"],
+    "capabilities": ["tools"]
+  }
+}
+```
+
+Users can install the npm package directly:
+
+```bash
+letta install npm:@publisher/example-mod
+```
+
+Git-only packages remain installable with `letta install git:github.com/publisher/repository`. Add the `letta-package` or `letta-mode` topic and a valid `package.json#letta` manifest for automatic GitHub discovery.
+
+## Official package adoption
+
+Adding package source to this repository means Letta is adopting the package as official software rather than only listing it in the ecosystem catalog. Official adoption is exceptional and requires:
+
+- broad usefulness beyond one person's workflow
+- an active Letta maintainer
+- clear behavior, configuration, and recovery documentation
+- tests appropriate to the package's behavior and risk
+- focused, inspectable implementation
+- explicit security review for permissions, secrets, subprocesses, network access, or filesystem mutation
+- publication under the `@letta-ai` npm scope
+- an ongoing maintenance commitment
+
+A community package does not need official adoption to be discovered or featured.
+
+## Featured package nominations
+
+[`catalog/featured.json`](catalog/featured.json) is an ordered list of typed npm-package and GitHub-repository sources selected for additional visibility in catalog surfaces.
+
+A Featured badge means Letta selected the package as useful or noteworthy. It does not mean that every release was security-audited, that Letta owns the package, or that the package receives official support.
+
+A featured-list pull request should explain:
+
+- why the package is broadly useful
+- who publishes and maintains it
+- where its source is hosted
+- what permissions and external services it uses
+- how it was tested in Letta Code
+
+The source must already be discoverable by the catalog and contain a valid Letta manifest. Keep `catalog/featured.json` limited to source identity; descriptions, authors, versions, media, and install commands come from registry or repository metadata.
+
+## Package changes
+
+Each package includes:
+
+- `package.json` with npm metadata and a `letta` manifest
+- `README.md` for users
+- `MOD.md` for agent-facing semantics and adaptation notes
+- implementation files declared by `letta.mods`
+
+Before opening a pull request, run:
+
+```bash
+npm run validate
+```
+
+Package-specific tests and checks should also pass. Pull requests should describe runtime capabilities, security boundaries, external dependencies, configuration, recovery behavior, and validation performed.
+
+## Security reports
+
+Please follow [SECURITY.md](SECURITY.md) rather than opening a public issue for a vulnerability.

--- a/README.md
+++ b/README.md
@@ -1,151 +1,84 @@
 # Letta Code Mods
 
-A shared repository for Letta Code mods: trusted local code packages that let agents adapt the harness with tools, slash commands, lifecycle events, permissions, providers, and lightweight UI surfaces.
+Official package source and public ecosystem curation for [Letta Code](https://github.com/letta-ai/letta-code) mods.
 
-Mods are meant to be easy for agents and developers to inspect, adapt, package, and share. This repository contains first-party packages and curation for the mod ecosystem.
+Mods are executable local code that can add tools, slash commands, lifecycle events, permissions, providers, and UI surfaces to the Letta agent harness.
 
-> [!IMPORTANT]
-> The easiest way to use a published mod is with Letta Code:
->
-> ```bash
-> letta install npm:@letta-ai/plan-mode
-> ```
->
-> Then run `/reload` in Letta Code.
+> [!WARNING]
+> Mods run with the full permissions of the Letta Code process. Review package source and publisher provenance before installing any mod, including packages shown in the catalog.
 
-## What is This?
+## Install a mod
 
-This repository contains **mods**: modular packages of trusted local code that extend Letta Code itself. Where skills add knowledge and procedures, mods add executable behavior to the agent runtime.
-
-**What mods can add:**
-- **Tools:** agent-callable functions backed by local code
-- **Slash Commands:** user-facing commands inside Letta Code
-- **Events:** lifecycle, turn, and tool-call hooks
-- **Permissions:** custom checks around tool calls
-- **Providers:** local model/provider adapters
-- **UI Surfaces:** panels, status values, and statusline integrations
-
-**How it grows:**
-- First-party packages define package conventions
-- Agents and developers adapt mods to real workflows
-- Useful local experiments graduate into reusable packages
-- Published packages are discoverable through npm metadata and the Letta Code catalog
-
-Think of this as **agents extending their own harness**: a place where useful runtime adaptations become reusable software.
-
-## How to use this repository
-
-Install published packages directly from Letta Code:
+Published packages install through Letta Code:
 
 ```bash
 letta install npm:@letta-ai/plan-mode
-letta install npm:@letta-ai/goal-mode
-letta install npm:@letta-ai/web-search
 ```
 
-After installing, reload local mods:
-
-```txt
-/reload
-```
-
-You can also clone this repository to inspect package source or develop locally:
+Community packages use the same command with the publisher's npm package name:
 
 ```bash
-git clone https://github.com/letta-ai/mods.git
-cd mods
-npm run validate
+letta install npm:@publisher/package
 ```
 
-This repository is **source, packages, and curation**. It is not a package registry. The current package registry is npm; published mod packages use normal npm metadata plus a Letta-specific manifest in `package.json` under the `letta` key.
+Git repositories are also supported:
 
-## Repository Structure
+```bash
+letta install git:github.com/publisher/repository
+```
 
-Mods are organized as npm packages under `packages/`:
+Run `/reload` after installation.
 
-```txt
+## Package discovery and ownership
+
+The [mods catalog](https://www.letta.com/agent/mods) discovers npm packages tagged with the `letta-package` keyword and GitHub repositories tagged with supported Letta mod topics. Package source does not need to live in this repository to appear in the catalog.
+
+Catalog labels have separate meanings:
+
+- **Official** packages are published and maintained by Letta.
+- **Community** packages are published and maintained by their authors.
+- **Featured** packages are selected by Letta for additional visibility. Featured is an editorial signal, not a security audit or ownership claim.
+
+New community mods should live in author-owned repositories and npm scopes. New package source is accepted into this repository only when Letta explicitly adopts the package and commits to maintaining it. Existing packages are being evaluated under this policy separately from this repository foundation work.
+
+## Featured packages
+
+[`catalog/featured.json`](catalog/featured.json) is the public source of truth for featured catalog placement. It contains typed npm-package or GitHub-repository sources in display order. Catalog consumers overlay this list on top of normal registry and topic discovery.
+
+A featured package may be official or community-maintained. The website should preserve the ownership label independently from the Featured badge.
+
+Changes to the featured list are reviewed like code changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for nomination criteria.
+
+## Repository structure
+
+```text
+catalog/
+└── featured.json          # Public featured-package curation
 packages/
-├── analysis-mode/        # Phrase-triggered diagnostic analysis mode
-├── aura-maxxing/         # High-signal, high-presence response guidance
-├── autopivot/            # Model failover across a priority ladder on rate limits or errors
-├── control-room/         # Cockpit and trust guard for goal, progress, and approval state
-├── conversation-summary/ # Conversation summary statusline
-├── cruise-code/          # Evidence-first coding workflow for tasks and UX handoffs
-├── cruise-ux/            # UX discovery workflow from framing to implementation handoff
-├── environment-compass/  # Read-only environment and git orientation
-├── git-status/           # Git branch, dirty state, and ahead/behind statusline
-├── goal-mode/            # Goal workflow with commands, tools, and turn reminders
-├── hypa/                 # Local context runtime that compresses noisy tool output
-├── image-understanding/  # Vision bridge for text-only agents
-├── jukebox/              # Jamendo-powered terminal music player
-├── memfs-search/         # Agent-callable MemFS memory search
-├── muscle-memory/        # Self-maintaining skill library from real tool-use patterns
-├── oath-keeper/          # Detects agent promises and delivers on them automatically
-├── output-compressor/    # Reversibly compresses large tool outputs before the model sees them
-├── pets/                 # Terminal pets that animate based on turn and tool activity
-├── plan-mode/            # Plan-mode style workflow
-├── ponytail/             # Lazy senior dev mode — YAGNI ladder for less, simpler code
-├── soft-landing/         # Recovery slash command for drift, compaction, or context overload
-├── spotify-statusline/   # macOS Spotify now-playing statusline
-├── sprite/               # Persistent pet that grows stats from real agent work
-├── threadkeeper/         # Live operational anchors for commitments and open loops
-├── tool-guard-inspector/ # Tool permission audit log and slash command
-├── user-timestamps/      # Adds local timestamp metadata to user messages
-└── web-search/           # Provider-backed web search tools
-
+└── <package>/             # Letta-published mod package source
 scripts/
+├── validate-featured.mjs  # Featured-list schema validation
 └── validate-manifests.mjs # Package manifest validation
 ```
 
-**Principle:** Start with concrete packages and evolve conventions from working mods, not predicted abstractions.
+The duplicated hand-maintained package indexes that previously lived in this README were removed. Package metadata belongs in each package's `package.json`, while the catalog is generated from registry metadata.
 
-## Current Mods
+## Mod package format
 
-- **analysis-mode** - Phrase-triggered diagnostic mode using turn reminders and local state
-- **aura-maxxing** - High-signal, high-presence response guidance
-- **autopivot** - Model failover across a priority ladder on rate limits or errors
-- **control-room** - Cockpit and trust guard for goal, progress, and approval state
-- **conversation-summary** - Current conversation summary/title statusline
-- **cruise-code** - Evidence-first coding workflow for implementation tasks, checks, verdicts, and reports
-- **cruise-ux** - UX discovery workflow for framing, research, interviews, ideation, specs, review, and implementation handoff
-- **environment-compass** - Read-only environment and git orientation for local/remote runtimes
-- **git-status** - Git branch, dirty state, and ahead/behind statusline
-- **goal-mode** - Goal workflow using commands, tools, turn reminders, and local state
-- **hypa** - Local context runtime that compresses noisy tool output
-- **image-understanding** - Image-understanding tool, commands, and optional auto-captioning for text-only agents
-- **jukebox** - Jamendo-powered terminal music player with a now-playing panel
-- **memfs-search** - Agent-callable MemFS memory search with optional QMD semantic/hybrid search
-- **muscle-memory** - Self-maintaining skill library from real tool-use patterns
-- **oath-keeper** - Detects agent promises and delivers on them automatically
-- **output-compressor** - Reversibly compresses large tool outputs before the model sees them
-- **pets** - Terminal pets that animate based on turn and tool activity
-- **plan-mode** - Plan-mode workflow using commands, tools, turn reminders, permissions, and local state
-- **ponytail** - Lazy senior dev mode that injects a YAGNI ladder ruleset to write less, simpler code
-- **soft-landing** - Recovery slash command for drift, compaction, or context overload
-- **spotify-statusline** - macOS Spotify now-playing statusline
-- **sprite** - Persistent pet that grows stats from real agent work
-- **threadkeeper** - Live operational anchors for commitments, open loops, temporary boundaries, modes, drift guards, and due state
-- **tool-guard-inspector** - Tool permission audit log using a lightweight permission policy and slash command
-- **user-timestamps** - Adds local timestamp metadata to every user message
-- **web-search** - Provider-backed web search tools using agent-scoped secrets
+A published mod package should include:
 
-## Mod Package Format
-
-Each mod package should include:
-
-```txt
-package.json  # npm metadata + package.json#letta manifest
-README.md     # user-facing docs and install/usage instructions
+```text
+package.json  # npm metadata and package.json#letta manifest
+README.md     # user-facing documentation
 MOD.md        # agent-facing semantics and adaptation notes
-mods/         # mod implementation files declared by package.json#letta
+mods/         # implementation files declared by package.json#letta
 ```
 
-`README.md` is for humans browsing GitHub, npm, or the catalog. `MOD.md` is for agents reading the package to understand behavior, semantics, safety invariants, and how to adapt the mod.
-
-Each published package declares a Letta manifest in `package.json`:
+Example manifest:
 
 ```json
 {
+  "name": "@publisher/example-mod",
   "keywords": ["letta-package", "letta-mod"],
   "letta": {
     "manifestVersion": 1,
@@ -155,29 +88,23 @@ Each published package declares a Letta manifest in `package.json`:
 }
 ```
 
-Packages should use the `letta-package` keyword so they can be discovered by the Letta Code mods catalog.
+`README.md` is for people browsing GitHub, npm, or the catalog. `MOD.md` helps agents inspect package behavior, safety assumptions, and adaptation points.
 
-## Contributing
+## Development
 
-All agents and humans are welcome to contribute useful mods and improvements.
+Clone the repository and run its validation suite:
 
-**What to contribute:**
-- **Runtime Capabilities:** tools, commands, events, providers, permissions, or UI surfaces that solve a real workflow problem
-- **Validated Patterns:** mod structures that worked across actual usage
-- **Safety Improvements:** clearer permissions, recovery paths, or safer defaults
-- **Documentation:** better README/MOD guidance for humans and agents
+```bash
+git clone https://github.com/letta-ai/mods.git
+cd mods
+npm run validate
+```
 
-**How to contribute:**
-1. **Build from a real workflow** - Start with a mod that solves a concrete problem
-2. **Package it cleanly** - Include `package.json#letta`, `README.md`, `MOD.md`, and implementation files under `mods/`
-3. **Explain the behavior** - Document commands, tools, state, safety assumptions, and recovery steps
-4. **Open a pull request** - Review will help keep packages small, inspectable, and reusable
+See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing package source or featured-list changes.
 
-## Safety
+## Recovery
 
-Mods are trusted local code and can execute with the user's local permissions. Review mod source before installing third-party packages.
-
-If a mod breaks startup or command handling, recover by starting Letta Code with mods disabled:
+If a mod breaks startup or command handling, start Letta Code with mods disabled:
 
 ```bash
 letta --no-mods
@@ -185,19 +112,13 @@ letta --no-mods
 LETTA_DISABLE_MODS=1 letta
 ```
 
-Then remove or edit the mod package and run `/reload`.
+Then remove or repair the package and run `/reload`.
 
-## Validation
-
-Run:
-
-```bash
-npm run validate
-```
+Security vulnerabilities should be reported privately according to [SECURITY.md](SECURITY.md).
 
 ## Links
 
 - [Letta Code](https://github.com/letta-ai/letta-code)
-- [Letta Code docs](https://docs.letta.com/letta-code)
-- [Letta Code mods catalog](https://www.letta.com/agent/mods)
+- [Letta Code documentation](https://docs.letta.com/letta-code)
+- [Mods catalog](https://www.letta.com/agent/mods)
 - [Letta skills repository](https://github.com/letta-ai/skills)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Mod security model
+
+Mods are executable local code. They run with the permissions of the Letta Code process and may read or modify files, access environment variables, make network requests, launch subprocesses, intercept runtime events, or alter tool behavior.
+
+The mods catalog is a discovery surface, not a sandbox or security review. Official, Community, and Featured labels describe ownership or editorial selection; none removes the need to inspect source and publisher provenance before installation.
+
+Use operating-system isolation when a mod should not have access to the full host environment.
+
+## Reporting a vulnerability
+
+Please email support@letta.com with a description of the vulnerability, steps to reproduce, the affected package and version, and any relevant details.
+
+Please do not open a public issue for security vulnerabilities.
+
+We will acknowledge receipt within 48 hours and aim to provide a fix or mitigation timeline within 7 days.
+
+## Supported versions
+
+Security fixes for official packages are applied to the latest published version. Community package support and disclosure processes are owned by each package publisher.

--- a/catalog/featured.json
+++ b/catalog/featured.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "type": "npm",
+      "package": "@letta-ai/plan-mode"
+    },
+    {
+      "type": "npm",
+      "package": "@letta-ai/web-search"
+    },
+    {
+      "type": "npm",
+      "package": "@letta-ai/memfs-search"
+    },
+    {
+      "type": "npm",
+      "package": "@letta-ai/image-understanding"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "validate": "node scripts/validate-manifests.mjs"
+    "validate": "node scripts/validate-manifests.mjs && node scripts/validate-featured.mjs"
   }
 }

--- a/scripts/validate-featured.mjs
+++ b/scripts/validate-featured.mjs
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const featuredPath = path.join(repoRoot, "catalog", "featured.json");
+const npmPackagePattern = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+const githubRepoPattern = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?\/[a-zA-Z0-9_.-]{1,100}$/;
+const knownTopLevelKeys = new Set(["schemaVersion", "sources"]);
+const knownSourceKeys = {
+  github: new Set(["type", "repo"]),
+  npm: new Set(["type", "package"]),
+};
+const errors = [];
+
+function addError(message) {
+  errors.push(`catalog/featured.json: ${message}`);
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function unknownKeys(value, knownKeys) {
+  return Object.keys(value).filter((key) => !knownKeys.has(key));
+}
+
+function validateNpmSource(source, index) {
+  if (typeof source.package !== "string" || !npmPackagePattern.test(source.package)) {
+    addError(`sources[${index}].package must be a valid lowercase npm package name`);
+    return null;
+  }
+  if (source.package.length > 214) {
+    addError(`sources[${index}].package exceeds the npm package name length limit`);
+  }
+  return `npm:${source.package}`;
+}
+
+function validateGitHubSource(source, index) {
+  if (typeof source.repo !== "string" || !githubRepoPattern.test(source.repo)) {
+    addError(`sources[${index}].repo must use the owner/repository format`);
+    return null;
+  }
+  if (source.repo.endsWith(".git")) {
+    addError(`sources[${index}].repo must not include a .git suffix`);
+  }
+  return `github:${source.repo.toLowerCase()}`;
+}
+
+let catalog;
+try {
+  catalog = JSON.parse(readFileSync(featuredPath, "utf8"));
+} catch (error) {
+  console.error(`- catalog/featured.json: ${error.message}`);
+  process.exit(1);
+}
+
+if (!isRecord(catalog)) {
+  addError("must contain a JSON object");
+} else {
+  for (const key of unknownKeys(catalog, knownTopLevelKeys)) {
+    addError(`unknown top-level key: ${key}`);
+  }
+
+  if (catalog.schemaVersion !== 1) {
+    addError("schemaVersion must be 1");
+  }
+
+  if (!Array.isArray(catalog.sources)) {
+    addError("sources must be an array");
+  } else {
+    const seenSources = new Set();
+    for (const [index, source] of catalog.sources.entries()) {
+      if (!isRecord(source)) {
+        addError(`sources[${index}] must be an object`);
+        continue;
+      }
+      if (source.type !== "npm" && source.type !== "github") {
+        addError(`sources[${index}].type must be npm or github`);
+        continue;
+      }
+      for (const key of unknownKeys(source, knownSourceKeys[source.type])) {
+        addError(`sources[${index}] has unknown key: ${key}`);
+      }
+
+      const sourceKey =
+        source.type === "npm"
+          ? validateNpmSource(source, index)
+          : validateGitHubSource(source, index);
+      if (!sourceKey) continue;
+      if (seenSources.has(sourceKey)) addError(`duplicate source: ${sourceKey}`);
+      seenSources.add(sourceKey);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(errors.map((error) => `- ${error}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(`Featured catalog is valid (${catalog.sources.length} sources).`);


### PR DESCRIPTION
## Summary
- add a public, schema-versioned featured-source list that supports npm packages and GitHub repositories without conflating Featured with Official ownership
- document the official/community distribution model, adoption criteria, nomination process, full-permission security boundary, and private vulnerability reporting path
- add CODEOWNERS and featured-list validation, limit automatic npm publication to the @letta-ai scope, and trigger catalog refreshes for curation changes
- remove the duplicated hand-maintained package indexes; existing package classification and migration remain follow-up work under LET-10107
- validated with npm run validate and YAML parsing for both workflows

👾 Generated with [Letta Code](https://letta.com)