### PR TITLE
fix(retitle-conversation): reject default conversation

### DIFF
--- a/packages/retitle-conversation/MOD.md
+++ b/packages/retitle-conversation/MOD.md
@@ -24,6 +24,7 @@ Choose a short title, usually two to seven words. Describe the work with concret
 - Requires approval in permission modes that enforce tool approval.
 - Runs as a non-parallel mutation.
 - Requires a current conversation ID.
+- Rejects the default conversation because it has no stored conversation record to rename.
 - Uses `ctx.conversation.updateTitle()` to save the title and refresh active local interface state.
 - Replaces terminal controls, bidirectional text controls, unsafe invisible separators, line breaks, and repeated whitespace with spaces.
 - Rejects empty, invisible-only, and longer-than-100-code-point titles.

--- a/packages/retitle-conversation/README.md
+++ b/packages/retitle-conversation/README.md
@@ -32,6 +32,8 @@ The tool normalizes the requested title before it saves the title:
 
 The active Letta Code interface receives the title update through the conversation mod API. Other clients can show the new title after they receive or reload the stored conversation state.
 
+The default conversation cannot be renamed because it has no stored conversation record. The tool returns an error before it sends an update request.
+
 ## Suggested title style
 
 Use a short title that describes the main work. Two to seven words usually fit conversation lists well.

--- a/packages/retitle-conversation/mods/index.ts
+++ b/packages/retitle-conversation/mods/index.ts
@@ -1,4 +1,5 @@
 const MAX_TITLE_LENGTH = 100;
+const DEFAULT_CONVERSATION_ID = "default";
 const UNSAFE_TITLE_CHARACTERS =
   /[\p{Cc}\p{Bidi_Control}\u200b\u2060\ufeff]/gu;
 const INVISIBLE_TITLE_CHARACTERS = /\p{Default_Ignorable_Code_Point}/gu;
@@ -47,6 +48,12 @@ export default function activate(letta: any) {
         return {
           status: "error",
           content: "The current conversation does not have a conversation ID.",
+        };
+      }
+      if (ctx.conversation.id === DEFAULT_CONVERSATION_ID) {
+        return {
+          status: "error",
+          content: "The default conversation cannot be renamed.",
         };
       }
 

--- a/packages/retitle-conversation/package.json
+++ b/packages/retitle-conversation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@letta-ai/retitle-conversation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Letta Code mod package that lets agents update the current conversation title.",
   "author": "just-cameron",
   "license": "MIT",

--- a/packages/retitle-conversation/test.mjs
+++ b/packages/retitle-conversation/test.mjs
@@ -80,6 +80,19 @@ test("normalizes and persists a safe conversation title", async () => {
   assert.equal(result, 'Conversation title changed to "Release readiness review".');
 });
 
+test("rejects the default conversation before mutation", async () => {
+  const harness = createHarness();
+  const { ctx, updates } = conversationContext({ id: "default" });
+
+  const result = await harness.tool.run(ctx);
+
+  assert.deepEqual(result, {
+    status: "error",
+    content: "The default conversation cannot be renamed.",
+  });
+  assert.deepEqual(updates, []);
+});
+
 test("accepts 100 Unicode code points and rejects 101", async () => {
   const harness = createHarness();
   const accepted = conversationContext({ title: "😀".repeat(100) });


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Problem

The mod passes the default conversation sentinel to `ctx.conversation.updateTitle()`. The default conversation has no stored conversation record, so the update API returns a 404.

## Change

- Return a clear error when `ctx.conversation.id` is `default`.
- Keep normal conversation title updates unchanged.
- Add a regression test that proves no update runs for the default conversation.
- Bump `@letta-ai/retitle-conversation` to 0.1.1 and document the boundary.

## Validation

- `npm test` in `packages/retitle-conversation` — 8 passed
- TypeScript 5.9.2 `tsc --noEmit` — passed
- `npm run validate` — passed