### PR TITLE
chore: point CODEOWNERS at @letta-ai/lettamates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Official package source, ecosystem curation, and release infrastructure.
-# Any member of @letta-ai/mods-owners can satisfy required code-owner review.
-* @letta-ai/mods-owners
+# Any member of @letta-ai/lettamates can satisfy required code-owner review.
+* @letta-ai/lettamates


### PR DESCRIPTION
## Summary
- Broaden mods required review from the three-person `mods-owners` team to `@letta-ai/lettamates` (everyone at Letta except we still skip treating the bot account as the owner team itself; lettamates already includes the humans).
- Any one member still satisfies code-owner review (OR).

Could not add people to `mods-owners` from this account (not a team maintainer). `lettamates` already has the full org.

**Needs admin:** grant `@letta-ai/lettamates` write on this repo if it does not already have it. GitHub ignores a CODEOWNERS team without write.

## Test plan
- [ ] After merge, a mods PR requests the `lettamates` team, not Charles+Caren as individuals
- [ ] One approval from any Letta member satisfies the code-owner check