### PR TITLE
chore: point CODEOWNERS at @letta-ai/mods-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
-# Official package source, ecosystem curation, and release infrastructure
-* @cpacker @carenthomas
-
-/catalog/ @cpacker @carenthomas
-/.github/ @cpacker @carenthomas
-/scripts/ @cpacker @carenthomas
+# Official package source, ecosystem curation, and release infrastructure.
+# Any member of @letta-ai/mods-owners can satisfy required code-owner review.
+* @letta-ai/mods-owners


### PR DESCRIPTION
## Summary
- Collapse the duplicated Charles+Caren CODEOWNERS rules into a single `* @letta-ai/mods-owners` line so required review is OR, not two individual requests.
- Team members: @cpacker, @carenthomas, @just-cameron. Any one of them satisfies code-owner review.

GitHub still auto-requests every *user* listed on a CODEOWNERS line, which is why Charles stayed requested after Caren approved #80. A team is one review request; any member counts.

**Needs admin:** grant `@letta-ai/mods-owners` write on this repo. GitHub ignores a team in CODEOWNERS until the team itself has write, even if every member already has it personally. I do not have admin on `mods`, so I could not do that from here.

## Test plan
- [ ] After merge, open a PR that touches any file and confirm the requested reviewer is the `mods-owners` team, not both Charles and Caren as individuals
- [ ] Confirm one approval from Charles, Caren, or Cameron satisfies the code-owner check