### PR TITLE
fix(memfs-search): support Windows path and QMD resolution

### DIFF
--- a/packages/memfs-search/MOD.md
+++ b/packages/memfs-search/MOD.md
@@ -31,7 +31,8 @@ If semantic or hybrid search fails because QMD is unavailable, retry with `mode:
 ## Important behavior
 
 - The tool reads local markdown memory files from the current agent's MemFS projection.
-- The tool first checks `MEMORY_DIR`, then common Letta local memory paths for `ctx.agent.id`.
+- The tool first checks `ctx.memfs.memoryDir`, then `MEMORY_DIR`, then common Letta local memory paths for `ctx.agent.id`.
+- `status` shows relevant field availability and all candidate paths checked, without printing environment values.
 - Keyword search skips large files over 1 MB and searches `.md` files only.
 - QMD modes use collection name `memory` and `--no-rerank` to avoid surprise reranker/model downloads.
 - The tool is read-only and marked `parallelSafe: true`.

--- a/packages/memfs-search/README.md
+++ b/packages/memfs-search/README.md
@@ -52,12 +52,16 @@ Status check:
 
 If QMD is unavailable, use `mode: "keyword"`.
 
+QMD discovery uses the current process `PATH` on macOS, Linux, and Windows. Windows npm PowerShell/command shims are supported without relying on a Unix `sh` executable.
+
 ## Memory path detection
 
-The mod first uses `MEMORY_DIR` when present. If not present in the mod runtime, it falls back to common local Letta memory paths using the current agent id:
+The mod checks the invocation-scoped `ctx.memfs.memoryDir` first, then `MEMORY_DIR` when present. If neither points to an existing directory, it falls back to common local Letta memory paths using `ctx.agent.id` (or `AGENT_ID`) and Node's cross-platform home-directory resolution:
 
 - `~/.letta/lc-local-backend/memfs/<agent-id>/memory`
 - `~/.letta/agents/<agent-id>/memory`
+
+`status` reports which context/environment fields were available and lists each candidate path with its existence result. It reports field availability rather than environment values to avoid exposing unrelated configuration.
 
 ## Safety
 

--- a/packages/memfs-search/mods/index.mjs
+++ b/packages/memfs-search/mods/index.mjs
@@ -117,10 +117,11 @@ async function commandExists(command) {
 
 function commandInvocation(executable, args, options = {}) {
   const platform = options.platform ?? process.platform;
+  const powerShellExecutable = options.powerShellExecutable ?? "powershell.exe";
   const extension = path.extname(executable).toLowerCase();
   if (platform === "win32" && extension === ".ps1") {
     return {
-      executable: "powershell.exe",
+      executable: powerShellExecutable,
       args: [
         "-NoLogo",
         "-NoProfile",
@@ -135,9 +136,10 @@ function commandInvocation(executable, args, options = {}) {
   }
   if (platform === "win32" && (extension === ".cmd" || extension === ".bat")) {
     return {
-      executable: "powershell.exe",
-      // Keep caller-provided args in PowerShell's $args array instead of
-      // interpolating them into a cmd.exe command string.
+      executable: powerShellExecutable,
+      // powershell.exe joins every argument after -Command into executable code.
+      // Carry the shim path and its arguments through the environment so queries
+      // remain data rather than becoming part of that command string.
       args: [
         "-NoLogo",
         "-NoProfile",
@@ -145,10 +147,12 @@ function commandInvocation(executable, args, options = {}) {
         "-ExecutionPolicy",
         "Bypass",
         "-Command",
-        "& $args[0] @($args | Select-Object -Skip 1)",
-        executable,
-        ...args,
+        "$qmdArgs = @(ConvertFrom-Json -InputObject $env:LETTA_QMD_SHIM_ARGS); & $env:LETTA_QMD_SHIM_PATH @qmdArgs",
       ],
+      env: {
+        LETTA_QMD_SHIM_PATH: executable,
+        LETTA_QMD_SHIM_ARGS: JSON.stringify(args),
+      },
     };
   }
   return { executable, args };
@@ -160,7 +164,10 @@ async function execQmd(args, options = {}) {
   const invocation = commandInvocation(executable, args);
   return await execFileAsync(invocation.executable, invocation.args, {
     ...options,
-    env: qmdEnv(path.dirname(executable)),
+    env: {
+      ...qmdEnv(path.dirname(executable)),
+      ...invocation.env,
+    },
   });
 }
 

--- a/packages/memfs-search/mods/index.mjs
+++ b/packages/memfs-search/mods/index.mjs
@@ -1,5 +1,6 @@
-import { readdir, readFile, stat } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { access, readdir, readFile, stat } from "node:fs/promises";
+import { constants, existsSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -10,23 +11,45 @@ const MAX_FILE_BYTES = 1_000_000;
 const COLLECTION_NAME = "memory";
 const QMD_TIMEOUT_MS = 60_000;
 
-function candidateMemoryDirs(ctx) {
+function candidateMemoryDirs(ctx, options = {}) {
   const candidates = [];
-  if (process.env.MEMORY_DIR) candidates.push(process.env.MEMORY_DIR);
+  const add = (source, value) => {
+    if (!value || typeof value !== "string") return;
+    const candidate = path.resolve(value);
+    if (!candidates.some((entry) => entry.path === candidate)) {
+      candidates.push({ source, path: candidate });
+    }
+  };
+
+  add("ctx.memfs.memoryDir", ctx?.memfs?.memoryDir);
+  add("env.MEMORY_DIR", process.env.MEMORY_DIR);
+
   const agentId = ctx?.agent?.id || process.env.AGENT_ID || "";
-  const home = process.env.HOME || "";
+  let home = "";
+  try {
+    home = options.homeDir ?? homedir();
+  } catch {
+    // Leave home empty when the operating system cannot resolve it.
+  }
   if (home && agentId) {
-    candidates.push(path.join(home, ".letta", "lc-local-backend", "memfs", agentId, "memory"));
-    candidates.push(path.join(home, ".letta", "agents", agentId, "memory"));
+    add(
+      "local-backend fallback",
+      path.join(home, ".letta", "lc-local-backend", "memfs", agentId, "memory"),
+    );
+    add(
+      "cloud-agent fallback",
+      path.join(home, ".letta", "agents", agentId, "memory"),
+    );
   }
   return candidates;
 }
 
 function memoryDir(ctx) {
-  for (const candidate of candidateMemoryDirs(ctx)) {
-    if (candidate && existsSync(candidate)) return candidate;
+  const candidates = candidateMemoryDirs(ctx);
+  for (const candidate of candidates) {
+    if (existsSync(candidate.path)) return candidate.path;
   }
-  return candidateMemoryDirs(ctx)[0] || "";
+  return candidates[0]?.path || "";
 }
 
 function clampLimit(value) {
@@ -38,31 +61,114 @@ function clampLimit(value) {
 function qmdEnv(extraPath = "") {
   const env = { ...process.env };
   delete env.BUN_INSTALL;
-  if (extraPath) env.PATH = `${extraPath}:${env.PATH || ""}`;
+  if (extraPath) {
+    env.PATH = [extraPath, env.PATH || env.Path || ""]
+      .filter(Boolean)
+      .join(path.delimiter);
+  }
   return env;
 }
 
-async function commandExists(command) {
-  try {
-    await execFileAsync("sh", ["-lc", `command -v ${command}`], { env: qmdEnv(), timeout: 5_000 });
-    return true;
-  } catch {
-    return false;
+function executableNames(command, platform = process.platform, env = process.env) {
+  if (platform !== "win32") return [command];
+  if (path.extname(command)) return [command];
+
+  // npm global installs include a PowerShell shim. Prefer it to .cmd so args can
+  // be passed through execFile without constructing a shell command string.
+  const extensions = [".exe", ".com", ".ps1"];
+  for (const extension of String(env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)) {
+    if (!extensions.includes(extension)) extensions.push(extension);
   }
+  return extensions.map((extension) => `${command}${extension}`);
 }
 
-async function qmdBinDir() {
-  const { stdout } = await execFileAsync("sh", ["-lc", "command -v qmd"], { env: qmdEnv(), timeout: 5_000 });
-  return path.dirname(stdout.trim());
+async function resolveExecutable(command, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const pathValue = env.PATH || env.Path || "";
+  const directories = pathValue.split(path.delimiter).filter(Boolean);
+  for (const directory of directories) {
+    for (const name of executableNames(command, platform, env)) {
+      const candidate = path.resolve(directory, name);
+      try {
+        await access(
+          candidate,
+          platform === "win32" ? constants.F_OK : constants.X_OK,
+        );
+        return candidate;
+      } catch {
+        // Try the next candidate.
+      }
+    }
+  }
+  return null;
+}
+
+async function qmdExecutable() {
+  return await resolveExecutable("qmd");
+}
+
+async function commandExists(command) {
+  return Boolean(await resolveExecutable(command));
+}
+
+function commandInvocation(executable, args, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const extension = path.extname(executable).toLowerCase();
+  if (platform === "win32" && extension === ".ps1") {
+    return {
+      executable: "powershell.exe",
+      args: [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        executable,
+        ...args,
+      ],
+    };
+  }
+  if (platform === "win32" && (extension === ".cmd" || extension === ".bat")) {
+    return {
+      executable: "powershell.exe",
+      // Keep caller-provided args in PowerShell's $args array instead of
+      // interpolating them into a cmd.exe command string.
+      args: [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "& $args[0] @($args | Select-Object -Skip 1)",
+        executable,
+        ...args,
+      ],
+    };
+  }
+  return { executable, args };
+}
+
+async function execQmd(args, options = {}) {
+  const executable = await qmdExecutable();
+  if (!executable) throw new Error("qmd executable not found on PATH");
+  const invocation = commandInvocation(executable, args);
+  return await execFileAsync(invocation.executable, invocation.args, {
+    ...options,
+    env: qmdEnv(path.dirname(executable)),
+  });
 }
 
 async function runQmd(args, cwd) {
   // QMD can break when Bun's sqlite runtime is selected; unset BUN_INSTALL.
   // Prefer the Node binary next to qmd so native sqlite modules match the qmd install.
-  const binDir = await qmdBinDir();
-  const { stdout, stderr } = await execFileAsync("qmd", args, {
+  const { stdout, stderr } = await execQmd(args, {
     cwd,
-    env: qmdEnv(binDir),
     timeout: QMD_TIMEOUT_MS,
     maxBuffer: 2 * 1024 * 1024,
   });
@@ -71,7 +177,7 @@ async function runQmd(args, cwd) {
 
 async function qmdFilesArgs() {
   try {
-    const { stdout } = await execFileAsync("qmd", ["query", "--help"], { env: qmdEnv(await qmdBinDir()), timeout: 5_000 });
+    const { stdout } = await execQmd(["query", "--help"], { timeout: 5_000 });
     return stdout.includes("--format") ? ["--format", "files"] : ["--files"];
   } catch {
     return ["--files"];
@@ -244,11 +350,31 @@ Try mode=keyword, or run the memfs-search skill setup/reindex flow.`,
 }
 
 async function status(ctx) {
+  const candidates = candidateMemoryDirs(ctx);
   const root = memoryDir(ctx);
   const lines = [];
   lines.push(`MEMORY_DIR: ${root || "not set"}`);
   lines.push(`exists: ${root && existsSync(root) ? "yes" : "no"}`);
-  lines.push(`qmd: ${(await commandExists("qmd")) ? "available" : "not found"}`);
+  lines.push("context:");
+  lines.push(`- ctx.memfs.memoryDir: ${ctx?.memfs?.memoryDir ? "set" : "not set"}`);
+  lines.push(`- ctx.agent.id: ${ctx?.agent?.id ? "set" : "not set"}`);
+  lines.push(`- env.MEMORY_DIR: ${process.env.MEMORY_DIR ? "set" : "not set"}`);
+  lines.push(`- env.AGENT_ID: ${process.env.AGENT_ID ? "set" : "not set"}`);
+  lines.push(`- env.HOME: ${process.env.HOME ? "set" : "not set"}`);
+  lines.push(`- env.USERPROFILE: ${process.env.USERPROFILE ? "set" : "not set"}`);
+  lines.push("candidates:");
+  if (candidates.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const candidate of candidates) {
+      lines.push(
+        `- ${candidate.source}: ${candidate.path} (exists: ${existsSync(candidate.path) ? "yes" : "no"})`,
+      );
+    }
+  }
+  const resolvedQmd = await qmdExecutable();
+  lines.push(`qmd: ${resolvedQmd ? "available" : "not found"}`);
+  if (resolvedQmd) lines.push(`qmd_path: ${resolvedQmd}`);
   if (root && existsSync(root)) {
     const count = (await walkMarkdown(root)).length;
     lines.push(`markdown_files: ${count}`);
@@ -303,3 +429,11 @@ export default function activate(letta) {
     },
   });
 }
+
+export const __test = {
+  candidateMemoryDirs,
+  commandInvocation,
+  executableNames,
+  qmdEnv,
+  resolveExecutable,
+};

--- a/packages/memfs-search/package.json
+++ b/packages/memfs-search/package.json
@@ -35,5 +35,8 @@
     "engines": {
       "lettaCodeCli": ">=0.27.14"
     }
+  },
+  "scripts": {
+    "test": "node --test test.mjs"
   }
 }

--- a/packages/memfs-search/test.mjs
+++ b/packages/memfs-search/test.mjs
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 
 import activate, { __test } from "./mods/index.mjs";
 
+const execFileAsync = promisify(execFile);
 const originalEnv = { ...process.env };
 
 test.afterEach(() => {
@@ -91,7 +94,7 @@ test("QMD lookup uses PATH directly and prepends with the platform delimiter", a
   await rm(root, { recursive: true, force: true });
 });
 
-test("Windows lookup prefers PowerShell shims and never builds a shell string", () => {
+test("Windows lookup prefers PowerShell shims and keeps command-shim args out of code", async () => {
   const names = __test.executableNames("qmd", "win32", {
     PATHEXT: ".COM;.EXE;.BAT;.CMD",
   });
@@ -103,10 +106,27 @@ test("Windows lookup prefers PowerShell shims and never builds a shell string", 
   assert.equal(ps1.executable, "powershell.exe");
   assert.deepEqual(ps1.args.slice(-3), ["C:\\bin\\qmd.ps1", "query", "a&b"]);
 
+  const root = await mkdtemp(path.join(tmpdir(), "memfs-search-powershell-"));
+  const fakePowerShell = path.join(root, "powershell.exe");
+  await writeFile(
+    fakePowerShell,
+    `#!${process.execPath}\nprocess.stdout.write(JSON.stringify({ argv: process.argv.slice(2), path: process.env.LETTA_QMD_SHIM_PATH, args: JSON.parse(process.env.LETTA_QMD_SHIM_ARGS) }));\n`,
+  );
+  await chmod(fakePowerShell, 0o755);
+
   const cmd = __test.commandInvocation("C:\\bin\\qmd.cmd", ["query", "a&b"], {
     platform: "win32",
+    powerShellExecutable: fakePowerShell,
   });
-  assert.equal(cmd.executable, "powershell.exe");
-  assert.equal(cmd.args.at(-1), "a&b");
-  assert.match(cmd.args[cmd.args.indexOf("-Command") + 1], /\$args/);
+  const { stdout } = await execFileAsync(cmd.executable, cmd.args, {
+    env: { ...process.env, ...cmd.env },
+  });
+  const child = JSON.parse(stdout);
+
+  assert.equal(child.path, "C:\\bin\\qmd.cmd");
+  assert.deepEqual(child.args, ["query", "a&b"]);
+  assert.equal(child.argv.at(-1), cmd.args.at(-1));
+  assert.ok(!child.argv.includes("C:\\bin\\qmd.cmd"));
+  assert.ok(!child.argv.includes("a&b"));
+  await rm(root, { recursive: true, force: true });
 });

--- a/packages/memfs-search/test.mjs
+++ b/packages/memfs-search/test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import activate, { __test } from "./mods/index.mjs";
+
+const originalEnv = { ...process.env };
+
+test.afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+});
+
+test("memory candidates prefer scoped MemFS and use a cross-platform home", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "memfs-search-"));
+  const scoped = path.join(root, "scoped-memory");
+  await mkdir(scoped);
+  delete process.env.MEMORY_DIR;
+  delete process.env.HOME;
+  process.env.USERPROFILE = root;
+
+  const candidates = __test.candidateMemoryDirs(
+    {
+      memfs: { memoryDir: scoped },
+      agent: { id: "agent-test" },
+    },
+    { homeDir: root },
+  );
+
+  assert.equal(candidates[0].source, "ctx.memfs.memoryDir");
+  assert.equal(candidates[0].path, scoped);
+  assert.deepEqual(
+    candidates.slice(1).map((candidate) => candidate.path),
+    [
+      path.join(root, ".letta", "lc-local-backend", "memfs", "agent-test", "memory"),
+      path.join(root, ".letta", "agents", "agent-test", "memory"),
+    ],
+  );
+  await rm(root, { recursive: true, force: true });
+});
+
+test("status reports available fields and every candidate without env values", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "memfs-search-status-"));
+  const memory = path.join(root, "memory");
+  await mkdir(memory);
+  await writeFile(path.join(memory, "note.md"), "hello");
+  delete process.env.MEMORY_DIR;
+  delete process.env.AGENT_ID;
+  delete process.env.HOME;
+  process.env.USERPROFILE = root;
+
+  let registration;
+  activate({
+    capabilities: { tools: true },
+    tools: { register(value) { registration = value; } },
+  });
+  const output = await registration.run({
+    args: { action: "status" },
+    agent: { id: "agent-test" },
+    memfs: { memoryDir: memory },
+  });
+
+  assert.match(output, /ctx\.memfs\.memoryDir: set/);
+  assert.match(output, /ctx\.agent\.id: set/);
+  assert.match(output, /env\.HOME: not set/);
+  assert.match(output, /env\.USERPROFILE: set/);
+  assert.match(output, /ctx\.memfs\.memoryDir: .*memory \(exists: yes\)/);
+  assert.doesNotMatch(output, new RegExp(`USERPROFILE: ${root}`));
+  assert.match(output, /markdown_files: 1/);
+  await rm(root, { recursive: true, force: true });
+});
+
+test("QMD lookup uses PATH directly and prepends with the platform delimiter", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "memfs-search-bin-"));
+  const executable = path.join(root, "qmd");
+  await writeFile(executable, "#!/bin/sh\nexit 0\n");
+  await chmod(executable, 0o755);
+
+  const resolved = await __test.resolveExecutable("qmd", {
+    platform: process.platform,
+    env: { PATH: root },
+  });
+  assert.equal(resolved, executable);
+
+  const env = __test.qmdEnv(root);
+  assert.equal(env.PATH.split(path.delimiter)[0], root);
+  await rm(root, { recursive: true, force: true });
+});
+
+test("Windows lookup prefers PowerShell shims and never builds a shell string", () => {
+  const names = __test.executableNames("qmd", "win32", {
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  });
+  assert.ok(names.indexOf("qmd.ps1") < names.indexOf("qmd.cmd"));
+
+  const ps1 = __test.commandInvocation("C:\\bin\\qmd.ps1", ["query", "a&b"], {
+    platform: "win32",
+  });
+  assert.equal(ps1.executable, "powershell.exe");
+  assert.deepEqual(ps1.args.slice(-3), ["C:\\bin\\qmd.ps1", "query", "a&b"]);
+
+  const cmd = __test.commandInvocation("C:\\bin\\qmd.cmd", ["query", "a&b"], {
+    platform: "win32",
+  });
+  assert.equal(cmd.executable, "powershell.exe");
+  assert.equal(cmd.args.at(-1), "a&b");
+  assert.match(cmd.args[cmd.args.indexOf("-Command") + 1], /\$args/);
+});


### PR DESCRIPTION
## Summary
- resolve MemFS from `ctx.memfs.memoryDir` first, then environment/fallback paths using `os.homedir()` so Windows does not require `HOME`
- add safe status diagnostics for available context/env fields and all candidate paths checked
- replace Unix-only `sh -lc` QMD discovery and hardcoded PATH separators with cross-platform executable lookup and Windows shim execution
- add focused tests and update package documentation

## Test plan
- [x] `npm test --prefix packages/memfs-search`
- [x] `npm run validate`
- [x] `node --check packages/memfs-search/mods/index.mjs`
- [x] `git diff --check`

👾 Generated with [Letta Code](https://letta.com)