### PR TITLE
feat: add conversation retitle mod

### DIFF
--- a/catalog/official.json
+++ b/catalog/official.json
@@ -43,6 +43,10 @@
     },
     {
       "type": "npm",
+      "package": "@letta-ai/retitle-conversation"
+    },
+    {
+      "type": "npm",
       "package": "@letta-ai/spotify-statusline"
     },
     {

--- a/packages/retitle-conversation/LICENSE
+++ b/packages/retitle-conversation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Letta, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/retitle-conversation/MOD.md
+++ b/packages/retitle-conversation/MOD.md
@@ -1,0 +1,46 @@
+---
+name: "@letta-ai/retitle-conversation"
+description: "Agent-callable tool for updating the current Letta Code conversation title."
+---
+
+# Retitle conversation mod semantics
+
+## When to use
+
+Use `retitle_conversation` when the current conversation title is missing, generic, stale, or no longer describes the main work.
+
+Do not use the tool when the current title still describes the work. Do not retitle a conversation only to report progress or completion.
+
+## Tool
+
+The package registers one tool:
+
+- `retitle_conversation` accepts a required plain-text `title` and updates the current conversation.
+
+Choose a short title, usually two to seven words. Describe the work with concrete nouns and verbs. Avoid vague labels, status phrases, punctuation-only titles, and unnecessary detail.
+
+## Behavior
+
+- Requires approval in permission modes that enforce tool approval.
+- Runs as a non-parallel mutation.
+- Requires a current conversation ID.
+- Uses `ctx.conversation.updateTitle()` to save the title and refresh active local interface state.
+- Replaces control characters, bidirectional text controls, line breaks, and repeated whitespace with spaces.
+- Rejects empty titles and titles longer than 100 Unicode code points.
+- Returns an error without mutation when the host cannot update conversation titles.
+
+## Safety boundaries
+
+- Does not read conversation history.
+- Does not read or write files.
+- Does not read environment variables or secrets.
+- Does not start subprocesses.
+- Does not make direct network requests.
+- Mutates only the title of the current conversation.
+
+## Adaptation notes for agents
+
+- Keep the tool scoped to `ctx.conversation`. Do not replace the conversation handle with a global client call.
+- Keep `requiresApproval: true` and `parallelSafe: false` because the tool changes stored conversation state.
+- Preserve terminal-control and bidirectional-control filtering if title formatting changes.
+- Update the minimum Letta Code version if the package starts using a newer mod API.

--- a/packages/retitle-conversation/MOD.md
+++ b/packages/retitle-conversation/MOD.md
@@ -25,8 +25,8 @@ Choose a short title, usually two to seven words. Describe the work with concret
 - Runs as a non-parallel mutation.
 - Requires a current conversation ID.
 - Uses `ctx.conversation.updateTitle()` to save the title and refresh active local interface state.
-- Replaces control characters, bidirectional text controls, line breaks, and repeated whitespace with spaces.
-- Rejects empty titles and titles longer than 100 Unicode code points.
+- Replaces terminal controls, bidirectional text controls, unsafe invisible separators, line breaks, and repeated whitespace with spaces.
+- Rejects empty, invisible-only, and longer-than-100-code-point titles.
 - Returns an error without mutation when the host cannot update conversation titles.
 
 ## Safety boundaries
@@ -42,5 +42,5 @@ Choose a short title, usually two to seven words. Describe the work with concret
 
 - Keep the tool scoped to `ctx.conversation`. Do not replace the conversation handle with a global client call.
 - Keep `requiresApproval: true` and `parallelSafe: false` because the tool changes stored conversation state.
-- Preserve terminal-control and bidirectional-control filtering if title formatting changes.
+- Preserve control and invisible-content filtering if title formatting changes.
 - Update the minimum Letta Code version if the package starts using a newer mod API.

--- a/packages/retitle-conversation/README.md
+++ b/packages/retitle-conversation/README.md
@@ -26,9 +26,9 @@ The tool asks for approval before each update in permission modes that require a
 
 The tool normalizes the requested title before it saves the title:
 
-- Replaces terminal control characters and bidirectional text controls with spaces.
+- Replaces terminal controls, bidirectional text controls, and unsafe invisible separators with spaces.
 - Collapses line breaks and repeated whitespace into one space.
-- Rejects empty titles and titles longer than 100 characters.
+- Rejects empty, invisible-only, and longer-than-100-character titles.
 
 The active Letta Code interface receives the title update through the conversation mod API. Other clients can show the new title after they receive or reload the stored conversation state.
 

--- a/packages/retitle-conversation/README.md
+++ b/packages/retitle-conversation/README.md
@@ -1,0 +1,65 @@
+# Retitle Conversation
+
+A Letta Code mod package that lets an agent update the current conversation title.
+
+The `retitle_conversation` tool keeps conversation lists useful when a title is missing, generic, or stale. The agent supplies a short title that describes the main work.
+
+## Requirements
+
+- Letta Code `>=0.30.21`
+
+## Install
+
+```bash
+letta install npm:@letta-ai/retitle-conversation
+```
+
+Run `/reload` in active sessions after installation.
+
+## Tool behavior
+
+The package registers one model-callable tool:
+
+- `retitle_conversation` updates the title of the current conversation.
+
+The tool asks for approval before each update in permission modes that require approval. It does not run in parallel with other tool mutations.
+
+The tool normalizes the requested title before it saves the title:
+
+- Replaces terminal control characters and bidirectional text controls with spaces.
+- Collapses line breaks and repeated whitespace into one space.
+- Rejects empty titles and titles longer than 100 characters.
+
+The active Letta Code interface receives the title update through the conversation mod API. Other clients can show the new title after they receive or reload the stored conversation state.
+
+## Suggested title style
+
+Use a short title that describes the main work. Two to seven words usually fit conversation lists well.
+
+Good titles:
+
+- `Review OAuth retry logic`
+- `Add Windows smoke test`
+- `Investigate stale approvals`
+
+Avoid status-only titles such as `Working on it` or `Done`. Do not retitle a conversation when its current title still describes the work.
+
+## Data and permissions
+
+The package sends the new title through `ctx.conversation.updateTitle()`. It does not read messages, files, environment variables, or secrets. It does not start subprocesses or call external services directly.
+
+Mods run with the full permissions of the Letta Code process. Review the source before you install a mod.
+
+## Recovery
+
+If a mod breaks startup or tool handling, start Letta Code with mods disabled:
+
+```bash
+letta --no-mods
+# or
+LETTA_DISABLE_MODS=1 letta
+```
+
+Remove or repair the package, then run `/reload`.
+
+See [`MOD.md`](./MOD.md) for the agent-facing behavior contract.

--- a/packages/retitle-conversation/mods/index.ts
+++ b/packages/retitle-conversation/mods/index.ts
@@ -1,6 +1,7 @@
 const MAX_TITLE_LENGTH = 100;
 const UNSAFE_TITLE_CHARACTERS =
-  /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g;
+  /[\p{Cc}\p{Bidi_Control}\u200b\u2060\ufeff]/gu;
+const INVISIBLE_TITLE_CHARACTERS = /\p{Default_Ignorable_Code_Point}/gu;
 
 function normalizeTitle(value: unknown): string {
   if (typeof value !== "string") return "";
@@ -12,6 +13,10 @@ function normalizeTitle(value: unknown): string {
 
 function titleLength(title: string): number {
   return Array.from(title).length;
+}
+
+function hasVisibleContent(title: string): boolean {
+  return title.replace(INVISIBLE_TITLE_CHARACTERS, "").trim().length > 0;
 }
 
 export default function activate(letta: any) {
@@ -46,7 +51,7 @@ export default function activate(letta: any) {
       }
 
       const title = normalizeTitle(ctx.args?.title);
-      if (!title) {
+      if (!title || !hasVisibleContent(title)) {
         return {
           status: "error",
           content: "The conversation title must not be empty.",

--- a/packages/retitle-conversation/mods/index.ts
+++ b/packages/retitle-conversation/mods/index.ts
@@ -1,0 +1,73 @@
+const MAX_TITLE_LENGTH = 100;
+const UNSAFE_TITLE_CHARACTERS =
+  /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/g;
+
+function normalizeTitle(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value
+    .replace(UNSAFE_TITLE_CHARACTERS, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function titleLength(title: string): number {
+  return Array.from(title).length;
+}
+
+export default function activate(letta: any) {
+  if (!letta.capabilities.tools) return;
+
+  return letta.tools.register({
+    name: "retitle_conversation",
+    description:
+      "Change the current conversation title when it is missing, generic, stale, or no longer describes the main work. Choose a short title, usually 2 to 7 words. Do not retitle a conversation when its current title still describes the work.",
+    parameters: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description:
+            "The new conversation title. Use plain text and usually 2 to 7 words.",
+          minLength: 1,
+          maxLength: MAX_TITLE_LENGTH,
+        },
+      },
+      required: ["title"],
+      additionalProperties: false,
+    },
+    requiresApproval: true,
+    parallelSafe: false,
+    async run(ctx: any) {
+      if (!ctx.conversation?.id) {
+        return {
+          status: "error",
+          content: "The current conversation does not have a conversation ID.",
+        };
+      }
+
+      const title = normalizeTitle(ctx.args?.title);
+      if (!title) {
+        return {
+          status: "error",
+          content: "The conversation title must not be empty.",
+        };
+      }
+      if (titleLength(title) > MAX_TITLE_LENGTH) {
+        return {
+          status: "error",
+          content: `The conversation title must be ${MAX_TITLE_LENGTH} characters or fewer.`,
+        };
+      }
+      if (typeof ctx.conversation.updateTitle !== "function") {
+        return {
+          status: "error",
+          content:
+            "Conversation title updates require Letta Code 0.30.21 or later.",
+        };
+      }
+
+      await ctx.conversation.updateTitle(title);
+      return `Conversation title changed to "${title}".`;
+    },
+  });
+}

--- a/packages/retitle-conversation/package.json
+++ b/packages/retitle-conversation/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@letta-ai/retitle-conversation",
+  "version": "0.1.0",
+  "description": "Letta Code mod package that lets agents update the current conversation title.",
+  "author": "just-cameron",
+  "license": "MIT",
+  "type": "module",
+  "keywords": [
+    "letta-package",
+    "letta-mod",
+    "letta-code",
+    "conversation-title",
+    "retitle"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/mods.git",
+    "directory": "packages/retitle-conversation"
+  },
+  "files": [
+    "README.md",
+    "MOD.md",
+    "LICENSE",
+    "mods"
+  ],
+  "letta": {
+    "manifestVersion": 1,
+    "mods": [
+      "./mods/index.ts"
+    ],
+    "capabilities": [
+      "tools"
+    ],
+    "engines": {
+      "lettaCodeCli": ">=0.30.21"
+    }
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --test test.mjs"
+  }
+}

--- a/packages/retitle-conversation/test.mjs
+++ b/packages/retitle-conversation/test.mjs
@@ -70,7 +70,8 @@ test("does not register without the tools capability", () => {
 test("normalizes and persists a safe conversation title", async () => {
   const harness = createHarness();
   const { ctx, updates } = conversationContext({
-    title: "  Release\n\t readiness \u0000 review \u202e ",
+    title:
+      "  Release\n\t readiness \u0000 review \u061c\u200e\u200f\u202e ",
   });
 
   const result = await harness.tool.run(ctx);
@@ -95,10 +96,18 @@ test("accepts 100 Unicode code points and rejects 101", async () => {
   });
 });
 
-test("rejects invalid input before mutation", async () => {
+test("rejects empty and invisible-only input before mutation", async () => {
   const harness = createHarness();
 
-  for (const title of ["", " \n\t ", 42, null]) {
+  for (const title of [
+    "",
+    " \n\t ",
+    "\u200b",
+    "\u200c\u200d",
+    "\u2060\ufeff",
+    42,
+    null,
+  ]) {
     const { ctx, updates } = conversationContext({ title });
     ctx.args.title = title;
     const result = await harness.tool.run(ctx);
@@ -108,6 +117,17 @@ test("rejects invalid input before mutation", async () => {
     });
     assert.deepEqual(updates, []);
   }
+});
+
+test("preserves joiners when the title also contains visible text", async () => {
+  const harness = createHarness();
+  const { ctx, updates } = conversationContext({
+    title: "Visible\u200c title\u200d",
+  });
+
+  await harness.tool.run(ctx);
+
+  assert.deepEqual(updates, ["Visible\u200c title\u200d"]);
 });
 
 test("reports unavailable conversation state without a partial update", async () => {

--- a/packages/retitle-conversation/test.mjs
+++ b/packages/retitle-conversation/test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import activate from "./mods/index.ts";
+
+function createHarness(capabilities = { tools: true }) {
+  let registration;
+  let disposed = false;
+  const dispose = activate({
+    capabilities,
+    tools: {
+      register(definition) {
+        registration = definition;
+        return () => {
+          disposed = true;
+        };
+      },
+    },
+  });
+
+  return {
+    dispose,
+    get disposed() {
+      return disposed;
+    },
+    get tool() {
+      return registration;
+    },
+  };
+}
+
+function conversationContext(options = {}) {
+  const updates = [];
+  const conversation = {
+    id: options.id === undefined ? "conv-test" : options.id,
+    async updateTitle(title) {
+      updates.push(title);
+    },
+  };
+  if (options.updateTitle === false) delete conversation.updateTitle;
+
+  return {
+    ctx: {
+      args: { title: options.title ?? "Focused title" },
+      conversation,
+    },
+    updates,
+  };
+}
+
+test("registers a mutating tool with a strict schema", () => {
+  const harness = createHarness();
+  assert.equal(harness.tool.name, "retitle_conversation");
+  assert.equal(harness.tool.requiresApproval, true);
+  assert.equal(harness.tool.parallelSafe, false);
+  assert.deepEqual(harness.tool.parameters.required, ["title"]);
+  assert.equal(harness.tool.parameters.additionalProperties, false);
+  assert.equal(harness.tool.parameters.properties.title.maxLength, 100);
+
+  harness.dispose();
+  assert.equal(harness.disposed, true);
+});
+
+test("does not register without the tools capability", () => {
+  const harness = createHarness({ tools: false });
+  assert.equal(harness.tool, undefined);
+  assert.equal(harness.dispose, undefined);
+});
+
+test("normalizes and persists a safe conversation title", async () => {
+  const harness = createHarness();
+  const { ctx, updates } = conversationContext({
+    title: "  Release\n\t readiness \u0000 review \u202e ",
+  });
+
+  const result = await harness.tool.run(ctx);
+
+  assert.deepEqual(updates, ["Release readiness review"]);
+  assert.equal(result, 'Conversation title changed to "Release readiness review".');
+});
+
+test("accepts 100 Unicode code points and rejects 101", async () => {
+  const harness = createHarness();
+  const accepted = conversationContext({ title: "😀".repeat(100) });
+  const rejected = conversationContext({ title: "😀".repeat(101) });
+
+  await harness.tool.run(accepted.ctx);
+  const result = await harness.tool.run(rejected.ctx);
+
+  assert.deepEqual(accepted.updates, ["😀".repeat(100)]);
+  assert.deepEqual(rejected.updates, []);
+  assert.deepEqual(result, {
+    status: "error",
+    content: "The conversation title must be 100 characters or fewer.",
+  });
+});
+
+test("rejects invalid input before mutation", async () => {
+  const harness = createHarness();
+
+  for (const title of ["", " \n\t ", 42, null]) {
+    const { ctx, updates } = conversationContext({ title });
+    ctx.args.title = title;
+    const result = await harness.tool.run(ctx);
+    assert.deepEqual(result, {
+      status: "error",
+      content: "The conversation title must not be empty.",
+    });
+    assert.deepEqual(updates, []);
+  }
+});
+
+test("reports unavailable conversation state without a partial update", async () => {
+  const harness = createHarness();
+  const missingId = conversationContext({ id: null });
+  const oldHost = conversationContext({ updateTitle: false });
+
+  assert.deepEqual(await harness.tool.run(missingId.ctx), {
+    status: "error",
+    content: "The current conversation does not have a conversation ID.",
+  });
+  assert.deepEqual(await harness.tool.run(oldHost.ctx), {
+    status: "error",
+    content: "Conversation title updates require Letta Code 0.30.21 or later.",
+  });
+  assert.deepEqual(missingId.updates, []);
+  assert.deepEqual(oldHost.updates, []);
+});


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Summary

- Add the official `@letta-ai/retitle-conversation` package.
- Register an approval-gated `retitle_conversation` tool through the scoped conversation mod API.
- Add user documentation, agent semantics, focused tests, and the official catalog entry.

## Why

This repository did not provide an official agent-callable package for conversation titles. This package gives agents a narrow way to update a missing, generic, or stale title.

## Behavior and limits

The tool calls `ctx.conversation.updateTitle()` for the current conversation. It requires Letta Code `>=0.30.21` and has no configuration or external dependencies.

The tool does not rename conversations automatically. It requires approval in permission modes that enforce approval. It does not run in parallel with other tool mutations.

The tool replaces terminal controls, bidirectional text controls, and unsafe invisible separators. It rejects empty, invisible-only, and longer-than-100-code-point titles.

## Security and recovery

The package mutates only the current conversation title. It does not read conversation history, files, environment variables, or secrets. It does not start subprocesses or call `fetch`. The host persists the title through the conversation API.

Users can recover from mod startup or tool failures with `letta --no-mods` or `LETTA_DISABLE_MODS=1 letta`.

## Validation

- `npm test --prefix packages/retitle-conversation` — 7 tests passed.
- All package test scripts passed.
- `npm run validate` — package manifests and catalogs passed.
- `npm pack --dry-run --json` — only the declared package files are included.
- Isolated local install with the source Letta Code CLI — package installed and listed with the `tools` capability.
- `bun test src/mods/conversation-handle.test.ts src/cli/app/conversation-title-sync.test.ts` in Letta Code — 8 host API tests passed.
- Independent adversarial review found incomplete Unicode control filtering. The follow-up commit covers the missing controls and invisible-only titles.

A live stored-conversation mutation was not repeated with the packaged copy. The host API tests cover persistence and active interface refresh for `ctx.conversation.updateTitle()`.
