### PR TITLE
chore(memfs-search): bump version to 0.1.1

### DIFF
--- a/packages/memfs-search/package.json
+++ b/packages/memfs-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/memfs-search",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Letta Code mod package that adds an agent-callable MemFS memory search tool.",
   "author": "just-cameron",
   "license": "MIT",


### PR DESCRIPTION
Bumps `@letta-ai/memfs-search` from 0.1.0 to 0.1.1 for npm publish.

Includes the Windows path and QMD resolution fix merged in #65.

Letta Code (agent-c2adbf5c-8419-4211-8cd8-3740db164974)