### PR TITLE
fix(user-timestamps): publish formatter correction

### DIFF
--- a/packages/user-timestamps/package.json
+++ b/packages/user-timestamps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/user-timestamps",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Letta Code turn-start mod that adds local timestamp metadata to every user message.",
   "author": "Letta",
   "license": "Apache-2.0",
@@ -29,5 +29,8 @@
     "engines": {
       "lettaCodeCli": ">=0.27.14"
     }
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --test test.mjs"
   }
 }

--- a/packages/user-timestamps/test.mjs
+++ b/packages/user-timestamps/test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import activate from "./mods/index.ts";
+
+function createHarness() {
+  const events = new Map();
+  const diagnostics = [];
+
+  const dispose = activate({
+    capabilities: { events: { turns: true } },
+    events: {
+      on(name, handler) {
+        events.set(name, handler);
+        return () => events.delete(name);
+      },
+    },
+    diagnostics: {
+      report(diagnostic) {
+        diagnostics.push(diagnostic);
+      },
+    },
+  });
+
+  return { diagnostics, dispose, events };
+}
+
+test("adds a local timestamp to user messages without throwing", (t) => {
+  const app = createHarness();
+  t.after(() => app.dispose());
+
+  const assistantMessage = { role: "assistant", content: "Existing response" };
+  const approvalMessage = { type: "approval", role: "user", content: "Approved" };
+  const event = {
+    input: [
+      {
+        role: "user",
+        content: "What time is it?",
+        metadata: { existing: true },
+      },
+      assistantMessage,
+      approvalMessage,
+    ],
+  };
+
+  assert.doesNotThrow(() => app.events.get("turn_start")(event));
+
+  const timestamped = event.input[0];
+  assert.match(timestamped.content, /^<user_timestamp>\nlocal: .+\ntimezone: .+\n<\/user_timestamp>\n/);
+  assert.equal(timestamped.metadata.existing, true);
+  assert.equal(typeof timestamped.metadata.user_timestamp.local, "string");
+  assert.equal(
+    timestamped.metadata.user_timestamp.timeZone,
+    Intl.DateTimeFormat().resolvedOptions().timeZone || "local",
+  );
+  assert.equal(event.input[1], assistantMessage);
+  assert.equal(event.input[2], approvalMessage);
+
+  app.events.get("turn_start")(event);
+  assert.equal(event.input[0].content.match(/<user_timestamp>/g).length, 1);
+});
+
+test("reports a warning when turn events are unavailable", () => {
+  const diagnostics = [];
+
+  const dispose = activate({
+    capabilities: { events: { turns: false } },
+    diagnostics: {
+      report(diagnostic) {
+        diagnostics.push(diagnostic);
+      },
+    },
+  });
+
+  assert.equal(dispose, undefined);
+  assert.deepEqual(diagnostics, [
+    {
+      severity: "warning",
+      message: "user-timestamps mod requires turn events, but this host does not expose them.",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

- bump `@letta-ai/user-timestamps` to `0.1.1` so the merged `Intl` formatter correction can be published
- add focused `turn_start` regression coverage for timestamp injection, metadata preservation, approval exclusion, duplicate prevention, and missing-capability diagnostics

## Context

The npm registry still serves `0.1.0`, published on June 25. The formatter correction merged later in #17, but the publishing workflow skips package versions that already exist on npm. This version bump gives the corrected source a new publishable version.

## Testing

- `npm --prefix packages/user-timestamps test`
- `npm run validate`
