### PR TITLE
fix: restrict quota routing to verified ChatGPT providers

### DIFF
--- a/packages/codex-quota-router/MOD.md
+++ b/packages/codex-quota-router/MOD.md
@@ -19,8 +19,8 @@ On each outbound turn, the mod:
 
 1. Resolves the conversation-level model handle.
 2. Refreshes connected `chatgpt_oauth` provider usage when the host exposes the Letta client and the cache is stale.
-3. Leaves non-ChatGPT providers and available ChatGPT plans unchanged.
-4. If the selected plan is exhausted, selects the non-exhausted connected plan with the highest remaining percentage.
+3. Verifies both the current and destination provider against cached records discovered as non-base `chatgpt_oauth`; non-OpenAI providers, unverified aliases, and stale manually injected names are never routed.
+4. If the selected verified ChatGPT OAuth plan is exhausted, selects the verified non-exhausted connected plan with the highest remaining percentage.
 5. Updates only the conversation-level model handle, preserving the model suffix and leaving the agent default unchanged.
 6. Relies on Letta Code 0.30.8 or newer to refresh the persisted conversation model after `turn_start`, preventing Desktop/listener requests from retaining a stale provider captured before the update.
 
@@ -54,7 +54,7 @@ Enables or disables automatic switching without removing providers or cached usa
 /codex-quota-router plans chatgpt-work,chatgpt-personal
 ```
 
-Replaces the cached eligible provider list with the comma-separated names and removes cached entries for providers no longer listed. The next successful automatic discovery or `refresh` replaces this list with the currently connected ChatGPT OAuth providers.
+First refreshes provider metadata, then replaces the cached eligible provider list with the comma-separated names only if every name is currently verified as a non-base `chatgpt_oauth` provider. Non-OpenAI and unknown aliases are rejected. The next successful automatic discovery or `refresh` replaces this list with the currently connected ChatGPT OAuth providers.
 
 ## State and security boundary
 

--- a/packages/codex-quota-router/README.md
+++ b/packages/codex-quota-router/README.md
@@ -14,10 +14,12 @@ Run `/reload` after installation.
 
 Before a Codex turn, the mod:
 
-1. Discovers connected `chatgpt_oauth` providers.
-2. Reads current usage for each plan.
-3. Checks whether the conversation's selected plan has reached its limit.
-4. If needed, changes only the conversation-level model provider to the available plan with the most quota remaining.
+1. Discovers connected non-base `chatgpt_oauth` providers and caches that verified set.
+2. Reads current usage for each verified plan.
+3. Checks that the conversation's selected provider is verified and has reached its limit.
+4. If needed, changes only the conversation-level model provider to the verified available plan with the most quota remaining.
+
+Both sides of every route must be in the verified ChatGPT OAuth set. Base providers, non-OpenAI providers, unknown aliases, and stale manually injected names are ignored.
 
 The model name is preserved. For example, an exhausted `chatgpt-work/gpt-5.5` conversation may move to `chatgpt-personal/gpt-5.5`.
 

--- a/packages/codex-quota-router/mods/index.ts
+++ b/packages/codex-quota-router/mods/index.ts
@@ -26,6 +26,7 @@ interface FailoverState {
   enabled: boolean;
   providerNames: string[];
   usage: Record<string, UsageState>;
+  verifiedChatgptOauthProviderNames: string[];
 }
 
 interface ProviderRecord {
@@ -47,6 +48,7 @@ const DEFAULT_STATE: FailoverState = {
   enabled: true,
   providerNames: [],
   usage: {},
+  verifiedChatgptOauthProviderNames: [],
 };
 
 function normalizeProviderNames(value: unknown): string[] {
@@ -70,6 +72,9 @@ function readState(): FailoverState {
       enabled: raw.enabled !== false,
       providerNames: normalizeProviderNames(raw.providerNames),
       usage: raw.usage && typeof raw.usage === "object" ? raw.usage : {},
+      verifiedChatgptOauthProviderNames: normalizeProviderNames(
+        raw.verifiedChatgptOauthProviderNames,
+      ),
     };
   } catch {
     return structuredClone(DEFAULT_STATE);
@@ -131,7 +136,9 @@ function chooseProvider(
   state: FailoverState,
   currentProvider: string,
 ): string | null {
+  const verified = new Set(state.verifiedChatgptOauthProviderNames);
   const candidates = state.providerNames
+    .filter((name) => verified.has(name))
     .filter((name) => name !== currentProvider)
     .filter((name) => !activeLimitReached(state.usage[name]))
     .sort(
@@ -150,7 +157,12 @@ async function refreshUsage(
     0,
     ...Object.values(state.usage).map((entry) => entry.fetchedAt || 0),
   );
-  if (Date.now() - newestFetch < REFRESH_TTL_MS) return state;
+  if (
+    state.verifiedChatgptOauthProviderNames.length > 0 &&
+    Date.now() - newestFetch < REFRESH_TTL_MS
+  ) {
+    return state;
+  }
 
   const client = await letta.getClient();
   const providers = (await client.get("/v1/providers")) as ProviderRecord[];
@@ -160,8 +172,7 @@ async function refreshUsage(
       .filter((provider) => provider.provider_category !== "base")
       .map((provider) => provider.name),
   );
-  const providerNames =
-    discovered.length > 0 ? discovered : state.providerNames;
+  const providerNames = discovered;
 
   const results = await Promise.allSettled(
     providerNames.map(async (providerName) => {
@@ -190,7 +201,12 @@ async function refreshUsage(
     }
   }
 
-  const refreshed = { ...state, providerNames, usage };
+  const refreshed = {
+    ...state,
+    providerNames,
+    usage,
+    verifiedChatgptOauthProviderNames: discovered,
+  };
   writeState(refreshed);
   return refreshed;
 }
@@ -249,7 +265,12 @@ export default function activate(letta: any) {
           }
         }
 
-        if (!state.providerNames.includes(model.provider)) return;
+        if (
+          !state.providerNames.includes(model.provider) ||
+          !state.verifiedChatgptOauthProviderNames.includes(model.provider)
+        ) {
+          return;
+        }
         if (!activeLimitReached(state.usage[model.provider])) return;
 
         const nextProvider = chooseProvider(state, model.provider);
@@ -322,6 +343,26 @@ export default function activate(letta: any) {
                 type: "output",
                 output:
                   "Provide comma-separated ChatGPT OAuth provider names.",
+              };
+            }
+            try {
+              state = await refreshUsage(letta, { ...state, usage: {} });
+            } catch (error) {
+              return {
+                type: "output",
+                output: `Could not verify ChatGPT OAuth providers: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              };
+            }
+            const invalid = providerNames.filter(
+              (name) =>
+                !state.verifiedChatgptOauthProviderNames.includes(name),
+            );
+            if (invalid.length > 0) {
+              return {
+                type: "output",
+                output: `Not eligible ChatGPT OAuth providers: ${invalid.join(", ")}`,
               };
             }
             state.providerNames = providerNames;


### PR DESCRIPTION
## Summary

- persist the exact provider aliases discovered as non-base `chatgpt_oauth`
- require both the current provider and selected destination to be members of that verified set before changing the conversation model
- reject non-OpenAI and unknown aliases passed through `/codex-quota-router plans`
- discard stale provider names when authoritative discovery returns no eligible ChatGPT OAuth providers

The original router only filtered provider type during discovery. Its execution guard later trusted cached `providerNames`, and the `plans` command accepted arbitrary aliases. A stale or manually injected non-OpenAI provider could therefore enter the routing pool.

## Validation

- `npm run validate`
- bundled `packages/codex-quota-router/mods/index.ts` with Bun
- runtime harness confirms an Anthropic conversation is not changed while an exhausted verified ChatGPT OAuth provider routes to another verified ChatGPT OAuth provider
- runtime harness confirms `plans anthropic` is rejected as ineligible
- verified the current cached aliases (`sarah`, `chatgpt-cameron`, `chatgpt-jin`, and `chatgpt-plus-pro`) are all `chatgpt_oauth` / `byok` records from `/v1/providers`

👾 Generated with [Letta Code](https://letta.com)